### PR TITLE
Fixed bug where selected level id=0 would show AUTO

### DIFF
--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -21,7 +21,13 @@ export default class FlasHLS extends BaseFlashPlayback {
   get swfPath() { return template(hlsSwf)({baseUrl: this.baseUrl}) }
 
   get levels() { return this._levels || [] }
-  get currentLevel() { return this._currentLevel || AUTO }
+  get currentLevel() {
+    if (this._currentLevel === null || this._currentLevel === undefined) {
+      return AUTO;
+    } else {
+      return this._currentLevel; //0 is a valid level ID
+    }
+  }
   set currentLevel(id) {
     this._currentLevel = id
     this.trigger(Events.PLAYBACK_LEVEL_SWITCH_START)

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -15,7 +15,13 @@ export default class HLS extends HTML5VideoPlayback {
   get name() { return 'hls' }
 
   get levels() { return this._levels || [] }
-  get currentLevel() { return this._currentLevel || AUTO }
+  get currentLevel() {
+    if (this._currentLevel === null || this._currentLevel === undefined) {
+      return AUTO;
+    } else {
+      return this._currentLevel; //0 is a valid level ID
+    }
+  }
   set currentLevel(id) {
     this._currentLevel = id
     this.trigger(Events.PLAYBACK_LEVEL_SWITCH_START)

--- a/test/playbacks/hls_spec.js
+++ b/test/playbacks/hls_spec.js
@@ -1,0 +1,26 @@
+import HLS from 'playbacks/hls'
+
+describe('HLS playback', () => {
+  var playback;
+
+  beforeEach(() => {
+    var options = {src: 'http://example.com/foo.m3u8'}
+    playback = new HLS(options);
+    playback.setupHls();
+    // XXX: Monkeypatching deep into hls.js to support our test. Demeter would be sad :(
+    playback.hls.levelController._levels = [];
+    playback.fillLevels();
+  });
+
+  it('supports specifying the level', () => {
+
+    // AUTO by default (-1)
+    expect(playback.currentLevel).to.equal(-1);
+
+    // supports other level specification
+    playback.currentLevel = 0;
+    expect(playback.currentLevel).to.equal(0);
+    playback.currentLevel = 1;
+    expect(playback.currentLevel).to.equal(1);
+  })
+})


### PR DESCRIPTION
There was a null vs 0 discrepancy which caused the level selector plugin to exhibit some odd behavior.

_I need a little help here getting a test working.  I'm at the point where I'm monkeypatching hls.js, but that isn't where we want to be.  Any ideas for a more appropriate pattern? _