### PR TITLE
Report correct times in PLAYBACK_PROGRESS event when hls with dvr

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -127,6 +127,8 @@ export default class HTML5Video extends Playback {
   onDurationChange() {
     this.updateSettings()
     this.onTimeUpdate()
+    // onProgress uses the duration
+    this.onProgress()
   }
 
   updateSettings() {


### PR DESCRIPTION
Previously the times reported in the event wouldn't take into consideration the media that has slid off the start of the timeline, in the case of a hls stream with sliding window dvr.