### PR TITLE
Set buffering to false when Html5Video is stopped

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -81,6 +81,7 @@ export default class HTML5Video extends Playback {
     this.loadStarted = false
     this.playheadMoving = false
     this.playheadMovingTimer = null
+    this.stopped = false
     this.options = options
     this.setupSrc(options.src)
     this.el.loop = options.loop
@@ -153,6 +154,8 @@ export default class HTML5Video extends Playback {
   }
 
   play() {
+    this.stopped = false
+    this.handleBufferingEvents()
     this.el.play()
   }
 
@@ -162,6 +165,7 @@ export default class HTML5Video extends Playback {
 
   stop() {
     this.pause()
+    this.stopped = true
     this.el.currentTime = 0
     this.stopPlayheadMovingChecks()
     this.handleBufferingEvents()
@@ -267,11 +271,12 @@ export default class HTML5Video extends Playback {
 
   // The playback should be classed as buffering if the following are true:
   // - the ready state is less then HAVE_FUTURE_DATA or the playhead isn't moving and it should be
-  // - the media hasn't "ended"
+  // - the media hasn't "ended",
+  // - the media hasn't been stopped
   // - loading has started
   handleBufferingEvents() {
     var playheadShouldBeMoving = !this.el.ended && !this.el.paused
-    var buffering = this.loadStarted && !this.el.ended && ((playheadShouldBeMoving && !this.playheadMoving) || this.el.readyState < this.el.HAVE_FUTURE_DATA)
+    var buffering = this.loadStarted && !this.el.ended && !this.stopped && ((playheadShouldBeMoving && !this.playheadMoving) || this.el.readyState < this.el.HAVE_FUTURE_DATA)
     if (this.bufferingState !== buffering) {
       this.bufferingState = buffering
       if (buffering) {


### PR DESCRIPTION
This fixes a bug which would cause the play button not to reappear when clicking stop on a live stream (because hlsjs is detached, but the video element still thinks it's buffering).

I think this is more of a simple fix for now. When hlsjs is detached I don't think `buffering` being true really makes sense, but not sure at the moment how to make it `false`. Maybe on stop() the video/audio element should be destroyed and recreated so it starts fresh? 