### PR TITLE
#373 Fix play icon height with player height percents

### DIFF
--- a/src/plugins/poster/poster.js
+++ b/src/plugins/poster/poster.js
@@ -100,7 +100,7 @@ class PosterPlugin extends UIContainerPlugin {
 
   updateSize() {
     if (this.container.playback.name === 'html_img') return
-    var height = PlayerInfo.currentSize ? PlayerInfo.currentSize.height : this.$el.height()
+    var height = this.$el.height()
     this.$el.css({ fontSize: height })
     if (this.$playWrapper.is(':visible')) {
       this.$playWrapper.css({ marginTop: -(this.$playWrapper.height() / 2) })


### PR DESCRIPTION
I think $el.height() is enough and make percent height for the player able to display the big play button in a good height