### PR TITLE
Add support to custom playback not supported message (fixes #672)

### DIFF
--- a/src/components/player.js
+++ b/src/components/player.js
@@ -91,6 +91,8 @@ export default class Player extends BaseObject {
    * disables the context menu (right click) on the video element if a HTML5Video playback is used.
    * @param {String} [options.poster]
    * define a poster by adding its address `poster: 'http://url/img.png'`. It will appear after video embed, disappear on play and go back when user stops the video.
+   * @param {String} [options.playbackNotSupportedMessage]
+   * define a custom message to be displayed when a playback is not supported.
    */
   constructor(options) {
     super(options)

--- a/src/playbacks/no_op/no_op.js
+++ b/src/playbacks/no_op/no_op.js
@@ -22,16 +22,17 @@ export default class NoOp extends Playback {
     messages['en-us'] = messages['en']
     messages['es-419'] = messages['es']
     messages['pt-br'] = messages['pt']
-    return messages[getBrowserLanguage()]||messages['en']
+    return messages[getBrowserLanguage()] || messages['en']
   }
 
   constructor(options) {
     super(options)
+    this.options = options
   }
 
   render() {
     var style = Styler.getStyleFor(noOpStyle);
-    this.$el.html(this.template({message:this.getNoOpMessage()}))
+    this.$el.html(this.template({message:this.options.playbackNotSupportedMessage || this.getNoOpMessage()}))
     this.$el.append(style);
     this.animate()
     this.trigger(Events.PLAYBACK_READY, this.name)


### PR DESCRIPTION
var playerElement = document.getElementById("player-wrapper");

var player = new Clappr.Player({
  source: 'http://clappr.io/highline.mapt4',
  baseUrl: '/latest',
  poster: 'http://clappr.io/poster.png',
  mute: true,
  height: 360,
  width: 640,
  playbackNotSupportedMessage: 'Sorry Maxwell - your browser can't play this video'
});

player.attachTo(playerElement);
