### PR TITLE
Fixed mixed content for ga.js

### DIFF
--- a/src/plugins/google_analytics/google_analytics.js
+++ b/src/plugins/google_analytics/google_analytics.js
@@ -23,7 +23,7 @@ class GoogleAnalytics extends ContainerPlugin {
       var script = document.createElement('script')
       script.setAttribute("type", "text/javascript")
       script.setAttribute("async", "async")
-      script.setAttribute("src", "http://www.google-analytics.com/ga.js")
+      script.setAttribute("src", "//www.google-analytics.com/ga.js")
       script.onload = () => this.addEventListeners()
       document.body.appendChild(script)
     } else {


### PR DESCRIPTION
Fixing :  Mixed Content: The page at '{host}' was loaded over HTTPS, but requested an insecure script 'http://www.google-analytics.com/ga.js'. This request has been blocked; the content must be served over HTTPS. 