### PR TITLE
Fix so that use of hlsjs doesn't make clappr incompatible with requirejs and commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "file-loader": "^0.8.4",
     "gulp": "^3.8.1",
     "html-loader": "^0.3.0",
+    "imports-loader": "^0.6.4",
     "isparta": "^3.0.3",
     "istanbul": "^0.3.19",
     "istanbul-instrumenter-loader": "^0.1.3",

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import HTML5VideoPlayback from 'playbacks/html5_video'
-import HLSJS from 'hls.js'
+import HLSJS from 'imports?define=>false!hls.js'
 import Events from 'base/events'
 import Browser from 'components/browser'
 

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import HTML5VideoPlayback from 'playbacks/html5_video'
-import HLSJS from 'imports?define=>false!hls.js'
+import HLSJS from 'imports?define=>false,require=>false!hls.js'
 import Events from 'base/events'
 import Browser from 'components/browser'
 


### PR DESCRIPTION
This makes sure that hls.js doesn't register itself with requirejs and commonjs. Without this the built clappr file will first define itself as an anonymous module, then later on where hlsjs is inserted hlsjs would also try to define itself resulting in this error: http://requirejs.org/docs/errors.html#mismatch

The imports loader plugin will inject a new line to the start of hlsjs which overrides `define` to `false` therefore removing the issue. 

![image](https://cloud.githubusercontent.com/assets/3259993/10561691/9d3ad0fa-752d-11e5-86f6-6f01b5c843dc.png)
