### PR TITLE
Send the entire level object

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -153,7 +153,7 @@ export default class HLS extends HTML5VideoPlayback {
 
   fillLevels() {
     this._levels = this.hls.levels.map((level, index) => {
-      return {id: index , label: `${level.bitrate/1000}Kbps`
+      return {id: index, level: level, label: `${level.bitrate/1000}Kbps`
     }})
     this.trigger(Events.PLAYBACK_LEVELS_AVAILABLE, this._levels)
   }


### PR DESCRIPTION
A recent commit https://github.com/clappr/clappr/commit/aa4effd3b524475d2a161ceca682ca9b105c68dc changed the label of the levels from the height (e.g. 720p) to the bitrate in kbps.  This affects level selector plugins.  We should allow the plugins to decide how to format their own labels by sending everything (including height and bitrate) to the PLAYBACK_LEVELS_AVAILABLE event.