### PR TITLE
three spinner bounce fix to make sure only one show timeout created

### DIFF
--- a/src/plugins/spinner_three_bounce/spinner_three_bounce.js
+++ b/src/plugins/spinner_three_bounce/spinner_three_bounce.js
@@ -21,6 +21,7 @@ export default class SpinnerThreeBouncePlugin extends UIContainerPlugin {
   constructor(options) {
     super(options)
     this.template = template(spinnerHTML);
+    this.showTimeout = null
     this.listenTo(this.container, Events.CONTAINER_STATE_BUFFERING, this.onBuffering)
     this.listenTo(this.container, Events.CONTAINER_STATE_BUFFERFULL, this.onBufferFull)
     this.listenTo(this.container, Events.CONTAINER_STOP, this.onStop)
@@ -29,15 +30,28 @@ export default class SpinnerThreeBouncePlugin extends UIContainerPlugin {
   }
 
   onBuffering() {
-    this.showTimeout = setTimeout(() => this.$el.show(), 300)
+    this.show()
   }
 
   onBufferFull() {
-    clearTimeout(this.showTimeout)
-    this.$el.hide()
+    this.hide()
   }
 
   onStop() {
+    this.hide()
+  }
+
+  show() {
+    if (this.showTimeout === null) {
+      this.showTimeout = setTimeout(() => this.$el.show(), 300)
+    }
+  }
+
+  hide() {
+    if (this.showTimeout !== null) {
+      clearTimeout(this.showTimeout)
+      this.showTimeout = null
+    }
     this.$el.hide()
   }
 


### PR DESCRIPTION
Previously if `onBuffering` was called twice (which was happening for me sometimes when playing a vod hls stream), 2 timeouts would be created, and then if `onStop()` was called within the timeout interval, only the first of the timeouts would get cleared. This would then cause the loading indicator to reappear.

This should fix this but I haven't built and tested it yet as having some issues npm installing due to windows path length issues.