### PR TITLE
Standardilizes *_PROGRESS event parameter

### DIFF
--- a/src/base/events.js
+++ b/src/base/events.js
@@ -255,6 +255,19 @@ Events.PLAYER_ERROR = 'error'
 Events.PLAYER_TIMEUPDATE = 'timeupdate'
 
 // Playback Events
+/**
+ * Fired when the browser loads more of the media file at playback level
+ *
+ * @event PLAYBACK_PROGRESS
+ * @param {Object} progress Data
+ * progress object
+ * @param {Number} [progress.start]
+ * start progress
+ * @param {Number} [progress.current]
+ * current progress
+ * @param {Number} [progress.total]
+ * total progress
+ */
 Events.PLAYBACK_PROGRESS = 'playback:progress'
 Events.PLAYBACK_TIMEUPDATE = 'playback:timeupdate'
 Events.PLAYBACK_READY = 'playback:ready'
@@ -285,6 +298,19 @@ Events.CONTAINER_READY = 'container:ready'
 Events.CONTAINER_ERROR = 'container:error'
 Events.CONTAINER_LOADEDMETADATA = 'container:loadedmetadata'
 Events.CONTAINER_TIMEUPDATE = 'container:timeupdate'
+/**
+ * Fired when the browser loads more of the media file at container level
+ *
+ * @event CONTAINER_PROGRESS
+ * @param {Object} progress Data
+ * progress object
+ * @param {Number} [progress.start]
+ * start progress
+ * @param {Number} [progress.current]
+ * current progress
+ * @param {Number} [progress.total]
+ * total progress
+ */
 Events.CONTAINER_PROGRESS = 'container:progress'
 Events.CONTAINER_PLAY = 'container:play'
 Events.CONTAINER_STOP = 'container:stop'

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -194,8 +194,8 @@ export default class Container extends UIObject {
     this.trigger(Events.CONTAINER_TIMEUPDATE, position, duration, this.name)
   }
 
-  progress(startPosition, endPosition, duration) {
-    this.trigger(Events.CONTAINER_PROGRESS, startPosition, endPosition, duration, this.name);
+  progress(progress) {
+    this.trigger(Events.CONTAINER_PROGRESS, progress)
   }
 
   playing() {

--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -334,9 +334,9 @@ export default class MediaControl extends UIObject {
     this.changeTogglePlay()
   }
 
-  updateProgressBar(startPosition, endPosition, duration) {
-    var loadedStart = startPosition / duration * 100
-    var loadedEnd = endPosition / duration * 100
+  updateProgressBar(progress) {
+    var loadedStart = progess.start / progress.total * 100
+    var loadedEnd = progress.current / progress.total * 100
     this.$seekBarLoaded.css({ left: loadedStart + '%', width: (loadedEnd - loadedStart) + '%' })
   }
 

--- a/src/playbacks/flash/flash.js
+++ b/src/playbacks/flash/flash.js
@@ -112,7 +112,7 @@ export default class Flash extends BaseFlashPlayback {
 
   progress() {
     if (this.currentState !== "IDLE" && this.currentState !== "ENDED") {
-      this.trigger(Events.PLAYBACK_PROGRESS, 0, this.el.getBytesLoaded(), this.el.getBytesTotal(), this.name)
+      this.trigger(Events.PLAYBACK_PROGRESS, {start: 0, current: this.el.getBytesLoaded(), total: this.el.getBytesTotal()})
     }
   }
 

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -341,7 +341,7 @@ export default class FlasHLS extends BaseFlashPlayback {
     this.trigger(Events.PLAYBACK_FRAGMENT_LOADED, loadmetrics)
     if (this.reportingProgress && this.el.getPosition) {
       var buffered = this.el.getPosition() + this.el.getbufferLength()
-      this.trigger(Events.PLAYBACK_PROGRESS, this.el.getPosition(), buffered, this.el.getDuration(), this.name)
+      this.trigger(Events.PLAYBACK_PROGRESS, {start: this.el.getPosition(), current: buffered, total: this.el.getDuration()})
     }
   }
 

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -216,7 +216,7 @@ export default class HTML5Video extends Playback {
       }
     }
     this.checkBufferState(this.el.buffered.end(bufferedPos))
-    this.trigger(Events.PLAYBACK_PROGRESS, this.el.buffered.start(bufferedPos), this.el.buffered.end(bufferedPos), this.el.duration, this.name)
+    this.trigger(Events.PLAYBACK_PROGRESS, {start: this.el.buffered.start(bufferedPos), current: this.el.buffered.end(bufferedPos), total: this.el.duration})
   }
 
   checkBufferState(bufferedPos) {


### PR DESCRIPTION
*This one is a little bit trick*, I was looking at *_PROGRESS events and noticed that we could provide a standard parameter to the progress event. 

Basically I think of `{start: start, current: current, total: total}` as these names pass the feeling of progress but maybe these are not the best names!?

## Just to put in context

It was:

```javascript
//container
this.trigger(Events.CONTAINER_PROGRESS, startPosition, endPosition, duration, this.name);
//flash
this.trigger(Events.PLAYBACK_PROGRESS, 0, this.el.getBytesLoaded(), this.el.getBytesTotal(), this.name)
/...
```

To become:
```javascript
//container
this.trigger(Events.CONTAINER_PROGRESS, progress)
//flash
this.trigger(Events.PLAYBACK_PROGRESS, {start: 0, current: this.el.getBytesLoaded(), total: this.el.getBytesTotal()})
//...
```

## Tests

I ran it on **Chrome (MacOS)** with two VOD's : **mp4** and **hls**. 

## Questions

I also ged rid off `this.name` parameter, can't we just add it within trigger itself?
Do we need `start` (`starPosition`) for this event?