### PR TITLE
Fix issues when player loaded with no source

### DIFF
--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -520,9 +520,7 @@ export default class MediaControl extends UIObject {
   }
 
   bindKeyEvents() {
-    if (this.kibo) {
-      this.unbindKeyEvents()
-    }
+    this.unbindKeyEvents()
     this.kibo = new Kibo(this.options.focusElement)
     this.kibo.down(['space'], () => this.togglePlayPause())
     this.kibo.down(['left'], () => this.seekRelative(-15))
@@ -532,10 +530,12 @@ export default class MediaControl extends UIObject {
   }
 
   unbindKeyEvents() {
-    this.kibo.off('space')
-    this.kibo.off('left')
-    this.kibo.off('right')
-    this.kibo.off([1,2,3,4,5,6,7,8,9,0])
+    if (this.kibo) {
+      this.kibo.off('space')
+      this.kibo.off('left')
+      this.kibo.off('right')
+      this.kibo.off([1,2,3,4,5,6,7,8,9,0])
+    }
   }
 
   parseColors() {

--- a/src/playbacks/no_op/no_op.js
+++ b/src/playbacks/no_op/no_op.js
@@ -1,4 +1,4 @@
-import {requestAnimationFrame, getBrowserLanguage} from 'base/utils'
+import {requestAnimationFrame, cancelAnimationFrame, getBrowserLanguage} from 'base/utils'
 import Playback from 'base/playback'
 import template from 'base/template'
 import Styler from 'base/styler'
@@ -70,8 +70,18 @@ export default class NoOp extends Playback {
   }
 
   loop() {
+    if (this.stop === true) {
+      return;
+    }
     this.noise()
-    requestAnimationFrame(() => this.loop())
+    this.animationHandle = requestAnimationFrame(() => this.loop())
+  }
+
+  destroy() {
+    if (this.animationHandle) {
+      cancelAnimationFrame(this.animationHandle);
+      this.stop = true;
+    }
   }
 
   animate() {


### PR DESCRIPTION
1. `requestAnimationFrame` leaking and killing CPU on canvas noise generator.  I was trying to re-use a single player instance across a playlist of videos (some of which were faulty during testing), and I found my CPU being pegged constantly.  Profiling found `noise()` to be the culprit.  Using `cancelAnimationFrame` (already polyfilled in utils) to take care of this.
2. `player.destroy()` fails unbinding kibo events - looks like the kibo safety check was missed in a few spots, so moved it closer to where it was needed