### PR TITLE
Fixed watermark position for top-right top-left + small tweak

### DIFF
--- a/src/plugins/watermark/public/watermark.css
+++ b/src/plugins/watermark/public/watermark.css
@@ -1,11 +1,12 @@
 [data-watermark] {
   position: absolute;
-  margin: 100px auto 0;
-  width: 70px;
+  width: 12%;
   text-align: center;
   z-index: 10;
-  margin-left: auto;
-  margin-right: auto;
+}
+
+[data-watermark] img {
+  max-width: 100%;
 }
 
 [data-watermark-bottom-left] {
@@ -19,12 +20,12 @@
 }
 
 [data-watermark-top-left] {
-  top: -95px;
+  top: 10px;
   left: 10px;
 }
 
 [data-watermark-top-right] {
-  top: -95px;
+  top: 10px;
   right: 37px;
 }
 

--- a/src/plugins/watermark/public/watermark.css
+++ b/src/plugins/watermark/public/watermark.css
@@ -1,5 +1,7 @@
 [data-watermark] {
   position: absolute;
+  min-width: 70px;
+  max-width: 200px;
   width: 12%;
   text-align: center;
   z-index: 10;


### PR DESCRIPTION
Fixing position for watermark when on position top-right , top-left + set max width on image inside wrapper + set relative watermark size based on player width,

Tested on all major browsers
Test logo collection: https://drive.google.com/file/d/0Bz9apPz75nEWbWZTZWsxY3U5ZkU/view?usp=sharing 