### PR TITLE
Update compass-mixins to a fork with "compact" function fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "check-dependencies": "^0.12.0",
     "clappr-zepto": "0.0.4",
     "clean-webpack-plugin": "^0.1.3",
-    "compass-mixins": "^0.12.7",
+    "compass-mixins": "git://github.com/tjenkinson/compass-mixins.git#v0.12.8",
     "coveralls": "^2.11.4",
     "css-loader": "^0.23.1",
     "dotenv": "^2.0.0",


### PR DESCRIPTION
This [fork](https://github.com/tjenkinson/compass-mixins) of [compass-mixins](https://github.com/Igosuki/compass-mixins) includes [this fix](https://github.com/Igosuki/compass-mixins/pull/86). It looks like the official compass mixins repo might not be being maintained at the moment, but this could easily be reverted if the fix is merged into the official compass mixins repo.

With this fix clappr will build fine with the latest version of node-sass, so once this is merged https://github.com/clappr/clappr/pull/970 should be good to go as well.