### PR TITLE
Fix option event listeners

### DIFF
--- a/src/components/player.js
+++ b/src/components/player.js
@@ -73,6 +73,21 @@ export default class Player extends BaseObject {
     return !!this.ready
   }
 
+  get eventsMapping() {
+    return {
+      "onReady": Events.PLAYER_READY,
+      "onResize": Events.PLAYER_RESIZE,
+      "onPlay": Events.PLAYER_PLAY,
+      "onPause": Events.PLAYER_PAUSE,
+      "onStop": Events.PLAYER_STOP,
+      "onEnded": Events.PLAYER_ENDED,
+      "onSeek": Events.PLAYER_SEEK,
+      "onError": Events.PLAYER_ERROR,
+      "onTimeUpdate": Events.PLAYER_TIMEUPDATE,
+      "onVolumeUpdate": Events.PLAYER_VOLUMEUPDATE
+    }
+  }
+
   /**
    * ## Player's constructor
    *
@@ -223,22 +238,9 @@ export default class Player extends BaseObject {
   }
 
   registerOptionEventListeners() {
-    var eventsMapping = {
-      "onReady": Events.PLAYER_READY,
-      "onResize": Events.PLAYER_RESIZE,
-      "onPlay": Events.PLAYER_PLAY,
-      "onPause": Events.PLAYER_PAUSE,
-      "onStop": Events.PLAYER_STOP,
-      "onEnded": Events.PLAYER_ENDED,
-      "onSeek": Events.PLAYER_SEEK,
-      "onError": Events.PLAYER_ERROR,
-      "onTimeUpdate": Events.PLAYER_TIMEUPDATE,
-      "onVolumeUpdate": Events.PLAYER_VOLUMEUPDATE
-    }
     var userEvents = this.options.events || {}
-
     Object.keys(userEvents).forEach((userEvent) => {
-      var eventType = eventsMapping[userEvent]
+      var eventType = this.eventsMapping[userEvent]
       if (eventType) {
         var eventFunction = userEvents[userEvent]
         eventFunction = typeof eventFunction === "function" && eventFunction

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -73,6 +73,11 @@ export default class Player extends BaseObject {
     return !!this.ready
   }
 
+  /**
+   * An events map that allows the user to add custom callbacks in player's options.
+   * @property eventsMapping
+   * @type {Object}
+   */
   get eventsMapping() {
     return {
       "onReady": Events.PLAYER_READY,

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -242,7 +242,7 @@ export default class Player extends BaseObject {
       if (eventType) {
         var eventFunction = userEvents[userEvent]
         eventFunction = typeof eventFunction === "function" && eventFunction
-        eventFunction && this.listenTo(this, eventType, eventFunction)
+        eventFunction && this.on(eventType, eventFunction)
       }
     })
   }


### PR DESCRIPTION
After a receiving a `MEDIACONTROL_CONTAINERCHANGED` event, `stopListening()` is called and, therefore, no watch is kept on `userEvents`. To reproduce the problem:

1. Instantiate a new Player, listening to `PLAYER_PLAY` and `PLAYER_PAUSE` for example.
  ```es6
  var player = new Clappr.Player({
      source: "http://clappr.io/highline.mp4",
      events: {
          "onPlay": () => console.log("onPlay"),
          "onPause": () => console.log("onPause")
      }
  });
  ```

2. Load a new source (or the same hehe).
  ```es6
  player.load("http://clappr.io/highline.mp4")
  ```

3. That's it. We are no longer listening to `PLAYER_PLAY` and `PLAYER_PAUSE`.

Also, `eventsMapping` is now a property that can be easily extended. Any feedback is appreciated!