### PR TITLE
Refactor poster plugin

### DIFF
--- a/src/plugins/poster/poster.js
+++ b/src/plugins/poster/poster.js
@@ -35,9 +35,7 @@ export default class PosterPlugin extends UIContainerPlugin {
     this.hasStartedPlaying = false
     this.playRequested = !!this.options.autoPlay
     this.render()
-    setTimeout(() => {
-      this.update()
-    }, 0)
+    process.nextTick(() => this.update())
   }
 
   bindEvents() {
@@ -68,12 +66,12 @@ export default class PosterPlugin extends UIContainerPlugin {
     if (!this.options.chromeless) {
       if (show) {
         this.$playButton.show()
-        this.$el.attr("data-clickable", "1")
+        this.$el.addClass("clickable")
         this.updateSize()
       }
       else {
         this.$playButton.hide()
-        this.$el.attr("data-clickable", "0")
+        this.$el.removeClass("clickable")
       }
     }
   }

--- a/src/plugins/poster/public/poster.scss
+++ b/src/plugins/poster/public/poster.scss
@@ -16,7 +16,7 @@
   top: 0;
   left: 0;
 
-  &[data-clickable="1"] {
+  &.clickable {
     cursor: pointer;
   }
 

--- a/src/plugins/poster/public/poster.scss
+++ b/src/plugins/poster/public/poster.scss
@@ -9,13 +9,16 @@
        url("../../../components/media_control/public/Player-Regular.svg#player") format("svg");
 }
 .player-poster[data-poster] {
-  cursor: pointer;
   position: absolute;
   height: 100%;
   width: 100%;
   z-index: 998;
   top: 0;
   left: 0;
+
+  &[data-clickable="1"] {
+    cursor: pointer;
+  }
 
   .poster-background[data-poster] {
     width: 100%;

--- a/test/plugins/poster_spec.js
+++ b/test/plugins/poster_spec.js
@@ -20,22 +20,6 @@ describe('Poster', function() {
     expect(this.container.mediaControlDisabled).to.be.true
   })
 
-  it('listens to container:state:buffering event', function() {
-    sinon.spy(this.poster, 'hidePlayButton')
-    this.container.trigger(Events.CONTAINER_STATE_BUFFERING)
-    expect(this.poster.hidePlayButton).called.once
-    expect(this.poster.$playButton.is(':visible')).to.be.false
-  })
-
-  it('listens to container:bufferfull event', function() {
-    sinon.spy(this.poster, 'onBufferfull')
-    this.poster.bindEvents()
-    this.container.trigger(Events.CONTAINER_STATE_BUFFERFULL)
-
-    expect(this.poster.onBufferfull).called.once
-    expect(this.poster.$el.is(':visible')).to.be.false
-  })
-
   it('listens to container:stop event', function() {
     sinon.spy(this.container, 'disableMediaControl')
     sinon.spy(this.poster, 'showPlayButton')


### PR DESCRIPTION
No longer listens to `CONTAINER_STATE_BUFFERING` or `CONTAINER_STATE_BUFFERFILL` and removes some duplicated code, as I think the same is being achieved now without those events?

Tested with a hls stream and mp4 and seems to be working.

Also this fixes a bug where the poster was hidden incorrectly when #747 is being used (although that pr is currently out of date).