### PR TITLE
Add test to extend method for exposed plugins on Clappr scope

### DIFF
--- a/test/plugins/external_plugin_spec.js
+++ b/test/plugins/external_plugin_spec.js
@@ -1,0 +1,49 @@
+import Clappr from '../../src/main'
+
+describe('External Plugin', function() {
+  it('should expose extend method for the plugins exposed on Clappr scope', function(){
+    var MyPluginClass
+    var myPluginInstance
+    var nativePluginInstance
+    var testMethod = function() {
+      return "test"
+    }
+
+  	MyPluginClass = Clappr.CorePlugin.extend({testMethod: testMethod})
+  	myPluginInstance = new MyPluginClass()
+  	nativePluginInstance = new Clappr.CorePlugin()
+    expect(myPluginInstance.enable).to.be.equal(nativePluginInstance.enable)
+    expect(myPluginInstance.disable).to.be.equal(nativePluginInstance.disable)
+    expect(myPluginInstance.testMethod).to.be.equal(testMethod)
+
+    MyPluginClass = Clappr.Playback.extend({testMethod: testMethod})
+    myPluginInstance = new MyPluginClass()
+    nativePluginInstance = new Clappr.Playback()
+    expect(myPluginInstance.play).to.be.equal(nativePluginInstance.play)
+    expect(myPluginInstance.stop).to.be.equal(nativePluginInstance.stop)
+    expect(myPluginInstance.testMethod).to.be.equal(testMethod)
+
+    MyPluginClass = Clappr.ContainerPlugin.extend({testMethod: testMethod})
+    myPluginInstance = new MyPluginClass({container:{}})
+    nativePluginInstance = new Clappr.ContainerPlugin({container:{}})
+    expect(myPluginInstance.enable).to.be.equal(nativePluginInstance.enable)
+    expect(myPluginInstance.disable).to.be.equal(nativePluginInstance.disable)
+    expect(myPluginInstance.testMethod).to.be.equal(testMethod)
+
+    MyPluginClass = Clappr.UIContainerPlugin.extend({testMethod: testMethod})
+    myPluginInstance = new MyPluginClass({container:{}})
+    nativePluginInstance = new Clappr.UIContainerPlugin({container:{}})
+    expect(myPluginInstance.enable).to.be.equal(nativePluginInstance.enable)
+    expect(myPluginInstance.disable).to.be.equal(nativePluginInstance.disable)
+    expect(myPluginInstance.testMethod).to.be.equal(testMethod)
+
+    MyPluginClass = Clappr.UICorePlugin.extend({testMethod: testMethod})
+    MyPluginClass.prototype.render = function() {}
+    Clappr.UICorePlugin.prototype.render = function() {}
+    myPluginInstance = new MyPluginClass()
+    nativePluginInstance = new Clappr.UICorePlugin()
+    expect(myPluginInstance.enable).to.be.equal(nativePluginInstance.enable)
+    expect(myPluginInstance.disable).to.be.equal(nativePluginInstance.disable)
+    expect(myPluginInstance.testMethod).to.be.equal(testMethod)
+  })
+})

--- a/test/plugins/external_plugin_spec.js
+++ b/test/plugins/external_plugin_spec.js
@@ -9,9 +9,9 @@ describe('External Plugin', function() {
       return "test"
     }
 
-  	MyPluginClass = Clappr.CorePlugin.extend({testMethod: testMethod})
-  	myPluginInstance = new MyPluginClass()
-  	nativePluginInstance = new Clappr.CorePlugin()
+    MyPluginClass = Clappr.CorePlugin.extend({testMethod: testMethod})
+    myPluginInstance = new MyPluginClass()
+    nativePluginInstance = new Clappr.CorePlugin()
     expect(myPluginInstance.enable).to.be.equal(nativePluginInstance.enable)
     expect(myPluginInstance.disable).to.be.equal(nativePluginInstance.disable)
     expect(myPluginInstance.testMethod).to.be.equal(testMethod)


### PR DESCRIPTION
extend method for plugins CorePlugin, Playback, ContainerPlugin, UIContainerPlugin, UICorePlugin