### PR TITLE
Make it easier to create custom MediaControl

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,32 @@ Result:
 
 I'm sure you can do better than me.
 
+For advanced configuration, you can create an entire `MediaControl` object. At its most basic,
+you might consider subclassing the base `MediaControl` and using your own custom HTML and CSS.
+
+```javascript
+  // ES6-style code shown
+  class MyMediaControl extends Clappr.MediaControl {
+    get template() {
+      return Clappr.template(
+        `<div>My HTML here based on clappr/src/components/media_control/public/media-control.html</div>`
+      )
+    }
+    get stylesheet () {
+      return Clappr.Styler.getStyleFor(
+        `.my-css-class { /* based on clappr/src/components/media_control/public/media-control.scss */ }`
+      )
+    }
+    constructor(options) {
+        super(options);
+    }
+  }
+  let player = new Clappr.Player({
+    source: "http://your.video/here.mp4",
+    mediacontrol: MyMediaControl
+  });
+```
+
 ##### Media Control Auto Hide
 
 If you want to disable media control auto hide, add `hideMediaControl: false` in your embed parameters.

--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -60,6 +60,8 @@ export default class MediaControl extends UIObject {
 
   get template() { return template(mediaControlHTML) }
 
+  get stylesheet() { return Styler.getStyleFor(mediaControlStyle, {baseUrl: this.options.baseUrl}) }
+
   constructor(options) {
     super(options)
     this.options = options
@@ -557,9 +559,8 @@ export default class MediaControl extends UIObject {
 
   render() {
     var timeout = 1000
-    var style = Styler.getStyleFor(mediaControlStyle, {baseUrl: this.options.baseUrl})
     this.$el.html(this.template({ settings: this.settings }))
-    this.$el.append(style)
+    this.$el.append(this.stylesheet)
     this.createCachedElements()
     this.$playPauseToggle.addClass('paused')
     this.$playStopToggle.addClass('stopped')

--- a/test/components/media_control_spec.js
+++ b/test/components/media_control_spec.js
@@ -1,4 +1,6 @@
 import {Config} from '../../src/base/utils'
+import Styler from '../../src/base/styler';
+import template from '../../src/base/template';
 import MediaControl from '../../src/components/media_control'
 import FakePlayback from '../../src/base/playback'
 import Container from '../../src/components/container'
@@ -83,5 +85,23 @@ describe('MediaControl', function() {
     mediacontrol.setVolume(78)
 
     expect(Config.restore("volume")).to.be.equal(78)
-  })
+  });
+
+  describe('custom media control', function() {
+    it('can be extend the base mediacontrol with a custom template and stylesheet', function() {
+      class MyMediaControl extends MediaControl {
+        get template() { return template(`<div>My HTML here</div>`) }
+        get stylesheet () { return Styler.getStyleFor(`.my-css-class {}`) }
+        constructor(options) { super(options) }
+      }
+
+      var mediaControl = new MyMediaControl({mute: true, container: this.container});
+      mediaControl.render();
+      expect(mediaControl.mute).to.be.equal(true);
+      expect(mediaControl.currentVolume).to.be.equal(0);
+      expect(mediaControl.$el.html()).to.be.equal(
+        '<div>My HTML here</div><style class="clappr-style">.my-css-class {}</style>'
+      );
+    });
+  });
 });


### PR DESCRIPTION
* Add overridable `stylesheet` property to base MediaControl rather than creating in constructor
* Update README with sample of how to do it
* Add unit test