### PR TITLE
Fix so that volume initialised on player load

### DIFF
--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -62,7 +62,7 @@ export default class MediaControl extends UIObject {
 
   get stylesheet() { return Styler.getStyleFor(mediaControlStyle, {baseUrl: this.options.baseUrl}) }
 
-  get volume() { return this.container ? this.container.volume : 100 }
+  get volume() { return this.intendedVolume }
   get muted() { return this.volume === 0 }
 
   constructor(options) {
@@ -309,6 +309,10 @@ export default class MediaControl extends UIObject {
 
   setVolume(value) {
     value = Math.min(100, Math.max(value, 0))
+    // this will hold the intended volume
+    // it may not actually get set to this straight away
+    // if the container is not ready etc
+    this.intendedVolume = value
     this.persistConfig && Config.persist("volume", value)
     var setWhenContainerReady = () => {
       if (this.container.isReady) {
@@ -343,6 +347,8 @@ export default class MediaControl extends UIObject {
     }
     Mediator.off(`${this.options.playerId}:${Events.PLAYER_RESIZE}`, this.playerResize, this)
     this.container = container
+    // set the new container to match the volume of the last one
+    this.setVolume(this.intendedVolume)
     this.changeTogglePlay()
     this.addEventListeners()
     this.settingsUpdate()

--- a/test/components/media_control_spec.js
+++ b/test/components/media_control_spec.js
@@ -16,54 +16,56 @@ describe('MediaControl', function() {
   describe('#constructor', function() {
     it('can be built muted', function() {
       var mediaControl = new MediaControl({mute: true, container: this.container});
-      expect(mediaControl.mute).to.be.equal(true);
-      expect(mediaControl.currentVolume).to.be.equal(0);
+      expect(mediaControl.muted).to.be.equal(true);
+      expect(mediaControl.volume).to.be.equal(0);
     });
 
     it('restores saved volume', function() {
       Config.persist('volume', 42)
       var mediaControl = new MediaControl({persistConfig: true, container: this.container});
 
-      expect(mediaControl.currentVolume).to.be.equal(42)
+      expect(mediaControl.volume).to.be.equal(42)
     });
   });
 
   describe('#setVolume', function() {
+    // TODO fix. needs to wait for container to be ready because
+    // setVolume only called at this point
     it('sets the volume', function() {
       sinon.spy(this.container, 'setVolume');
-      sinon.spy(this.mediaControl, 'setVolumeLevel');
+      sinon.spy(this.mediaControl, 'updateVolumeUI');
 
       this.mediaControl.setVolume(42)
 
-      expect(this.mediaControl.currentVolume).to.be.equal(42)
-      expect(this.mediaControl.mute).to.be.equal(false)
+      expect(this.mediaControl.volume).to.be.equal(42)
+      expect(this.mediaControl.muted).to.be.equal(false)
       expect(this.container.setVolume).called.once;
-      expect(this.mediaControl.setVolumeLevel).called.once;
+      expect(this.mediaControl.updateVolumeUI).called.once;
     });
 
     it('limits volume to an integer between 0 and 100', function() {
       this.mediaControl.setVolume(1000)
-      expect(this.mediaControl.currentVolume).to.be.equal(100)
+      expect(this.mediaControl.volume).to.be.equal(100)
 
       this.mediaControl.setVolume(101)
-      expect(this.mediaControl.currentVolume).to.be.equal(100)
+      expect(this.mediaControl.volume).to.be.equal(100)
 
       this.mediaControl.setVolume(481)
-      expect(this.mediaControl.currentVolume).to.be.equal(100)
+      expect(this.mediaControl.volume).to.be.equal(100)
 
       this.mediaControl.setVolume(-1)
-      expect(this.mediaControl.currentVolume).to.be.equal(0)
+      expect(this.mediaControl.volume).to.be.equal(0)
 
       this.mediaControl.setVolume(0)
-      expect(this.mediaControl.currentVolume).to.be.equal(0)
+      expect(this.mediaControl.volume).to.be.equal(0)
     })
 
     it('mutes when volume is 0 or less than 0', function() {
       this.mediaControl.setVolume(10)
-      expect(this.mediaControl.mute).to.be.equal(false)
+      expect(this.mediaControl.muted).to.be.equal(false)
 
       this.mediaControl.setVolume(0)
-      expect(this.mediaControl.mute).to.be.equal(true)
+      expect(this.mediaControl.muted).to.be.equal(true)
     });
 
     it('persists volume when persistence is on', function() {
@@ -97,8 +99,8 @@ describe('MediaControl', function() {
 
       var mediaControl = new MyMediaControl({mute: true, container: this.container});
       mediaControl.render();
-      expect(mediaControl.mute).to.be.equal(true);
-      expect(mediaControl.currentVolume).to.be.equal(0);
+      expect(mediaControl.muted).to.be.equal(true);
+      expect(mediaControl.volume).to.be.equal(0);
       expect(mediaControl.$el.html()).to.be.equal(
         '<div>My HTML here</div><style class="clappr-style">.my-css-class {}</style>'
       );


### PR DESCRIPTION
(Fixes #784)

[This fix](https://github.com/clappr/clappr/compare/master...fix-volume#diff-77857a480ef013cab1d709b21f7d2ba7R341) took a while to figure out. Whenever a new container was set all the listeners this was listening to were removed, because `this.container` was `undefined` initially, and that causes everything to get removed. Intended behaviour is only listeners for the container are removed if it changes.

