### PR TITLE
Dispatching PLAYBACK_LEVEL_SWITCH and FRAGMENT_LOADED events on HLS.js

### DIFF
--- a/src/base/events.js
+++ b/src/base/events.js
@@ -289,6 +289,7 @@ Events.PLAYBACK_PAUSE = 'playback:pause'
 Events.PLAYBACK_ERROR = 'playback:error'
 Events.PLAYBACK_STATS_ADD = 'playback:stats:add'
 Events.PLAYBACK_FRAGMENT_LOADED = 'playback:fragment:loaded'
+Events.PLAYBACK_LEVEL_SWITCH = 'playback:level:switch'
 
 // Container Events
 Events.CONTAINER_PLAYBACKSTATE = 'container:playbackstate'

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -36,9 +36,17 @@ export default class HLS extends HTML5VideoPlayback {
       this.updatePlaybackType(evt, data)
     })
     this.hls.on(HLSJS.Events.LEVEL_UPDATED, (evt, data) => this.updateDuration(evt, data))
+    this.hls.on(HLSJS.Events.LEVEL_SWITCH, (evt,data) => this.onLevelSwitch(evt, data))
     this.hls.on(HLSJS.Events.FRAG_LOADED, (evt, data) => this.onFragmentLoaded(evt, data))
-    this.hls.on(HLSJS.Events.LEVEL_SWITCH, (evt, data) => this.onLevelSwitch(evt, data))
     this.hls.attachVideo(this.el)
+  }
+
+  onLevelSwitch(evt, data) {
+    this.trigger(Events.PLAYBACK_LEVEL_SWITCH, data)
+  }
+
+  onFragmentLoaded(evt, data) {
+    this.trigger(Events.PLAYBACK_FRAGMENT_LOADED, data)
   }
 
   getCurrentTime() {


### PR DESCRIPTION
We need to disptach PLAYBACK_LEVEL_SWITCH and FRAGMENT_LOADED events to make the clappr-level-selector-plugin work with HLS.js