### PR TITLE
player: avoid duplicated code

### DIFF
--- a/src/components/player.js
+++ b/src/components/player.js
@@ -292,10 +292,7 @@ export default class Player extends BaseObject {
    * ```
    */
   getPlugin(name) {
-    var plugins = this.core.plugins.concat(this.core.mediaControl.container.plugins);
-    return find(plugins, function(plugin) {
-      return plugin.name === name;
-    });
+    return this.loader.getPlugin(name)
   }
 
   /**


### PR DESCRIPTION
Since we have `getPlugin(name)` at [Loader](https://github.com/clappr/clappr/blob/master/src/components/loader/loader.js#L75) and [Player](https://github.com/clappr/clappr/blob/master/src/components/player.js#L294) I think it's best to reuse this code.