### PR TITLE
Only invoke stop() and pause() on html5video from hls playback if hls is initialised

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -200,6 +200,9 @@ export default class HLS extends HTML5VideoPlayback {
   }
 
   pause() {
+    if (!this.hls) {
+      return
+    }
     super.pause()
     if (this.dvrEnabled) {
       this.updateDvr(true)
@@ -207,8 +210,8 @@ export default class HLS extends HTML5VideoPlayback {
   }
 
   stop() {
-    super.stop()
     if (this.hls) {
+      super.stop()
       this.hls.destroy()
       delete this.hls
     }


### PR DESCRIPTION
In ie11 trying to set the 'currentTime' property to a value when hlsjs hasn't initialised throws "InvalidStateError".

Fixes https://github.com/clappr/clappr/issues/954
Fixes https://github.com/clappr/clappr/issues/826