### PR TITLE
Refactored BUFFERING and BUFFERFULL events and added 'buffering' property

### DIFF
--- a/src/base/events.js
+++ b/src/base/events.js
@@ -307,13 +307,22 @@ Events.PLAYBACK_TIMEUPDATE = 'playback:timeupdate'
  */
 Events.PLAYBACK_READY = 'playback:ready'
 /**
- * Fired when playback is buffering
+ * Fired when the playback starts having to buffer because
+ * playback can currently not be smooth.
+ *
+ * This corresponds to the playback `buffering` property being
+ * `true`.
  *
  * @event PLAYBACK_BUFFERING
  */
 Events.PLAYBACK_BUFFERING = 'playback:buffering'
 /**
- * Fired when playback filled the buffer
+ * Fired when the playback has enough in the buffer to be
+ * able to play smoothly, after previously being unable to
+ * do this.
+ *
+ * This corresponds to the playback `buffering` property being
+ * `false`.
  *
  * @event PLAYBACK_BUFFERFULL
  */

--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -19,6 +19,17 @@ export default class Playback extends UIObject {
   }
 
   /**
+   * Determine if the playback is having to buffer in order for
+   * playback to be smooth.
+   * (i.e if a live stream is playing smoothly, this will be false)
+   * @property buffering
+   * @type Boolean
+   */
+  get buffering() {
+    return false
+  }
+
+  /**
    * @method constructor
    * @param {Object} options the options object
    */

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -51,6 +51,17 @@ export default class Container extends UIObject {
   }
 
   /**
+   * Determine if the playback is having to buffer in order for
+   * playback to be smooth.
+   * (i.e if a live stream is playing smoothly, this will be false)
+   * @property buffering
+   * @type Boolean
+   */
+  get buffering() {
+    return this.playback.buffering
+  }
+
+  /**
    * it builds a container
    * @method constructor
    * @param {Object} options the options object
@@ -100,7 +111,7 @@ export default class Container extends UIObject {
     this.listenTo(this.playback, Events.PLAYBACK_PROGRESS, this.progress)
     this.listenTo(this.playback, Events.PLAYBACK_TIMEUPDATE, this.timeUpdated)
     this.listenTo(this.playback, Events.PLAYBACK_READY, this.ready)
-    this.listenTo(this.playback, Events.PLAYBACK_BUFFERING, this.buffering)
+    this.listenTo(this.playback, Events.PLAYBACK_BUFFERING, this.onBuffering)
     this.listenTo(this.playback, Events.PLAYBACK_BUFFERFULL, this.bufferfull)
     this.listenTo(this.playback, Events.PLAYBACK_SETTINGSUPDATE, this.settingsUpdate)
     this.listenTo(this.playback, Events.PLAYBACK_LOADEDMETADATA, this.loadedMetadata)
@@ -110,7 +121,7 @@ export default class Container extends UIObject {
     this.listenTo(this.playback, Events.PLAYBACK_DVR, this.playbackDvrStateChanged)
     this.listenTo(this.playback, Events.PLAYBACK_MEDIACONTROL_DISABLE, this.disableMediaControl)
     this.listenTo(this.playback, Events.PLAYBACK_MEDIACONTROL_ENABLE, this.enableMediaControl)
-    this.listenTo(this.playback, Events.PLAYBACK_ENDED, this.ended)
+    this.listenTo(this.playback, Events.PLAYBACK_ENDED, this.onEnded)
     this.listenTo(this.playback, Events.PLAYBACK_PLAY, this.playing)
     this.listenTo(this.playback, Events.PLAYBACK_PAUSE, this.paused)
     this.listenTo(this.playback, Events.PLAYBACK_STOP, this.stopped)
@@ -247,7 +258,7 @@ export default class Container extends UIObject {
     this.playback.pause()
   }
 
-  ended() {
+  onEnded() {
     this.trigger(Events.CONTAINER_ENDED, this, this.name)
     this.currentTime = 0
   }
@@ -291,7 +302,7 @@ export default class Container extends UIObject {
     this.trigger(Events.CONTAINER_FULLSCREEN, this.name)
   }
 
-  buffering() {
+  onBuffering() {
     this.trigger(Events.CONTAINER_STATE_BUFFERING, this.name)
   }
 

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -52,6 +52,17 @@ export default class Player extends BaseObject {
     return this.core.mediaControl.container.ended
   }
 
+  /**
+   * Determine if the playback is having to buffer in order for
+   * playback to be smooth.
+   * (i.e if a live stream is playing smoothly, this will be false)
+   * @property buffering
+   * @type Boolean
+   */
+  get buffering() {
+    return this.core.mediaControl.container.buffering
+  }
+
   /*
    * determine if the player is ready.
    * @property isReady

--- a/src/playbacks/flash/flash.js
+++ b/src/playbacks/flash/flash.js
@@ -28,6 +28,16 @@ export default class Flash extends BaseFlashPlayback {
     return this.currentState === "ENDED"
   }
 
+  /**
+   * Determine if the playback is buffering.
+   * This is related to the PLAYBACK_BUFFERING and PLAYBACK_BUFFERFULL events
+   * @property buffering
+   * @type Boolean
+   */
+  get buffering() {
+    return !!this.bufferingState && this.currentState !== "ENDED"
+  }
+
   constructor(options) {
     super(options)
     this.src = options.src
@@ -105,9 +115,11 @@ export default class Flash extends BaseFlashPlayback {
     if (this.isIdle || this.currentState === "PAUSED") {
       return
     } else if (this.currentState !== "PLAYING_BUFFERING" && this.el.getState() === "PLAYING_BUFFERING") {
+      this.bufferingState = true
       this.trigger(Events.PLAYBACK_BUFFERING, this.name)
       this.currentState = "PLAYING_BUFFERING"
     } else if (this.el.getState() === "PLAYING") {
+      this.bufferingState = false
       this.trigger(Events.PLAYBACK_BUFFERFULL, this.name)
       this.currentState = "PLAYING"
     } else if (this.el.getState() === "IDLE") {

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -37,6 +37,16 @@ export default class FlasHLS extends BaseFlashPlayback {
     return this.hasEnded
   }
 
+  /**
+   * Determine if the playback is buffering.
+   * This is related to the PLAYBACK_BUFFERING and PLAYBACK_BUFFERFULL events
+   * @property buffering
+   * @type Boolean
+   */
+  get buffering() {
+    return !!this.bufferingState && !this.hasEnded
+  }
+
   constructor(options) {
     super(options)
     this.src = options.src
@@ -443,10 +453,12 @@ export default class FlasHLS extends BaseFlashPlayback {
 
   setPlaybackState(state) {
     if (["PLAYING_BUFFERING", "PAUSED_BUFFERING"].indexOf(state) >= 0)  {
+      this.bufferingState = true
       this.trigger(Events.PLAYBACK_BUFFERING, this.name)
       this.updateCurrentState(state)
     } else if (["PLAYING", "PAUSED"].indexOf(state) >= 0) {
       if (["PLAYING_BUFFERING", "PAUSED_BUFFERING", "IDLE"].indexOf(this.currentState) >= 0) {
+        this.bufferingState = false
         this.trigger(Events.PLAYBACK_BUFFERFULL, this.name)
       }
       this.updateCurrentState(state)

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -84,7 +84,7 @@ export default class HLS extends HTML5VideoPlayback {
     this.trigger(Events.PLAYBACK_STATS_ADD, {'dvr': status})
   }
 
-  durationChange() {
+  updateSettings() {
     if (this.playbackType === Playback.VOD) {
       this.settings.left = ["playpause", "position", "duration"]
     } else if (this.dvrEnabled) {
@@ -93,11 +93,10 @@ export default class HLS extends HTML5VideoPlayback {
       this.settings.left = ["playstop"]
     }
     this.settings.seekEnabled = this.isSeekEnabled()
-    this.timeUpdated()
     this.trigger(Events.PLAYBACK_SETTINGSUPDATE)
   }
 
-  timeUpdated() {
+  onTimeUpdate() {
     this.trigger(Events.PLAYBACK_TIMEUPDATE, {current: this.getCurrentTime(), total: this.getDuration()}, this.name)
   }
 
@@ -123,12 +122,6 @@ export default class HLS extends HTML5VideoPlayback {
     }
   }
 
-  render() {
-    super.render()
-    this.ready()
-    return this
-  }
-
   updatePlaybackType(evt, data) {
     this.playbackType = data.details.live ? Playback.LIVE : Playback.VOD
     this.fillLevels()
@@ -145,7 +138,7 @@ export default class HLS extends HTML5VideoPlayback {
       this.playableRegionStartTime = fragments[0].start
     }
     this.playableRegionDuration = data.details.totalduration
-    this.durationChange()
+    this.onDurationChange()
   }
 
   onFragmentLoaded(evt, data) {

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -115,10 +115,10 @@ export default class HLS extends HTML5VideoPlayback {
   }
 
   stop() {
+    super.stop()
     if (this.hls) {
       this.hls.destroy()
       delete this.hls
-      this.trigger(Events.PLAYBACK_STOP)
     }
   }
 

--- a/src/playbacks/html5_audio/html5_audio.js
+++ b/src/playbacks/html5_audio/html5_audio.js
@@ -11,7 +11,7 @@ export default class HTML5Audio extends HTML5Video {
   get name() { return 'html5_audio' }
   get tagName() { return 'audio' }
 
-  durationChange() {
+  updateSettings() {
     this.settings.left = ["playpause", "position", "duration"]
     this.settings.seekEnabled = this.isSeekEnabled()
     this.trigger(Events.PLAYBACK_SETTINGSUPDATE)
@@ -19,16 +19,6 @@ export default class HTML5Audio extends HTML5Video {
 
   getPlaybackType() {
     return Playback.AOD
-  }
-
-  stalled() {
-    if (this.el.readyState < this.el.HAVE_FUTURE_DATA) {
-      this.trigger(Events.PLAYBACK_BUFFERING, this.name)
-    }
-  }
-
-  timeUpdated() {
-    this.trigger(Events.PLAYBACK_TIMEUPDATE, {current: this.el.currentTime, total: this.el.duration}, this.name)
   }
 }
 

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -38,18 +38,21 @@ export default class HTML5Video extends Playback {
 
   get events() {
     return {
-      'timeupdate': 'timeUpdated',
-      'progress': 'progress',
+      'canplay': 'handleBufferingEvents',
+      'canplaythrough': 'handleBufferingEvents',
+      'durationchange': 'onDurationChange',
       'ended': 'onEnded',
-      'stalled': 'stalled',
-      'waiting': 'waiting',
-      'canplaythrough': 'bufferFull',
-      'loadedmetadata': 'loadedMetadata',
-      'canplay': 'ready',
-      'durationchange': 'durationChange',
-      'error': 'error',
-      'playing': 'playing',
-      'pause': 'paused'
+      'error': 'onError',
+      'loadedmetadata': 'onLoadedMetadata',
+      'loadstart': 'onLoadStart',
+      'pause': 'onPause',
+      'playing': 'onPlaying',
+      'progress': 'onProgress',
+      'seeked': 'handleBufferingEvents',
+      'seeking': 'handleBufferingEvents',
+      'stalled': 'handleBufferingEvents',
+      'timeupdate': 'onTimeUpdate',
+      'waiting': 'handleBufferingEvents'
     }
   }
 
@@ -62,19 +65,37 @@ export default class HTML5Video extends Playback {
     return this.el.ended
   }
 
+  /**
+   * Determine if the playback is having to buffer in order for
+   * playback to be smooth.
+   * This is related to the PLAYBACK_BUFFERING and PLAYBACK_BUFFERFULL events
+   * @property buffering
+   * @type Boolean
+   */
+  get buffering() {
+    return this.bufferingState
+  }
+
   constructor(options) {
     super(options)
+    this.loadStarted = false
+    this.playheadMoving = false
+    this.playheadMovingTimeOnCheck = null
+    this.playheadMovingTimer = setInterval(this.determineIfPlayheadMoving.bind(this), 500)
     this.options = options
     this.setupSrc(options.src)
     this.el.loop = options.loop
-    this.firstBuffer = true
-    this.settings = {default: ['seekbar']}
+    if (options.poster) {
+      this.$el.attr("poster", options.poster)
+    }
+    this.el.autoplay = options.autoPlay
     if (Browser.isSafari) {
       this.setupSafari()
     } else {
       this.el.preload = options.preload ? options.preload: 'metadata'
       this.settings.seekEnabled = true
     }
+    this.settings = {default: ['seekbar']}
     this.settings.left = ["playpause", "position", "duration"]
     this.settings.right = ["fullscreen", "volume", "hd-indicator"]
   }
@@ -93,16 +114,22 @@ export default class HTML5Video extends Playback {
     this.el.preload = 'auto'
   }
 
-  loadedMetadata(e) {
-    this.durationChange()
+  onLoadedMetadata(e) {
+    this.handleBufferingEvents()
+    this.trigger(Events.PLAYBACK_LOADEDMETADATA, {duration: e.target.duration, data: e})
+    this.updateSettings()
     var autoSeekFromUrl = typeof(this.options.autoSeekFromUrl) === "undefined" || this.options.autoSeekFromUrl
     if (this.getPlaybackType() !== Playback.LIVE && autoSeekFromUrl) {
       this.checkInitialSeek()
     }
-    this.trigger(Events.PLAYBACK_LOADEDMETADATA, {duration: e.target.duration, data: e})
   }
 
-  durationChange() {
+  onDurationChange() {
+    this.updateSettings()
+    this.onTimeUpdate()
+  }
+
+  updateSettings() {
     // we can't figure out if hls resource is VoD or not until it is being loaded or duration has changed.
     // that's why we check it again and update media control accordingly.
     if (this.getPlaybackType() === Playback.VOD) {
@@ -127,6 +154,10 @@ export default class HTML5Video extends Playback {
   }
 
   play() {
+    if (!this.loadStarted && this.el.preload === 'none') {
+      this.loadStarted = true
+      this.handleBufferingEvents()
+    }
     this.el.play()
   }
 
@@ -136,10 +167,9 @@ export default class HTML5Video extends Playback {
 
   stop() {
     this.pause()
-    if (this.el.readyState !== 0) {
-      this.el.currentTime = 0
-      this.trigger(Events.PLAYBACK_STOP)
-    }
+    this.el.currentTime = 0
+    this.handleBufferingEvents()
+    this.trigger(Events.PLAYBACK_STOP)
   }
 
   volume(value) {
@@ -166,51 +196,65 @@ export default class HTML5Video extends Playback {
     return this.isReadyState
   }
 
-  playing() {
-    this.trigger(Events.PLAYBACK_PLAY);
+  determineIfPlayheadMoving() {
+    var before = this.playheadMovingTimeOnCheck
+    var now = this.el.currentTime
+    this.playheadMoving = before !== now
+    this.playheadMovingTimeOnCheck = now
+    this.handleBufferingEvents()
   }
 
-  paused() {
-    this.trigger(Events.PLAYBACK_PAUSE);
+  onLoadStart() {
+    if (this.el.preload !== 'none') {
+      // when preload is none the onLoadStart event is still fired
+      // immediately. Pretend that load starts in play()
+      this.loadStarted = true
+      this.handleBufferingEvents()
+    }
+  }
+
+  onPlaying() {
+    this.handleBufferingEvents()
+    this.trigger(Events.PLAYBACK_PLAY)
+  }
+
+  onPause() {
+    this.handleBufferingEvents()
+    this.trigger(Events.PLAYBACK_PAUSE)
   }
 
   onEnded() {
-    this.trigger(Events.PLAYBACK_BUFFERFULL, this.name)
+    this.handleBufferingEvents()
     this.trigger(Events.PLAYBACK_ENDED, this.name)
-    this.trigger(Events.PLAYBACK_TIMEUPDATE, { current: 0, total: this.el.duration }, this.name)
   }
 
-  stalled() {
-    if (this.getPlaybackType() === Playback.VOD && this.el.readyState < this.el.HAVE_FUTURE_DATA) {
-      this.trigger(Events.PLAYBACK_BUFFERING, this.name)
-    }
-  }
-
-  waiting() {
-    if(this.el.readyState < this.el.HAVE_FUTURE_DATA) {
-      this.trigger(Events.PLAYBACK_BUFFERING, this.name)
-    }
-  }
-
-  bufferFull() {
-    if (this.options.poster && this.firstBuffer) {
-      this.firstBuffer = false
-      if (!this.isPlaying()) {
-        this.el.poster = this.options.poster
+  // The playback should be classed as buffering if the following are true:
+  // - the ready state is less then HAVE_FUTURE_DATA or the playhead isn't moving and it should be
+  // - the media hasn't "ended"
+  // - loading has started
+  handleBufferingEvents() {
+    var playheadShouldBeMoving = !this.elended && !this.el.paused
+    var buffering = this.loadStarted && !this.el.ended && ((playheadShouldBeMoving && !this.playheadMoving) || this.el.readyState < this.el.HAVE_FUTURE_DATA)
+    if (this.bufferingState !== buffering) {
+      this.bufferingState = buffering
+      if (buffering) {
+        this.trigger(Events.PLAYBACK_BUFFERING, this.name)
       }
-    } else {
-      this.el.poster = ''
+      else {
+        this.trigger(Events.PLAYBACK_BUFFERFULL, this.name)
+      }
     }
-    this.trigger(Events.PLAYBACK_BUFFERFULL, this.name)
   }
 
-  error(event) {
+  onError(event) {
     this.trigger(Events.PLAYBACK_ERROR, this.el.error, this.name)
   }
 
   destroy() {
     this.stop()
     this.el.src = ''
+    this.src = ''
+    clearInterval(this.playheadMovingTimer)
     this.$el.remove()
   }
 
@@ -225,7 +269,9 @@ export default class HTML5Video extends Playback {
 
   checkInitialSeek() {
     var seekTime = seekStringToSeconds(window.location.href)
-    if (seekTime !== 0) this.seek(seekTime)
+    if (seekTime !== 0) {
+      this.seek(seekTime)
+    }
   }
 
   getCurrentTime() {
@@ -236,7 +282,8 @@ export default class HTML5Video extends Playback {
     return this.el.duration
   }
 
-  timeUpdated() {
+  onTimeUpdate() {
+    this.handleBufferingEvents()
     if (this.getPlaybackType() === Playback.LIVE) {
       this.trigger(Events.PLAYBACK_TIMEUPDATE, {current: 1, total: 1}, this.name)
     } else {
@@ -244,8 +291,10 @@ export default class HTML5Video extends Playback {
     }
   }
 
-  progress() {
-    if (!this.el.buffered.length) return
+  onProgress() {
+    if (!this.el.buffered.length) {
+      return
+    }
     var bufferedPos = 0
     for (var i = 0;  i < this.el.buffered.length; i++) {
       if (this.el.currentTime >= this.el.buffered.start(i) && this.el.currentTime <= this.el.buffered.end(i)) {
@@ -253,7 +302,6 @@ export default class HTML5Video extends Playback {
         break
       }
     }
-    this.checkBufferState(this.el.buffered.end(bufferedPos))
     this.trigger(Events.PLAYBACK_PROGRESS, {
       start: this.el.buffered.start(bufferedPos),
       current: this.el.buffered.end(bufferedPos),
@@ -261,19 +309,8 @@ export default class HTML5Video extends Playback {
     })
   }
 
-  checkBufferState(bufferedPos) {
-    var playbackPos = this.el.currentTime + 0.05; // 50 ms threshold
-    if (this.isPlaying() && playbackPos >= bufferedPos) {
-      this.trigger(Events.PLAYBACK_BUFFERING, this.name)
-      this.buffering = true
-    } else if (this.buffering) {
-      this.trigger(Events.PLAYBACK_BUFFERFULL, this.name)
-      this.buffering = false
-    }
-  }
-
   typeFor(src) {
-    return (src.indexOf('.m3u8') > 0) ? 'application/vnd.apple.mpegurl' : 'video/mp4'
+    return 'video/mp4'
   }
 
   ready() {
@@ -282,10 +319,6 @@ export default class HTML5Video extends Playback {
     }
     this.isReadyState = true
     this.trigger(Events.PLAYBACK_READY, this.name)
-    if (this.firstBuffer) {
-      this.trigger(Events.PLAYBACK_BUFFERFULL, this.name)
-      this.firstBuffer = this.buffering = false
-    }
   }
 
   render() {
@@ -304,11 +337,7 @@ export default class HTML5Video extends Playback {
     }
 
     this.$el.append(style)
-
-    process.nextTick(() => this.options.autoPlay && this.play())
-    if (this.el.readyState === this.el.HAVE_ENOUGH_DATA) {
-      this.ready()
-    }
+    this.ready()
     return this
   }
 }

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -233,7 +233,7 @@ export default class HTML5Video extends Playback {
   // - the media hasn't "ended"
   // - loading has started
   handleBufferingEvents() {
-    var playheadShouldBeMoving = !this.elended && !this.el.paused
+    var playheadShouldBeMoving = !this.el.ended && !this.el.paused
     var buffering = this.loadStarted && !this.el.ended && ((playheadShouldBeMoving && !this.playheadMoving) || this.el.readyState < this.el.HAVE_FUTURE_DATA)
     if (this.bufferingState !== buffering) {
       this.bufferingState = buffering

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -253,7 +253,7 @@ export default class HTML5Video extends Playback {
   destroy() {
     this.stop()
     this.el.src = ''
-    this.src = ''
+    this.src = null
     clearInterval(this.playheadMovingTimer)
     this.$el.remove()
   }

--- a/src/plugins/poster/poster.js
+++ b/src/plugins/poster/poster.js
@@ -42,7 +42,12 @@ export default class PosterPlugin extends UIContainerPlugin {
     this.listenTo(this.container, Events.CONTAINER_STOP, this.onStop)
     this.listenTo(this.container, Events.CONTAINER_PLAY, this.onPlay)
     this.listenTo(this.container, Events.CONTAINER_ENDED, this.onStop)
-    this.listenToOnce(this.container, Events.CONTAINER_STATE_BUFFERING, this.onBuffering)
+    if (this.container.buffering) {
+      process.nextTick(() => this.onBuffering())
+    }
+    else {
+      this.listenToOnce(this.container, Events.CONTAINER_STATE_BUFFERING, this.onBuffering)
+    }
     this.listenTo(this.container, Events.CONTAINER_OPTIONS_CHANGE, this.render)
     Mediator.on(`${this.options.playerId}:${Events.PLAYER_RESIZE}`, this.updateSize, this)
   }

--- a/src/plugins/poster/public/poster.scss
+++ b/src/plugins/poster/public/poster.scss
@@ -23,6 +23,7 @@
   .poster-background[data-poster] {
     width: 100%;
     height: 100%;
+    background-color: #000;
     background-size: cover;
     background-repeat: no-repeat;
     background-position: 50% 50%;

--- a/src/plugins/spinner_three_bounce/spinner_three_bounce.js
+++ b/src/plugins/spinner_three_bounce/spinner_three_bounce.js
@@ -23,6 +23,9 @@ export default class SpinnerThreeBouncePlugin extends UIContainerPlugin {
     this.template = template(spinnerHTML);
     this.showTimeout = null
     this.listenTo(this.container, Events.CONTAINER_STATE_BUFFERING, this.onBuffering)
+    if (this.container.buffering) {
+      process.nextTick(() => this.onBuffering())
+    }
     this.listenTo(this.container, Events.CONTAINER_STATE_BUFFERFULL, this.onBufferFull)
     this.listenTo(this.container, Events.CONTAINER_STOP, this.onStop)
     this.listenTo(this.container, Events.CONTAINER_ENDED, this.onStop)

--- a/test/components/container_spec.js
+++ b/test/components/container_spec.js
@@ -43,10 +43,10 @@ describe('Container', function() {
   })
 
   it('listens to playback:buffering event', function() {
-    sinon.spy(this.container, 'buffering')
+    sinon.spy(this.container, 'onBuffering')
     this.container.bindEvents()
     this.playback.trigger(Events.PLAYBACK_BUFFERING)
-    assert.ok(this.container.buffering.calledOnce)
+    assert.ok(this.container.onBuffering.calledOnce)
   })
 
   it('listens to playback:bufferfull event', function() {
@@ -97,10 +97,10 @@ describe('Container', function() {
   })
 
   it('listens to playback:ended event', function() {
-    sinon.spy(this.container, 'ended')
+    sinon.spy(this.container, 'onEnded')
     this.container.bindEvents()
     this.playback.trigger(Events.PLAYBACK_ENDED)
-    assert.ok(this.container.ended.calledOnce)
+    assert.ok(this.container.onEnded.calledOnce)
   })
 
   it('listens to playback:play event', function() {

--- a/test/plugins/stats_spec.js
+++ b/test/plugins/stats_spec.js
@@ -15,7 +15,7 @@ describe('StatsPlugin', function() {
   afterEach(function() { this.clock.restore() })
 
   it('should calculate startup time', function() {
-    this.container.buffering()
+    this.container.onBuffering()
     this.clock.tick(1000)
     this.container.bufferfull()
     expect(this.stats.getStats().startupTime).to.equal(1000)
@@ -24,10 +24,10 @@ describe('StatsPlugin', function() {
   it('should calculate rebuffer events', function() {
     // to maintain compatibility with the first ping version
     // we'll increment rebuffers even on the startup rebuffer event
-    this.container.buffering()
+    this.container.onBuffering()
     this.container.bufferfull()
 
-    this.container.buffering()
+    this.container.onBuffering()
     this.container.bufferfull()
 
     expect(this.stats.getStats().rebuffers).to.equal(2)
@@ -35,15 +35,15 @@ describe('StatsPlugin', function() {
 
   it('should calculate total rebuffer time', function() {
     this.container.play()
-    this.container.buffering() // startup time
+    this.container.onBuffering() // startup time
     this.clock.tick(1000)
     this.container.bufferfull()
 
-    this.container.buffering()
+    this.container.onBuffering()
     this.clock.tick(1000)
     this.container.bufferfull()
 
-    this.container.buffering()
+    this.container.onBuffering()
     this.clock.tick(500)
     this.container.bufferfull()
 
@@ -52,7 +52,7 @@ describe('StatsPlugin', function() {
 
   it('should avoid NaN on watching time and rebuffering time when more than one bufferfull is dispatched', function() {
     this.container.play()
-    this.container.buffering() // startup time
+    this.container.onBuffering() // startup time
     this.clock.tick(1000)
     this.container.bufferfull()
     this.container.bufferfull()
@@ -65,14 +65,14 @@ describe('StatsPlugin', function() {
 
   it('should calculate total watching time', function() {
     this.container.play()
-    this.container.buffering() // startup time
+    this.container.onBuffering() // startup time
     this.clock.tick(1000)
     this.container.bufferfull()
 
     this.clock.tick(2000) // watching for 2 secs
     expect(this.stats.getStats().watchingTime).to.equal(2000)
 
-    this.container.buffering()
+    this.container.onBuffering()
     this.clock.tick(500)
     this.container.bufferfull()
 
@@ -82,16 +82,16 @@ describe('StatsPlugin', function() {
 
   it('should consider current rebuffering state', function() {
     this.container.play()
-    this.container.buffering() // startup time
+    this.container.onBuffering() // startup time
     this.clock.tick(1000)
     this.container.bufferfull()
 
-    this.container.buffering()
+    this.container.onBuffering()
     this.clock.tick(1000)
     this.container.bufferfull()
     this.clock.tick(10000)
 
-    this.container.buffering()
+    this.container.onBuffering()
     this.clock.tick(500)
     // still rebuffering
 


### PR DESCRIPTION
`PLAYBACK_BUFFERING` and `PLAYBACK_BUFFERFULL` are now only fired whenever the new 'buffering' state changes.

The `PLAYBACK_BUFFERING` event is fired when loading has started the tech isn't happy that it's got enough content to play smoothly. The `PLAYBACK_BUFFERFULL`event is fired when the tech is happy it's got enough content to play smoothly.

The `readyState` in chrome (didn't test firefox) remained at `HAVE_ENOUGH_DATA` even when it had was stuttering/stalled, so there's also a separate check to determine if the playhead is actually moving.
'PLAYBACK_BUFFERING' is triggered if the playhead isn't moving but the tech is stating that it should be playing.

`PLAYBACK_READY` is now fired when rendering finishes, as at this point`'play()` can actually be called successfully and it means it's the same for `html5_video` as `hls`.

Tested hlsjs mp4 in internet explorer, edge, firefox and chrome and seems to be fine. Also tested flashls in chrome as well.

(Fixes #785)