### PR TITLE
Revert "Allow source to be a an instance of a class"

### DIFF
--- a/src/components/container_factory/container_factory.js
+++ b/src/components/container_factory/container_factory.js
@@ -38,17 +38,14 @@ export default class ContainerFactory extends BaseObject {
     if (typeof source === "string" || source instanceof String) {
       resolvedSource = source.toString()
     }
-    else if (typeof source === "object" && !source.constructor) {
+    else {
       resolvedSource = source.source.toString()
       if (source.mimeType) {
         mimeType = source.mimeType
       }
     }
-    else {
-      resolvedSource = source
-    }
     
-    if (typeof resolvedSource === "string" && !!resolvedSource.match(/^\/\//)) resolvedSource = window.location.protocol + resolvedSource
+    if (!!resolvedSource.match(/^\/\//)) resolvedSource = window.location.protocol + resolvedSource
 
     var options = $.extend({}, this.options, {
       src: resolvedSource,


### PR DESCRIPTION
It thinks that {} is a class instance.

This reverts commit 3c33821c8bfffd7f2a2052ad882cc530b3c23821.

This looks like it might work but it seems like a bit of a hack.
https://github.com/jonschlinkert/is-plain-object