### PR TITLE
core: fix mimetype when setting it using configure()

### DIFF
--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -301,7 +301,7 @@ export default class Core extends UIObject {
     var sources = options.source || options.sources
 
     if (sources) {
-      this.load(sources)
+      this.load(sources, options.mimeType || this.options.mimeType)
     } else {
       this.trigger(Events.CORE_OPTIONS_CHANGE)
 


### PR DESCRIPTION
When setting source using configure(), mimetype was null. If source had not appropriate file extension, source could not be played.