### PR TITLE
Fix "back to live" so that it seeks explicitly to end position, not -1

### DIFF
--- a/src/plugins/dvr_controls/dvr_controls.js
+++ b/src/plugins/dvr_controls/dvr_controls.js
@@ -55,11 +55,13 @@ export default class DVRControls extends UICorePlugin {
   }
 
   click() {
-    if (!this.core.mediaControl.container.isPlaying()) {
-      this.core.mediaControl.container.play()
+    var mediaControl = this.core.mediaControl
+    var container = mediaControl.container
+    if (!container.isPlaying()) {
+      container.play()
     }
-    if (this.core.mediaControl.$el.hasClass('dvr')) {
-      this.core.mediaControl.container.seek(-1)
+    if (mediaControl.$el.hasClass('dvr')) {
+      container.seek(container.getDuration())
     }
   }
 


### PR DESCRIPTION
I think previously it worked most of the time because of default browser behaviour when trying to seek to an area of the buffer where there wasn't content. When the stream had been running for a bit, sometimes there would be content at -1 seconds that hadn't been cleaned up, hence the seek back to the beginning.

(Fixes #808)