### PR TITLE
Fix so that seek time doesn't flicker when hovering

### DIFF
--- a/src/components/seek_time/public/seek_time.scss
+++ b/src/components/seek_time/public/seek_time.scss
@@ -2,6 +2,7 @@
 
 .seek-time[data-seek-time] {
   position: absolute;
+  white-space: nowrap;
   width: auto;
   height: 20px;
   line-height: 20px;

--- a/src/components/seek_time/seek_time.js
+++ b/src/components/seek_time/seek_time.js
@@ -34,6 +34,12 @@ export default class SeekTime extends UIObject {
   }
 
   showTime(event) {
+    if (!this.mediaControl.container.settings.seekEnabled) {
+      return
+    }
+
+    // the element must be unhidden before its width is requested, otherwise it's width will be reported as 0
+    this.$el.removeClass('hidden')
     var offset = event.pageX - this.mediaControl.$seekBarContainer.offset().left
     if (offset >= 0 && offset <= this.mediaControl.$seekBarContainer.width()) {
       var timePosition = Math.min(100, Math.max((offset) / this.mediaControl.$seekBarContainer.width() * 100, 0))
@@ -56,11 +62,8 @@ export default class SeekTime extends UIObject {
   }
 
   update(options) {
-    if (this.mediaControl.container.settings.seekEnabled) {
-      this.$el.find('[data-seek-time]').text(options.formattedTime)
-      this.$el.css('left', Math.max(0, options.pointerPosition - (this.$el.width() / 2)))
-      this.$el.removeClass('hidden')
-    }
+    this.$el.find('[data-seek-time]').text(options.formattedTime)
+    this.$el.css('left', Math.max(0, options.pointerPosition - (this.$el.width() / 2)))
   }
 
   render() {


### PR DESCRIPTION
Previously the `showTime` and `update` methods both queried `$el` for it's width, but if `$el` wasn't visible its width would be reported as 0 by the browser, resulting in the time then being shown in the wrong place. This change ensures that the element is always visible before the width queries are made, and prevents the time jumping left and right when hovering.

This also makes sure it doesn't wrap onto 2 lines when it reaches the far right of the player. Previously if it did wrap this would also cause the width to change and it would get a bit confused.

Also the previous code didn't, and this change currently doesn't listen to see if the `this.mediaControl.container.settings.seekEnabled` option changes, and then update appropriately. E.g. the user is hovering over the bar whilst `seekEnabled` is `true`, and then it flips to `false`. The time will still be visible until the cursor is moved. The reverse behaviour can happen when a HLS stream becomes longer than the minimum duration to DVR, causing DVR to become enabled.

Is there an event that is fired when settings change? If so I can have a look at adding this functionality in as well if you'd like?
