### PR TITLE
initialize missing global variable

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -351,6 +351,9 @@ export default class HLS extends Playback {
   }
 
   createCallbacks() {
+    if (!window.Clappr) {
+      window.Clappr = {}
+    }
     if (!window.Clappr.flashlsCallbacks) {
       window.Clappr.flashlsCallbacks = {}
     }

--- a/test/playbacks/hls_spec.js
+++ b/test/playbacks/hls_spec.js
@@ -57,5 +57,11 @@ describe('HLS playback', function() {
       this.hls.setPlaybackState("IDLE")
       expect(current).to.be.equal(0)
     })
+
+    it('should create flashls callbacks', function() {
+      this.hls.createCallbacks()
+      expect(window.Clappr.flashlsCallbacks).to.be.a('object')
+      expect(window.Clappr.flashlsCallbacks[this.hls.cid]).to.be.a('function')
+    })
   })
 })


### PR DESCRIPTION
referencing: https://github.com/clappr/clappr/issues/519

Now that the clappr player is no longer using `window` to store variables (https://github.com/clappr/clappr/blob/0.2.1/src/main.js#L21), `window.Clappr` is not getting initialized. It seems that the Flash HLS code was missed in this upgrade.

This may not be the most elegant solution, but the flash player still needs some sort of global hook for its callbacks. I will let y'all decide a better way to solve this, but here is one solution that is working for us locally.