### PR TITLE
Changes bitrate event parameter

### DIFF
--- a/src/base/events.js
+++ b/src/base/events.js
@@ -263,6 +263,21 @@ Events.PLAYBACK_BUFFERFULL = 'playback:bufferfull'
 Events.PLAYBACK_SETTINGSUPDATE = 'playback:settingsupdate'
 Events.PLAYBACK_LOADEDMETADATA = 'playback:loadedmetadata'
 Events.PLAYBACK_HIGHDEFINITIONUPDATE = 'playback:highdefinitionupdate'
+/**
+ * Fired when playback updates its bitrate
+ *
+ * @event PLAYBACK_BITRATE
+ * @param {Object} bitrate Data
+ * bitrate object
+ * @param {Number} [bitrate.bandwidth]
+ * bitrate bandwidth when it's available
+ * @param {Number} [bitrate.width]
+ * playback width (ex: 720, 640, 1080)
+ * @param {Number} [bitrate.height]
+ * playback height (ex: 240, 480, 720)
+ * @param {Number} [bitrate.level]
+ * playback level when it's available, it could be just a map for width (0 => 240, 1 => 480, 2 => 720)
+ */
 Events.PLAYBACK_BITRATE = 'playback:bitrate'
 Events.PLAYBACK_PLAYBACKSTATE = 'playback:playbackstate'
 Events.PLAYBACK_DVR = 'playback:dvr'
@@ -278,6 +293,21 @@ Events.PLAYBACK_FRAGMENT_LOADED = 'playback:fragment:loaded'
 // Container Events
 Events.CONTAINER_PLAYBACKSTATE = 'container:playbackstate'
 Events.CONTAINER_PLAYBACKDVRSTATECHANGED = 'container:dvr'
+/**
+ * Fired when the container updates its bitrate
+ *
+ * @event CONTAINER_BITRATE
+ * @param {Object} bitrate Data
+ * bitrate object
+ * @param {Number} [bitrate.bandwidth]
+ * bitrate bandwidth when it's available
+ * @param {Number} [bitrate.width]
+ * playback width (ex: 720, 640, 1080)
+ * @param {Number} [bitrate.height]
+ * playback height (ex: 240, 480, 720)
+ * @param {Number} [bitrate.level]
+ * playback level when it's available, it could be just a map for width (0 => 240, 1 => 480, 2 => 720)
+ */
 Events.CONTAINER_BITRATE = 'container:bitrate'
 Events.CONTAINER_STATS_REPORT = 'container:stats:report'
 Events.CONTAINER_DESTROYED = 'container:destroyed'

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -212,7 +212,13 @@ export default class FlasHLS extends BaseFlashPlayback {
     if (currentLevel) {
       this.highDefinition = (currentLevel.height >= 720 || (currentLevel.bitrate / 1000) >= 2000);
       this.trigger(Events.PLAYBACK_HIGHDEFINITIONUPDATE)
-      this.trigger(Events.PLAYBACK_BITRATE, {bitrate: this.getCurrentBitrate(), level: level})
+      this.trigger(Events.PLAYBACK_BITRATE, {
+        height: currentLevel.height,
+        width: currentLevel.width,
+        bandwidth: currentLevel.bandwidth,
+        bitrate: this.getCurrentBitrate(),
+        level: level
+      })
     }
   }
 


### PR DESCRIPTION
Very inspired by [Shaka](https://shaka-player-demo.appspot.com/docs/shaka.media.IStream.html#event:AdaptationEvent) I propose that we follow this  API for bitrate event parameter:

```javascript
{bitrate,bandwidth,width,height,level}
```

## Questions

I'm not 100% sure about `level`, do we need that? it looks pretty coupled to HLS and maybe not useful outside this context.