### PR TITLE
Fix bug which would sometimes prevent video playing when overriding mimetype

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -49,6 +49,11 @@ export default class HLS extends HTML5VideoPlayback {
     this.hls.attachMedia(this.el)
   }
 
+  // override
+  setupSrc(srcUrl) {
+    // this playback manages the src on the video element itself
+  }
+
   // the duration on the video element itself should not be used
   // as this does not necesarily represent the duration of the stream
   // https://github.com/clappr/clappr/issues/668#issuecomment-157036678

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -71,12 +71,10 @@ export default class HTML5Video extends Playback {
     this.settings.right = ["fullscreen", "volume", "hd-indicator"]
   }
 
+  // this may be overridden in playbacks that extend this
   setupSrc(srcUrl) {
-    //avoid to set el.src of an "invalid" source since we're extending video tag with MSE
-    if (HTML5Video.canPlay(srcUrl)) {
-      this.src = srcUrl
-      this.el.src = srcUrl
-    }
+    this.src = srcUrl
+    this.el.src = srcUrl
   }
 
   setupSafari() {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -71,7 +71,11 @@ export default class HTML5Video extends Playback {
     this.settings.right = ["fullscreen", "volume", "hd-indicator"]
   }
 
-  // this may be overridden in playbacks that extend this
+  /**
+   * Sets the source url on the <video> element, and also the 'src' property.
+   * @method setupSrc
+   * @param {String} srcUrl The source URL.
+   */
   setupSrc(srcUrl) {
     this.src = srcUrl
     this.el.src = srcUrl

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -20,11 +20,4 @@ describe('HTML5Video playback', () => {
     expect(playback.src).to.be.equals('http://example.com/dash.ogg')
   })
 
-  it('does not set an invalid src to video element', () => {
-    // although clappr can play dash.mpd it uses MSE, this is done to avoid to create source tag with invalid src
-    var options = {src: 'http://example.com/dash.mpd'}
-    var playback = new HTML5Video(options)
-
-    expect(playback.src).to.be.equals(undefined)
-  })
 })


### PR DESCRIPTION
Previously if the user was specifying a mime type, it was not carried through when the check was performed again in `setupSrc()`