### PR TITLE
Added "getStartTimeOffset()"

### DIFF
--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -70,10 +70,20 @@ export default class Playback extends UIObject {
    */
   seekPercentage(percentage) {/*jshint unused:false*/}
 
+
+  /**
+   * The time that "0" now represents relative to when playback started.
+   * For a stream with a sliding window this will increase as content is
+   * removed from the beginning.
+   * @method getStartTimeOffset
+   * @return {Number} time (in seconds) that time "0" represents.
+   */
+  getStartTimeOffset() { return 0 }
+
   /**
    * gets the duration in seconds
    * @method getDuration
-   * @return {Number} duration time (in seconds) of the current source
+   * @return {Number} duration (in seconds) of the current source
    */
   getDuration() { return 0 }
 

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -197,6 +197,10 @@ export default class Container extends UIObject {
     return this.playback.isPlaying()
   }
 
+  getStartTimeOffset() {
+    return this.playback.getStartTimeOffset()
+  }
+
   getCurrentTime() {
     return this.currentTime
   }

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -439,6 +439,17 @@ export default class Player extends BaseObject {
   }
 
   /**
+   * The time that "0" now represents relative to when playback started.
+   * For a stream with a sliding window this will increase as content is
+   * removed from the beginning.
+   * @method getStartTimeOffset
+   * @return {Number} time (in seconds) that time "0" represents.
+   */
+  getStartTimeOffset() {
+   return this.core.mediaControl.container.getStartTimeOffset()
+  }
+
+  /**
    * the duration time in seconds.
    * @method getDuration
    * @return {Number} duration time (in seconds) of the current source

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -72,6 +72,13 @@ export default class HLS extends HTML5VideoPlayback {
     return this.el.currentTime - this.playableRegionStartTime
   }
 
+  // the time that "0" now represents relative to when playback started
+  // for a stream with a sliding window this will increase as content is
+  // removed from the beginning
+  getStartTimeOffset() {
+    return this.playableRegionStartTime
+  }
+
   seekPercentage(percentage) {
     var seekTo = this.playableRegionDuration
     if (percentage > 0) {


### PR DESCRIPTION
This returns the time that "0" now represents relative to when playback started.

Useful for plugins that want to place items in the player which correspond with a particular point in time when it's a live stream with a sliding window. The plugins will need to know how the media sliding.

It cannot be assumed that the media slides at a constant rate. It actually jumps because it maps to chunks, and the server may decide not to start removing chunks from the start of the stream until it's reached a certain duration.

Ref: https://github.com/tjenkinson/clappr-markers-plugin/issues/3