### PR TITLE
Fire loadedmetadata event after performing an automatic seek, instead of before

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -87,10 +87,10 @@ export default class HTML5Video extends Playback {
 
   loadedMetadata(e) {
     this.durationChange()
-    this.trigger(Events.PLAYBACK_LOADEDMETADATA, {duration: e.target.duration, data: e})
     if (this.getPlaybackType() !== Playback.LIVE) {
       this.checkInitialSeek()
     }
+    this.trigger(Events.PLAYBACK_LOADEDMETADATA, {duration: e.target.duration, data: e})
   }
 
   durationChange() {


### PR DESCRIPTION
Without this if the user calls seek() from their code in a handler from clappr's LOADEDMETADATA event it will immediately get replaced with the seek in `checkInitialSeek()`