### PR TITLE
Fixing gaTrackerName on GoogleAnalytics plugin

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@ Bernardo Camilo <bcvcamilo@gmail.com>
 Bruno Torres <me@brunotorr.es>
 Felipe Victor (Baiano) <felipevictor13@gmail.com>
 Flávio Ribeiro <email@flavioribeiro.com>
+Guilherme Heynemann Bruzzi <guibruzzi@gmail.com>
 Karina Sirqueira <sirqueira.karina@gmail.com>
 Leandro Moreira <leandro.ribeiro.moreira@gmail.com>
 Quentin V <valmori@gutenberg-technology.com>

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Enable Google Analytics events dispatch (play/pause/stop/buffering/etc) adding y
   var player = new Clappr.Player({
     source: "http://your.video/here.mp4",
 		gaAccount: 'UA-44332211-1',
-		gaTracker: 'MyPlayerInstance'
+		gaTrackerName: 'MyPlayerInstance'
   });
 ```
 

--- a/src/plugins/google_analytics/google_analytics.js
+++ b/src/plugins/google_analytics/google_analytics.js
@@ -12,7 +12,7 @@ class GoogleAnalytics extends ContainerPlugin {
     if (options.gaAccount) {
       this.embedScript()
       this.account = options.gaAccount
-      this.trackerName = options.gaTrackerName + "." || 'Clappr.'
+      this.trackerName = (options.gaTrackerName) ? options.gaTrackerName + "." : 'Clappr.'
       this.currentHDState = undefined
     }
   }

--- a/test/google_analytics_spec.js
+++ b/test/google_analytics_spec.js
@@ -1,0 +1,45 @@
+var GoogleAnalytics = require('../src/plugins/google_analytics');
+var gaControl;
+
+describe('GoogleAnalytics', () => {
+  describe('constructor without gaAccount', () => {
+    it('no trackerName by default', () => {
+      gaControl = new GoogleAnalytics({});
+      expect(gaControl.trackerName).to.not.exist;
+    });
+  });
+
+  describe('constructor with gaAccount', () => {
+    beforeEach(() => {
+      window._gaq = [];
+      gaControl = new GoogleAnalytics({gaAccount: "UA-XXXXX-X"});
+    });
+    it('trackerName equals to Clappr. by default', () => {
+      expect(gaControl.trackerName).to.equal("Clappr.");
+    });
+    it('tracks data with Clappr. as trackerName', () => {
+      gaControl.push(["Video", "Play", "video.mp4"]);
+      expect(window._gaq[0][0]).to.equal("Clappr._trackEvent");
+      expect(window._gaq[0][1]).to.equal("Video");
+      expect(window._gaq[0][2]).to.equal("Play");
+      expect(window._gaq[0][3]).to.equal("video.mp4");
+    });
+  });
+
+  describe('constructor with gaAccount and gaTrackerName', () => {
+    beforeEach(() => {
+      window._gaq = [];
+      gaControl = new GoogleAnalytics({gaAccount: "UA-XXXXX-X", gaTrackerName: "MyPlayerInstance"});
+    });
+    it('trackerName equals to gaTrackerName parameter', () => {
+      expect(gaControl.trackerName).to.equal("MyPlayerInstance.");
+    });
+    it('tracks data with gaTrackerName parameter as trackerName', () => {
+      gaControl.push(["Video", "Play", "video.mp4"]);
+      expect(window._gaq[0][0]).to.equal("MyPlayerInstance._trackEvent");
+      expect(window._gaq[0][1]).to.equal("Video");
+      expect(window._gaq[0][2]).to.equal("Play");
+      expect(window._gaq[0][3]).to.equal("video.mp4");
+    });
+  });
+});


### PR DESCRIPTION
When you used to pass a gaAccount parameter to player and didn't pass a gaTrackerName parameter, the default trackerName on GoogleAnalytics plugin was "undefined.".
I fixed that issue and added some tests to cover this GoogleAnalytics plugin's behaviour.
I also fixed the example on "README.md", because it was saying to pass a "gaTracker" parameter, but the correct parameter in the example would be "gaTrackerName".
