### PR TITLE
Fix 'sources' plugin so it still handles future sources

### DIFF
--- a/src/plugins/sources.js
+++ b/src/plugins/sources.js
@@ -7,7 +7,7 @@ export default class SourcesPlugin extends CorePlugin {
   get name() { return 'sources' }
 
   bindEvents() {
-    this.listenToOnce(this.core, Events.CORE_CONTAINERS_CREATED, this.onContainersCreated)
+    this.listenTo(this.core, Events.CORE_CONTAINERS_CREATED, this.onContainersCreated)
   }
 
   onContainersCreated() {


### PR DESCRIPTION
e.g if someone calls `load()` with an array

refs #998