### PR TITLE
Added core.isReady(), player.isReady(), and make sure PLAYER_READY not missed

### DIFF
--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -124,6 +124,7 @@ export default class Core extends UIObject {
   resolveOnContainersReady(containers) {
     $.when.apply($, containers).done(() => {
       this.defer.resolve(this)
+      this.ready = true
       this.trigger(Events.CORE_READY)
     })
   }
@@ -159,7 +160,7 @@ export default class Core extends UIObject {
     $(document).unbind('fullscreenchange')
     $(document).unbind('MSFullscreenChange')
     $(document).unbind('mozfullscreenchange')
-}
+  }
 
   exit() {
     this.updateSize()
@@ -269,6 +270,14 @@ export default class Core extends UIObject {
       this.$el.removeClass('nocursor')
     else if (Fullscreen.isFullscreen())
       this.$el.addClass('nocursor')
+  }
+
+  /**
+   * Determine if the core is ready.
+   * @return {boolean} true if the core is ready. ie CORE_READY event fired
+   */
+  isReady() {
+    return !!this.ready
   }
 
   /**

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -139,10 +139,15 @@ export default class Player extends BaseObject {
     this.options.parentElement = element
     this.core = this.coreFactory.create()
     this.addEventListeners()
+    if (this.core.isReady()) {
+      this.onReady()
+    }
   }
 
   addEventListeners() {
-    this.listenTo(this.core, Events.CORE_READY, this.onReady)
+    if (!this.core.isReady()) {
+      this.listenToOnce(this.core, Events.CORE_READY, this.onReady)
+    }
     this.listenTo(this.core.mediaControl,  Events.MEDIACONTROL_CONTAINERCHANGED, this.containerChanged)
     var container = this.core.mediaControl.container
     if (!!container) {

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -144,6 +144,14 @@ export default class Player extends BaseObject {
     }
   }
 
+  /**
+   * Determine if the player is ready.
+   * @return {boolean} true if the player is ready. ie PLAYER_READY event has fired
+   */
+  isReady() {
+    return !!this.ready
+  }
+
   addEventListeners() {
     if (!this.core.isReady()) {
       this.listenToOnce(this.core, Events.CORE_READY, this.onReady)
@@ -168,6 +176,7 @@ export default class Player extends BaseObject {
   }
 
   onReady() {
+    this.ready = true
     this.trigger(Events.PLAYER_READY)
   }
 


### PR DESCRIPTION
It's possible for the `CORE_READY` event to be fired before the `create()` method returns, making it impossible to listen to the event.

Therefore added `isReady()` method, and this is used to determine if event has been missed.