### PR TITLE
Google Analytics: Fixing embed script sequence

### DIFF
--- a/src/plugins/google_analytics/google_analytics.js
+++ b/src/plugins/google_analytics/google_analytics.js
@@ -10,10 +10,10 @@ class GoogleAnalytics extends ContainerPlugin {
   constructor(options) {
     super(options)
     if (options.gaAccount) {
-      this.embedScript()
       this.account = options.gaAccount
       this.trackerName = (options.gaTrackerName) ? options.gaTrackerName + "." : 'Clappr.'
       this.currentHDState = undefined
+      this.embedScript()
     }
   }
 


### PR DESCRIPTION
Running embedScript just after setting analytics account information, fixing problem when sending events and 'window._gat' is already defined.