### PR TITLE
Fix so that volume level doesn't get replaced by MediaControl

### DIFF
--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -135,10 +135,10 @@ export default class MediaControl extends UIObject {
     this.container.stop()
   }
 
-  onVolumeChanged(event) {
+  onVolumeChanged(level) {
     this.mute = (this.currentVolume === 0)
-    this.setVolumeLevel(event)
-    this.persistConfig && Config.persist("volume", event)
+    this.setVolumeLevel(level)
+    this.persistConfig && Config.persist("volume", level)
   }
 
   changeTogglePlay() {
@@ -588,7 +588,7 @@ export default class MediaControl extends UIObject {
         this.$seekBarContainer.addClass('seek-disabled')
       }
 
-      this.setVolume(this.currentVolume)
+      this.onVolumeChanged(this.container.volume)
       this.bindKeyEvents()
       this.playerResize({width: this.options.width, height: this.options.height})
       this.hideVolumeBar(0)


### PR DESCRIPTION
Previously if the user did `player.setVolume(something)` immediately after loading the player, it would get reset on the next tick due to a media control `render()`.