### PR TITLE
Make HTML5VideoPlayback have priority over HTML5AudioPlayback

### DIFF
--- a/src/components/loader/loader.js
+++ b/src/components/loader/loader.js
@@ -44,7 +44,7 @@ export default class Loader extends BaseObject {
   constructor(externalPlugins, playerId) {
     super()
     this.playerId = playerId
-    this.playbackPlugins = [HTML5AudioPlayback, HTML5VideoPlayback, FlashVideoPlayback, HLSVideoPlayback, FlasHLSVideoPlayback, HTMLImgPlayback, NoOp]
+    this.playbackPlugins = [HTML5VideoPlayback, HTML5AudioPlayback, FlashVideoPlayback, HLSVideoPlayback, FlasHLSVideoPlayback, HTMLImgPlayback, NoOp]
     this.containerPlugins = [SpinnerThreeBouncePlugin, WaterMarkPlugin, PosterPlugin, StatsPlugin, GoogleAnalyticsPlugin, ClickToPausePlugin]
     this.corePlugins = [DVRControls, Favicon]
     if (externalPlugins) {


### PR DESCRIPTION
Currently if you load a video file but specify the mime type manually, it will be played with the audio playback because that would also be a supported playback, when I think videos should always be played with the `HTML5VideoPlayback` by default.