### PR TITLE
Hide duration (current time) if using actual time in seek time component

### DIFF
--- a/src/plugins/seek_time/seek_time.js
+++ b/src/plugins/seek_time/seek_time.js
@@ -26,7 +26,7 @@ export default class SeekTime extends UICorePlugin {
   get mediaControl() { return this.core.mediaControl }
   get mediaControlContainer() { return this.mediaControl.container }
   get isLiveStreamWithDvr() { return this.mediaControlContainer && this.mediaControlContainer.getPlaybackType() === Playback.LIVE && this.mediaControlContainer.isDvrEnabled() }
-  get durationShown() { return this.isLiveStreamWithDvr }
+  get durationShown() { return this.isLiveStreamWithDvr && !this.useActualLiveTime }
   get useActualLiveTime() { return this.actualLiveTime && this.isLiveStreamWithDvr }
   constructor(core) {
     super(core)


### PR DESCRIPTION
When using the actualLiveTime feature on a live stream, currently the duration will be shown as the current time. This removes this as I don't think it's really useful.

@cowai you happy with this change? If you still want to be able to show the actual time as the duration it could be changed to be another config option instead.