### PR TITLE
hls.js: play when autoPlay is true

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -36,6 +36,7 @@ export default class HLS extends HTML5VideoPlayback {
     // if content is removed from the beginning then this empty area should
     // be ignored. "playableRegionDuration" does not consider this
     this.playableRegionDuration = 0
+    options.autoPlay && this.setupHls()
   }
 
   setupHls() {


### PR DESCRIPTION
It seems now that is responsibility of each playback to autoplay itself, since html5video already provide the basic (marking autoplay attribute).