### PR TITLE
Fix three spinner bounce buffer handling

### DIFF
--- a/src/plugins/spinner_three_bounce/spinner_three_bounce.js
+++ b/src/plugins/spinner_three_bounce/spinner_three_bounce.js
@@ -23,9 +23,6 @@ export default class SpinnerThreeBouncePlugin extends UIContainerPlugin {
     this.template = template(spinnerHTML);
     this.showTimeout = null
     this.listenTo(this.container, Events.CONTAINER_STATE_BUFFERING, this.onBuffering)
-    if (this.container.buffering) {
-      process.nextTick(() => this.onBuffering())
-    }
     this.listenTo(this.container, Events.CONTAINER_STATE_BUFFERFULL, this.onBufferFull)
     this.listenTo(this.container, Events.CONTAINER_STOP, this.onStop)
     this.listenTo(this.container, Events.CONTAINER_ENDED, this.onStop)
@@ -65,6 +62,9 @@ export default class SpinnerThreeBouncePlugin extends UIContainerPlugin {
     this.container.$el.append(style)
     this.container.$el.append(this.$el)
     this.$el.hide()
+    if (this.container.buffering) {
+      this.onBuffering()
+    }
     return this
   }
 }


### PR DESCRIPTION
Can't assume the playback is still buffering a tick after the point the plugin loads.

Was causing bug when native hls used. Loading indicator was sticking on screen until play clicked on iOS. Think it might be that on ios the buffering doesn't start until play is requested.