### PR TITLE
hlsjs: checks if MSE is enabled

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -158,7 +158,7 @@ HLS.canPlay = function(resource, mimeType) {
   var resourceParts = resource.split('?')[0].match(/.*\.(.*)$/) || []
   var isHls = ((resourceParts.length > 1 && resourceParts[1] === "m3u8") ||
         mimeType === 'application/x-mpegURL' || mimeType === 'application/vnd.apple.mpegurl')
-  var ignoredBrowser = Browser.isSafari || Browser.isFirefox
+  var isMSEEnabled = !!window.MediaSource
 
-  return !!(HLSJS.isSupported() && isHls && !ignoredBrowser)
+  return !!(HLSJS.isSupported() && isHls && isMSEEnabled && !Browser.isSafari)
 }

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -158,7 +158,6 @@ HLS.canPlay = function(resource, mimeType) {
   var resourceParts = resource.split('?')[0].match(/.*\.(.*)$/) || []
   var isHls = ((resourceParts.length > 1 && resourceParts[1] === "m3u8") ||
         mimeType === 'application/x-mpegURL' || mimeType === 'application/vnd.apple.mpegurl')
-  var isMSEEnabled = !!window.MediaSource
 
-  return !!(HLSJS.isSupported() && isHls && isMSEEnabled && !Browser.isSafari)
+  return !!(HLSJS.isSupported() && isHls && !Browser.isSafari)
 }


### PR DESCRIPTION
Why do we need to explicitly skip Safari? (isn't [html5 video](https://github.com/clappr/clappr/blob/master/src/components/loader/loader.js#L47) playback [able to play](https://github.com/clappr/clappr/blob/master/src/playbacks/html5_video/html5_video.js#L267) it?)

@cpeterso is it safe to assume that `!!window.MediaSource` will return `false` for all FF with disabled **MSE**?

I'm trying to test in multiple browsers:

* http://browsershots.org/https://jsfiddle.net/xd93z211/1/

It seems that is reliable.