### PR TITLE
Avoid triggering extraneous MediaControl events which can cause playbar to show unexpectedly

### DIFF
--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -363,14 +363,14 @@ export default class Container extends UIObject {
   }
 
   disableMediaControl() {
-    if (this.mediaControlDisabled !== true) {
+    if (!this.mediaControlDisabled) {
       this.mediaControlDisabled = true
       this.trigger(Events.CONTAINER_MEDIACONTROL_DISABLE)
     }
   }
 
   enableMediaControl() {
-    if (this.mediaControlDisabled !== false) {
+    if (this.mediaControlDisabled) {
       this.mediaControlDisabled = false
       this.trigger(Events.CONTAINER_MEDIACONTROL_ENABLE)
     }

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -363,13 +363,17 @@ export default class Container extends UIObject {
   }
 
   disableMediaControl() {
-    this.mediaControlDisabled = true
-    this.trigger(Events.CONTAINER_MEDIACONTROL_DISABLE)
+    if (this.mediaControlDisabled !== true) {
+      this.mediaControlDisabled = true
+      this.trigger(Events.CONTAINER_MEDIACONTROL_DISABLE)
+    }
   }
 
   enableMediaControl() {
-    this.mediaControlDisabled = false
-    this.trigger(Events.CONTAINER_MEDIACONTROL_ENABLE)
+    if (this.mediaControlDisabled !== false) {
+      this.mediaControlDisabled = false
+      this.trigger(Events.CONTAINER_MEDIACONTROL_ENABLE)
+    }
   }
 
   /**


### PR DESCRIPTION
The Poster Plugin was enabling/disabling the media control bar on every buffer, bufferfull, and play events.  This caused the media control bar to show up unexpectedly (for example during hls.js's instantaneous jumps over holes in a segment).  The container now only triggers the CONTAINER_MEDIACONTROL_ENABLE and CONTAINER_MEDIACONTROL_DISABLE events when they change.