### PR TITLE
fix spinner_three_bounce plugin so that dots animate in sequence

### DIFF
--- a/src/plugins/spinner_three_bounce/public/spinner.scss
+++ b/src/plugins/spinner_three_bounce/public/spinner.scss
@@ -29,7 +29,7 @@
   }
 
   [data-bounce2] {
-    @include animation-delay(-0.32s);
+    @include animation-delay(-0.16s);
   }
 }
 


### PR DESCRIPTION
Previously the first 2 dots animated at the same time, not sure if this was intentional?