### PR TITLE
fix bug if calling load() with a single source

### DIFF
--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -162,7 +162,7 @@ export default class Core extends UIObject {
 
   load(sources, mimeType) {
     this.options.mimeType = mimeType
-    sources = sources && sources.constructor === Array ? sources : [sources.toString()];
+    sources = sources && sources.constructor === Array ? sources : [sources];
     this.containers.forEach((container) => container.destroy())
     this.mediaControl.container = null
     this.containerFactory.options = $.extend(this.options, {sources})


### PR DESCRIPTION
source could be `{source, mimeType}`