### PR TITLE
Fixed bug with flushLiveURLCache if undefined

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -27,12 +27,7 @@ class HLS extends Playback {
     super(options)
     this.src = options.src
     this.swfPath = options.swfPath || "http://cdn.clappr.io/latest/assets/HLSPlayer.swf"
-    if (options.flushLiveURLCache == undefined){
-      this.flushLiveURLCache = true
-    }
-    else{
-      this.flushLiveURLCache = options.flushLiveURLCache
-    }
+    this.flushLiveURLCache = (options.flushLiveURLCache === undefined)? true: options.flushLiveURLCache
     this.highDefinition = false
     this.autoPlay = options.autoPlay
     this.defaultSettings = {


### PR DESCRIPTION
There was a bug when flushLiveURLCache was not set in the embed.
