### PR TITLE
Added actualLiveTime option.

### DIFF
--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -23,7 +23,7 @@ export function extend(parent, properties) {
   return MergedPlugin
 }
 
-export function formatTime(time) {
+export function formatTime(time, paddedHours) {
     if (!isFinite(time)) {
       return "--:--"
     }
@@ -40,29 +40,7 @@ export function formatTime(time) {
       out += days + ":"
       if (hours < 1) out += "00:"
     }
-    if (hours && hours > 0) out += ("0" + hours).slice(-2) + ":"
-    out += ("0" + minutes).slice(-2) + ":"
-    out += ("0" + seconds).slice(-2)
-    return out.trim()
-}
-export function formatActualTime(time) {
-    if (!isFinite(time)) {
-      return "--:--"
-    }
-    time = time * 1000
-    time = parseInt(time/1000)
-    var seconds = time % 60
-    time = parseInt(time/60)
-    var minutes = time % 60
-    time = parseInt(time/60)
-    var hours = time % 24
-    var days = parseInt(time/24)
-    var out = ""
-    if (days && days > 0) {
-      out += days + ":"
-      if (hours < 1) out += "00:"
-    }
-    out += ("0" + hours).slice(-2) + ":"
+    if (hours && hours > 0 || paddedHours !== undefined && paddedHours) out += ("0" + hours).slice(-2) + ":"
     out += ("0" + minutes).slice(-2) + ":"
     out += ("0" + seconds).slice(-2)
     return out.trim()

--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -40,7 +40,7 @@ export function formatTime(time, paddedHours) {
       out += days + ":"
       if (hours < 1) out += "00:"
     }
-    if (hours && hours > 0 || paddedHours !== undefined && paddedHours) out += ("0" + hours).slice(-2) + ":"
+    if (hours && hours > 0 || paddedHours) out += ("0" + hours).slice(-2) + ":"
     out += ("0" + minutes).slice(-2) + ":"
     out += ("0" + seconds).slice(-2)
     return out.trim()

--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -45,6 +45,28 @@ export function formatTime(time) {
     out += ("0" + seconds).slice(-2)
     return out.trim()
 }
+export function formatActualTime(time) {
+    if (!isFinite(time)) {
+      return "--:--"
+    }
+    time = time * 1000
+    time = parseInt(time/1000)
+    var seconds = time % 60
+    time = parseInt(time/60)
+    var minutes = time % 60
+    time = parseInt(time/60)
+    var hours = time % 24
+    var days = parseInt(time/24)
+    var out = ""
+    if (days && days > 0) {
+      out += days + ":"
+      if (hours < 1) out += "00:"
+    }
+    out += ("0" + hours).slice(-2) + ":"
+    out += ("0" + minutes).slice(-2) + ":"
+    out += ("0" + seconds).slice(-2)
+    return out.trim()
+}
 
 export var Fullscreen = {
   isFullscreen: function() {

--- a/src/components/seek_time/seek_time.js
+++ b/src/components/seek_time/seek_time.js
@@ -30,7 +30,7 @@ export default class SeekTime extends UIObject {
     this.hoveringOverSeekBar = false
     this.hoverPosition = null
     this.duration = null
-    this.actualLiveTime = this.mediaControl.options.actualLiveTime === true
+    this.actualLiveTime = !!this.mediaControl.options.actualLiveTime
     this.durationShown = false
     this.addEventListeners()
   }

--- a/src/components/seek_time/seek_time.js
+++ b/src/components/seek_time/seek_time.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import {formatTime} from 'base/utils'
+import {formatActualTime} from 'base/utils'
 
 import UIObject from 'base/ui_object'
 import Styler from 'base/styler'
@@ -30,6 +30,7 @@ export default class SeekTime extends UIObject {
     this.hoveringOverSeekBar = false
     this.hoverPosition = null
     this.duration = null
+    this.actualLiveTime = this.mediaControl.options.actualLiveTime === true
     this.durationShown = false
     this.addEventListeners()
   }
@@ -89,8 +90,17 @@ export default class SeekTime extends UIObject {
       this.$el.css('left', "-100%")
     }
     else {
-      var seekTime = this.hoverPosition * this.duration
-      var currentSeekTime = formatTime(seekTime)
+      if (this.actualLiveTime) {
+        var d = new Date(), e = new Date(d);
+        var secondsSinceMidnight = (e - d.setHours(0,0,0,0)) / 1000;
+        var seekTime = (secondsSinceMidnight - this.duration) + (this.hoverPosition * this.duration)
+        if (seekTime < 0) {
+          seekTime = (3600 * 24) + seekTime
+        }
+      } else {
+        var seekTime = this.hoverPosition * this.duration
+      }
+      var currentSeekTime = formatActualTime(seekTime)
       // only update dom if necessary, ie time actually changed
       if (currentSeekTime !== this.displayedSeekTime) {
         this.$seekTimeEl.text(currentSeekTime)
@@ -99,7 +109,12 @@ export default class SeekTime extends UIObject {
 
       if (this.durationShown) {
         this.$durationEl.show()
-        var currentDuration = formatTime(this.duration)
+        if (this.actualLiveTime) {
+          var currentDuration = formatActualTime(secondsSinceMidnight)
+        } else {
+          var currentDuration = formatActualTime(this.duration)
+        }
+
         if (currentDuration !== this.displayedDuration) {
           this.$durationEl.text(currentDuration)
           this.displayedDuration = currentDuration

--- a/src/components/seek_time/seek_time.js
+++ b/src/components/seek_time/seek_time.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import {formatActualTime} from 'base/utils'
+import {formatTime} from 'base/utils'
 
 import UIObject from 'base/ui_object'
 import Styler from 'base/styler'
@@ -100,7 +100,7 @@ export default class SeekTime extends UIObject {
       } else {
         var seekTime = this.hoverPosition * this.duration
       }
-      var currentSeekTime = formatActualTime(seekTime)
+      var currentSeekTime = formatTime(seekTime)
       // only update dom if necessary, ie time actually changed
       if (currentSeekTime !== this.displayedSeekTime) {
         this.$seekTimeEl.text(currentSeekTime)
@@ -110,9 +110,9 @@ export default class SeekTime extends UIObject {
       if (this.durationShown) {
         this.$durationEl.show()
         if (this.actualLiveTime) {
-          var currentDuration = formatActualTime(secondsSinceMidnight)
+          var currentDuration = formatTime(secondsSinceMidnight)
         } else {
-          var currentDuration = formatActualTime(this.duration)
+          var currentDuration = formatTime(this.duration)
         }
 
         if (currentDuration !== this.displayedDuration) {


### PR DESCRIPTION
![screenshot1-crop](https://cloud.githubusercontent.com/assets/445843/11341001/cd0fcd5e-9200-11e5-8822-66240734d057.png)
Displays the seek time according to current time. (browser time though)
This is meant to be used with a live feed with dvr. Instead of showing seektime relative to the buffer, this makes it relative to the browsers time.
The time of the screenshot was 16:37:25 and the buffer was ~3.5h.
This implements #685.