### PR TITLE
Ensure dvr only enables when duration has stabilized

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -43,6 +43,10 @@ export default class HLS extends HTML5VideoPlayback {
     // if content is removed from the beginning then this empty area should
     // be ignored. "playableRegionDuration" does not consider this
     this.playableRegionDuration = 0
+    // true when the actual duration is longer than hlsjs's live sync point
+    // when this is false playableRegionDuration will be the actual duration
+    // when this is true playableRegionDuration will exclude the time after the sync point
+    this.durationExcludesAfterLiveSyncPoint = false
     options.autoPlay && this.setupHls()
     this.recoverAttemptsRemaining = options.hlsRecoverAttempts || 16
   }
@@ -212,6 +216,10 @@ export default class HLS extends HTML5VideoPlayback {
       let hiddenAreaDuration = fragmentTargetDuration * liveSyncDurationCount
       if (hiddenAreaDuration <= newDuration) {
         newDuration -= hiddenAreaDuration
+        this.durationExcludesAfterLiveSyncPoint = true
+      }
+      else {
+        this.durationExcludesAfterLiveSyncPoint = false
       }
     }
     if (newDuration !== this.playableRegionDuration) {
@@ -245,7 +253,11 @@ export default class HLS extends HTML5VideoPlayback {
   }
 
   get dvrEnabled() {
-    return (this.playableRegionDuration >= this.minDvrSize && this.getPlaybackType() === Playback.LIVE)
+    // enabled when:
+    // - the duration does not include content after hlsjs's live sync point
+    // - the playable region duration is longer than the configured duration to enable dvr after
+    // - the playback type is LIVE.
+    return (this.durationExcludesAfterLiveSyncPoint && this.playableRegionDuration >= this.minDvrSize && this.getPlaybackType() === Playback.LIVE)
   }
 
   getPlaybackType() {


### PR DESCRIPTION
The duration will initially be the actual duration until the real duration is longer the hlsjs's live sync point, then it drops back down to hide the content after the sync point (to prevent someone seeking to
a point which will cause their buffer to run out before the next chunk arrives).

This ensures that the dvr can only be enabled when the duration is not including the content after the live sync point.

Feels a little bit hacky with the duration being reduced when there is enough content, so if you can think of a better way let me know. I think the nicest would be only making the playback ready when the actual duration goes past the sync point, but this means when a live stream starts the user would be shown the buffering indicator for a while, unless the live stream was only made available to the player after there was already enough chunks in the playlist to bring the duration past the live sync point already.