### PR TITLE
Allow poster to stay open for audio-only broadcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,10 @@ Put `watermark: http://url/img.png` on your embed parameters to automatically ad
 ```
 
 ##### Poster
-Define a poster by adding `poster: http://url/img.png` on your embed parameters. It will appear after video embed, disappear on play and go back when user stops the video.
+Define a poster image by adding `poster: 'http://url/img.png'` on your player options. It will appear after video embed, disappear on play and go back when user stops the video. For audio broadcasts, the poster stays up while playing.
+
+##### Audio Only Hint
+Some audio-only sources (e.g. HLS) cannot be easily detected as such; for that you can add `audioOnly: true` to the options so clappr knows to treat the source as such.
 
 ##### Stats
 Clappr has a native statistics plugin that accounts QoE metrics such playing time, rebuffering time, total rebuffers, etc. Metrics report happens periodically, learn how to access these numbers on [Create your own plugin](https://github.com/globocom/generator-clappr-plugin) session.

--- a/src/components/core/public/style.scss
+++ b/src/components/core/public/style.scss
@@ -39,6 +39,8 @@
   &.fullscreen {
     width: 100% !important;
     height: 100% !important;
+    top: 0;
+    left: 0;
   }
 
   &.nocursor {

--- a/src/plugins/poster/poster.js
+++ b/src/plugins/poster/poster.js
@@ -107,6 +107,11 @@ export default class PosterPlugin extends UIContainerPlugin {
     }
   }
 
+  shouldHideOnPlay() {
+    // Audio broadcasts should keep the poster up; video should hide poster while playing.
+    return !((this.container.playback.name == 'html5_audio') || this.options.audioOnly);
+  }
+
   update() {
     if (!this.shouldRender) {
       return
@@ -118,7 +123,9 @@ export default class PosterPlugin extends UIContainerPlugin {
     }
     else {
       this.container.enableMediaControl()
-      this.$el.hide()
+      if (this.shouldHideOnPlay()) {
+        this.$el.hide()
+      }
     }
   }
 

--- a/test/plugins/poster_spec.js
+++ b/test/plugins/poster_spec.js
@@ -57,4 +57,18 @@ describe('Poster', function() {
     $(this.poster.$el).click()
     expect(this.container.play).called.once
   })
+
+  it('keeps the poster up for audio sources', function() {
+    this.playback.name = 'html5_video';
+    expect(this.poster.shouldHideOnPlay()).to.equal(true);
+
+    this.playback.name = 'html5_audio';
+    expect(this.poster.shouldHideOnPlay()).to.equal(false);
+
+    // HLS audio-only needs overridden manually via config
+    this.playback.name = 'html5_video';
+    this.poster.options.audioOnly = true;
+    expect(this.poster.shouldHideOnPlay()).to.equal(false);
+  });
+
 })


### PR DESCRIPTION
The use-case is an audio-only HLS stream, which ends up using the `<video>` playback.  We want to have the poster stick around in this case, even though the source is playing.