### PR TITLE
playbackNotSupportedMessage: center text when only one line long (fixes #768)

### DIFF
--- a/src/playbacks/no_op/public/style.scss
+++ b/src/playbacks/no_op/public/style.scss
@@ -8,8 +8,11 @@
 
 [data-no-op] p[data-no-op-msg] {
   position: absolute;
+  text-align: center;
   font-size: 25px;
   top: 40%;
+  left: 0;
+  right: 0;
   color: white;
 }
 


### PR DESCRIPTION
I'm not sure if this is the correct solution. Worked for me on all browsers that I initially had the issue on though. Seems to work. Someone more experienced double check it please haha