### PR TITLE
Introduces high definition update event parameter

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,0 @@
-java_script:
-  enabled: true
-  config_file: .jshintrc 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 sudo: required
 node_js:

--- a/README.md
+++ b/README.md
@@ -174,8 +174,34 @@ Starting a local server:
 
 This command will start a HTTP Server on port 8080, you can check a sample page with Clappr on http://localhost:8080/webpack-dev-server/
 
+### Guideline to open an issue (bug)
 
+Please, try to follow this to open new bugs (questions, suggetions and others are welcome in freestyle)
 
+For the **issue title**: A **meaningful title** (like: HLS doesn't work at windows 10) at the same time try to **avoid helpless title** (like: it doesn't work, IE10, bug, problem) 
+
+**Be sure**: 
+
+* try to reproduce the bug at http://cdn.clappr.io/
+* there is no open bug like yours
+
+For the **issue body**:
+<hr>
+
+**Browser**: YOUR BROWSER (ex: Chrome Version 46.0.2490.80, Firefox, IE)
+
+**OS**: YOUR OS (ex: Mac OS 10.11.1, iOS9, android4.5)
+
+**ClapprVersion**: 0.2.25
+
+**Steps to reproduce**:
+
+* first step
+* then second step
+* I was exptecting X and but instead it show Y
+
+ps: you can attach images, logs or whatever you think might be helpful.
+<hr>
 
 ### Contributors
 

--- a/src/base/events.js
+++ b/src/base/events.js
@@ -262,6 +262,12 @@ Events.PLAYBACK_BUFFERING = 'playback:buffering'
 Events.PLAYBACK_BUFFERFULL = 'playback:bufferfull'
 Events.PLAYBACK_SETTINGSUPDATE = 'playback:settingsupdate'
 Events.PLAYBACK_LOADEDMETADATA = 'playback:loadedmetadata'
+/**
+ * Fired when playback updates its high definition
+ *
+ * @event PLAYBACK_HIGHDEFINITIONUPDATE
+ * @param {Boolean} state `true` when is updated to HD otherwise `false`
+ */
 Events.PLAYBACK_HIGHDEFINITIONUPDATE = 'playback:highdefinitionupdate'
 /**
  * Fired when playback updates its bitrate
@@ -330,6 +336,12 @@ Events.CONTAINER_FULLSCREEN = 'container:fullscreen'
 Events.CONTAINER_STATE_BUFFERING = 'container:state:buffering'
 Events.CONTAINER_STATE_BUFFERFULL = 'container:state:bufferfull'
 Events.CONTAINER_SETTINGSUPDATE = 'container:settingsupdate'
+/**
+ * Fired when container updates its high definition
+ *
+ * @event CONTAINER_HIGHDEFINITIONUPDATE
+ * @param {Boolean} state `true` when is updated to HD otherwise `false`
+ */
 Events.CONTAINER_HIGHDEFINITIONUPDATE = 'container:highdefinitionupdate'
 Events.CONTAINER_MEDIACONTROL_DISABLE = 'container:mediacontrol:disable'
 Events.CONTAINER_MEDIACONTROL_ENABLE = 'container:mediacontrol:enable'

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -307,8 +307,8 @@ export default class Container extends UIObject {
     this.trigger(Events.CONTAINER_SETTINGSUPDATE);
   }
 
-  highDefinitionUpdate() {
-    this.trigger(Events.CONTAINER_HIGHDEFINITIONUPDATE);
+  highDefinitionUpdate(state) {
+    this.trigger(Events.CONTAINER_HIGHDEFINITIONUPDATE, state)
   }
 
   isHighDefinitionInUse() {

--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -423,12 +423,9 @@ export default class MediaControl extends UIObject {
     }
   }
 
-  highDefinitionUpdate() {
-    if (this.container.isHighDefinitionInUse()) {
-      this.$el.find('button[data-hd-indicator]').addClass("enabled")
-    } else {
-      this.$el.find('button[data-hd-indicator]').removeClass("enabled")
-    }
+  highDefinitionUpdate(state) {
+    var method = state ? 'addClass' : 'removeClass'
+    this.$el.find('button[data-hd-indicator]')[method]("enabled")
   }
 
   createCachedElements() {

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -211,7 +211,7 @@ export default class FlasHLS extends BaseFlashPlayback {
     var currentLevel = this.getLevels()[level]
     if (currentLevel) {
       this.highDefinition = (currentLevel.height >= 720 || (currentLevel.bitrate / 1000) >= 2000);
-      this.trigger(Events.PLAYBACK_HIGHDEFINITIONUPDATE)
+      this.trigger(Events.PLAYBACK_HIGHDEFINITIONUPDATE, this.highDefinition)
       this.trigger(Events.PLAYBACK_BITRATE, {
         height: currentLevel.height,
         width: currentLevel.width,
@@ -420,7 +420,6 @@ export default class FlasHLS extends BaseFlashPlayback {
     }
     this.el.playerSeek(time)
     this.trigger(Events.PLAYBACK_TIMEUPDATE, time, duration, this.name)
-    this.trigger(Events.PLAYBACK_HIGHDEFINITIONUPDATE)
   }
 
   updateDvr(dvrInUse) {

--- a/src/plugins/google_analytics/google_analytics.js
+++ b/src/plugins/google_analytics/google_analytics.js
@@ -77,8 +77,8 @@ export default class GoogleAnalytics extends ContainerPlugin {
     this.push(["Video", "Error", this.container.playback.src])
   }
 
-  onHD() {
-    var status = this.container.isHighDefinitionInUse()? "ON": "OFF"
+  onHD(state) {
+    var status = state? "ON": "OFF"
     if (status !== this.currentHDState) {
       this.currentHDState = status
       this.push(["Video", "HD - " + status, this.container.playback.src])

--- a/test/components/container_spec.js
+++ b/test/components/container_spec.js
@@ -67,9 +67,11 @@ describe('Container', function() {
   })
 
   it('listens to playback:highdefinitionupdate event', function() {
+    var isOnHD = true
+
     sinon.spy(this.container, 'highDefinitionUpdate')
     this.container.bindEvents()
-    this.playback.trigger(Events.PLAYBACK_HIGHDEFINITIONUPDATE)
+    this.playback.trigger(Events.PLAYBACK_HIGHDEFINITIONUPDATE, isOnHD)
     assert.ok(this.container.highDefinitionUpdate.calledOnce)
   })
 

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -1,7 +1,7 @@
 {
   "name": "Clappr",
   "description": "An extensible media player for the web",
-  "version": "0.2.13",
+  "version": "0.2.15",
   "url": "https://github.com/clappr/clappr",
   "logo": "https://cloud.githubusercontent.com/assets/244265/6373134/a845eb50-bce7-11e4-80f2-592ba29972ab.png",
   "options": {


### PR DESCRIPTION
## Questions

I saw that [`seek`](https://github.com/clappr/clappr/blob/master/src/playbacks/flashls/flashls.js#L417) at flashls is triggering **high definition update** event and I removed it. Is there any reason for this?

## Tests
I couldn't test this, in a sense of show/hide('ing) HD icon. Although I played mp4 and hls with no problems.