### PR TITLE
Added the 'parent' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ var player = new Clappr.Player({
 ##### Player Size
 You can set the player size setting `width` and `height` parameters.
 
+##### Player Location
+You can specify where the player should be attached to using either the `parentId`, or `parent` option. `parentId` should be the id of the element you would like the player to be inserted into, or `parent` should be set to a reference to a dom element.
+
 ##### Auto Play
 Add `autoPlay: true` if you want the video to automatically play after page load.
 

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -55,6 +55,10 @@ export default class Player extends BaseObject {
    * player's width **default**: `640`
    * @param {Number} [options.height]
    * player's height **default**: `360`
+   * @param {String} [options.parentId]
+   * the id of the element on the page that the player should be inserted into
+   * @param {Object} [options.parent]
+   * a reference to a dom element that the player should be inserted into
    * @param {Boolean} [options.autoPlay]
    * automatically play after page load **default**: `false`
    * @param {Boolean} [options.loop]
@@ -99,6 +103,9 @@ export default class Player extends BaseObject {
     this.playerInfo.options = this.options
     if (this.options.parentId) {
       this.setParentId(this.options.parentId)
+    }
+    else if (this.options.parent) {
+      this.attachTo(this.options.parent)
     }
   }
 


### PR DESCRIPTION
Now the reference to a dom can be provided in the options instead of it having to be a string id.