### PR TITLE
Switched to lodash 'find' from native ES6 'find' for older browser support

### DIFF
--- a/src/plugins/sources.js
+++ b/src/plugins/sources.js
@@ -1,6 +1,7 @@
 import CorePlugin from 'base/core_plugin'
 
 import Events from 'base/events'
+import find from 'lodash.find'
 
 export default class SourcesPlugin extends CorePlugin {
   get name() { return 'sources' }
@@ -10,7 +11,7 @@ export default class SourcesPlugin extends CorePlugin {
   }
 
   onContainersCreated() {
-    var firstValidSource = this.core.containers.find((container) => container.playback.name !== 'no_op') || this.core.containers[0]
+    var firstValidSource = find(this.core.containers, (container) => container.playback.name !== 'no_op' || this.core.containers[0])
     if (firstValidSource) {
       this.core.containers.forEach((container) => {
         if (container !== firstValidSource) {


### PR DESCRIPTION
This PR fixes the error:

```
 %c[error]color: #ff0000;font-weight: bold; font-size: 13px;error on eventcore:containers:createdtrigger-TypeError: Object doesn't support property or method 'find'
```

Which occurs on any browser which does not support the native ES6 method 'find' on the Array prototype object. (IE10 and IE11 for example)

Per discussion with @leandromoreira this is a new PR to fix the issue described in https://github.com/clappr/clappr/pull/816 