### PR TITLE
Fix so that SeekTime component works properly after a render() call

### DIFF
--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -351,11 +351,11 @@ export default class MediaControl extends UIObject {
     this.setSeekPercentage(seekbarValue)
 
     if (currentPosition !== this.displayedPosition) {
-      this.$position.html(currentPosition)
+      this.$position.text(currentPosition)
       this.displayedPosition = currentPosition
     }
     if (currentDuration !== this.displayedDuration) {
-      this.$duration.html(currentDuration)
+      this.$duration.text(currentDuration)
       this.displayedDuration = currentDuration
     }
   }
@@ -527,6 +527,8 @@ export default class MediaControl extends UIObject {
 
   render() {
     var timeout = 1000
+    this.displayedPosition = null
+    this.displayedDuration = null
     var style = Styler.getStyleFor(mediaControlStyle, {baseUrl: this.options.baseUrl})
     this.$el.html(this.template({ settings: this.settings }))
     this.$el.append(style)

--- a/src/components/seek_time/seek_time.js
+++ b/src/components/seek_time/seek_time.js
@@ -18,7 +18,7 @@ export default class SeekTime extends UIObject {
   }
   get attributes() {
     return {
-      'class': 'seek-time hidden',
+      'class': 'seek-time',
       'data-seek-time': ''
     }
   }
@@ -48,14 +48,13 @@ export default class SeekTime extends UIObject {
   }
 
   showDuration() {
-    this.$durationEl.show()
     this.durationShown = true
     this.update()
   }
 
   hideDuration() {
-    this.$durationEl.hide()
     this.durationShown = false
+    this.update()
   }
 
   updateDuration(position, duration) {
@@ -86,7 +85,7 @@ export default class SeekTime extends UIObject {
       return
     }
     if (!this.shouldBeVisible()) {
-      this.$el.addClass('hidden')
+      this.$el.hide()
       this.$el.css('left', "-100%")
     }
     else {
@@ -94,20 +93,24 @@ export default class SeekTime extends UIObject {
       var currentSeekTime = formatTime(seekTime)
       // only update dom if necessary, ie time actually changed
       if (currentSeekTime !== this.displayedSeekTime) {
-        this.$seekTimeEl.html(currentSeekTime)
+        this.$seekTimeEl.text(currentSeekTime)
         this.displayedSeekTime = currentSeekTime
       }
 
       if (this.durationShown) {
+        this.$durationEl.show()
         var currentDuration = formatTime(this.duration)
         if (currentDuration !== this.displayedDuration) {
-          this.$durationEl.html(currentDuration)
+          this.$durationEl.text(currentDuration)
           this.displayedDuration = currentDuration
         }
       }
+      else {
+        this.$durationEl.hide()
+      }
 
       // the element must be unhidden before its width is requested, otherwise it's width will be reported as 0
-      this.$el.removeClass('hidden')
+      this.$el.show()
       var containerWidth = this.mediaControl.$seekBarContainer.width()
       var elWidth = this.$el.width()
       var elLeftPos = this.hoverPosition * containerWidth
@@ -123,9 +126,12 @@ export default class SeekTime extends UIObject {
 
   render() {
     this.rendered = true
+    this.displayedDuration = null
+    this.displayedSeekTime = null
     var style = Styler.getStyleFor(seekTimeStyle)
     this.$el.html(this.template())
     this.$el.append(style)
+    this.$el.hide()
     this.mediaControl.$el.append(this.el)
     this.$seekTimeEl = this.$el.find('[data-seek-time]')
     this.$durationEl = this.$el.find('[data-duration]')


### PR DESCRIPTION
Previously when a stream changes from live to dvr (after duration becomes long enough) render() would be called and then the times wouldn't be updated because the cached versions weren't cleared.

Also I was using a hidden class that never existed again.