### PR TITLE
Remove old baseUrl references and provide way to set baseUrl at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ The project is on npm at https://www.npmjs.com/package/clappr
 By default Clappr will assume that assets are located at the same location as the script.
 If this is not the case you need to set your base url immediately BEFORE requiring Clappr, or importing the script.
 
-```javascript
+```html
   <script type="text/javascript">
     window.CLAPPR_ASSETS_BASE_URL = "http://mycdn.example.com/assets/clappr";
   </script>

--- a/README.md
+++ b/README.md
@@ -241,15 +241,22 @@ The project is on npm at https://www.npmjs.com/package/clappr
 
 `npm install clappr --save-dev`
 
-You should specify the base url for where the assets are located using the `baseUrl` option:
+By default Clappr will assume that assets are located at the same location as the script.
+If this is not the case you need to set your base url immediately BEFORE requiring Clappr, or importing the script.
+
 ```javascript
-  var player = new Clappr.Player({
-  	source: "http://your.video/here.mp4",
-	baseUrl: "http://example.com/assets/clappr"
-  });
+  <script type="text/javascript">
+    window.CLAPPR_ASSETS_BASE_URL = "http://mycdn.example.com/assets/clappr";
+  </script>
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/clappr/latest/clappr.min.js"></script>
 ```
-In the above case clappr will expect all of the [assets (in the dist folder)](https://github.com/clappr/clappr/tree/master/dist) to be accessible at "http://example.com/assets/clappr".
-You need to arrange for the assets to be located at `baseUrl` during your build process.
+or
+```javascript
+  window.CLAPPR_ASSETS_BASE_URL = "http://mycdn.example.com/assets/clappr";
+  var Clappr = require("clappr");
+```
+In the above case clappr will expect all of the [assets (in the dist folder)](https://github.com/clappr/clappr/tree/master/dist) to be accessible at "http://mycdn.example.com/assets/clappr".
+You need to arrange for the assets to be located at this url.
 
 #### Installing for [webpack](https://webpack.github.io/)
 By default webpack will look at the `browser` field in `package.json` and use the built version of the project. If this is all you want there is nothing else for you to do.

--- a/README.md
+++ b/README.md
@@ -242,18 +242,16 @@ The project is on npm at https://www.npmjs.com/package/clappr
 `npm install clappr --save-dev`
 
 By default Clappr will assume that assets are located at the same location as the script.
-If this is not the case you need to set your base url immediately BEFORE requiring Clappr, or importing the script.
-
+If this is not the case you need to set your base url immediately BEFORE clappr is loaded.
 ```html
   <script type="text/javascript">
-    window.CLAPPR_ASSETS_BASE_URL = "http://mycdn.example.com/assets/clappr";
+    window.clapprAssetsBaseUrl = "http://mycdn.example.com/assets/clappr";
   </script>
   <script type="text/javascript" src="https://cdn.jsdelivr.net/clappr/latest/clappr.min.js"></script>
 ```
-or
+If you are using webpack you can inject `clapprAssetsBaseUrl` into the module using the [webpack imports loader](https://github.com/webpack/imports-loader), and therefore don't need to set a global.
 ```javascript
-  window.CLAPPR_ASSETS_BASE_URL = "http://mycdn.example.com/assets/clappr";
-  var Clappr = require("clappr");
+  var Clappr = require("imports?clapprAssetsBaseUrl=>'http://mycdn.example.com/assets/clappr'!clappr");
 ```
 In the above case clappr will expect all of the [assets (in the dist folder)](https://github.com/clappr/clappr/tree/master/dist) to be accessible at "http://mycdn.example.com/assets/clappr".
 You need to arrange for the assets to be located at this url.

--- a/public/index.html
+++ b/public/index.html
@@ -52,7 +52,6 @@
 
 var player = new Clappr.Player({
   source: 'http://clappr.io/highline.mp4',
-  baseUrl: '/latest',
   poster: 'http://clappr.io/poster.png',
   mute: true,
   height: 360,

--- a/src/base/styler.js
+++ b/src/base/styler.js
@@ -6,7 +6,7 @@ import $ from 'clappr-zepto'
 import template from './template'
 
 var Styler = {
-  getStyleFor: function(style, options={baseUrl: ''}) {
+  getStyleFor: function(style, options={}) {
     return $('<style class="clappr-style"></style>').html(template(style.toString())(options));
   }
 };

--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -194,11 +194,6 @@ export function isNumber(value) {
   return value - parseFloat(value) + 1 >= 0
 }
 
-export function currentScriptUrl() {
-  var scripts = document.getElementsByTagName('script')
-  return scripts[scripts.length - 1].src
-}
-
 export var requestAnimationFrame = (window.requestAnimationFrame ||
                             window.mozRequestAnimationFrame ||
                             window.webkitRequestAnimationFrame ||
@@ -224,7 +219,6 @@ export default {
   formatTime,
   seekStringToSeconds,
   uniqueId,
-  currentScriptUrl,
   isNumber,
   requestAnimationFrame,
   cancelAnimationFrame,

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,6 +1,7 @@
-// This allows the user to change the assets public path at runtime by setting
-// window.CLAPPR_ASSETS_BASE_URL to the value they want.
+// This allows the user to change the assets public path at runtime by setting clapprAssetsBaseUrl
+// to the value they want.
+// They may do this by setting window.clapprAssetsBaseUrl or they may inject it (e.g. https://github.com/webpack/imports-loader if using webpack)
 // https://webpack.github.io/docs/configuration.html#output-publicpath
-if (typeof(window) !== "undefined" && typeof(window.CLAPPR_ASSETS_BASE_URL) === "string") {
-	__webpack_public_path__ = window.CLAPPR_ASSETS_BASE_URL;
+if (typeof(clapprAssetsBaseUrl) === "string") {
+	__webpack_public_path__ = clapprAssetsBaseUrl;
 }

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,0 +1,6 @@
+// This allows the user to change the assets public path at runtime by setting
+// window.CLAPPR_ASSETS_BASE_URL to the value they want.
+// https://webpack.github.io/docs/configuration.html#output-publicpath
+if (typeof(window) !== "undefined" && typeof(window.CLAPPR_ASSETS_BASE_URL) === "string") {
+	__webpack_public_path__ = window.CLAPPR_ASSETS_BASE_URL;
+}

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -322,7 +322,7 @@ export default class Core extends UIObject {
   }
 
   render() {
-    var style = Styler.getStyleFor(coreStyle, {baseUrl: this.options.baseUrl});
+    var style = Styler.getStyleFor(coreStyle);
     this.$el.append(style)
     this.$el.append(this.mediaControl.render().el)
 

--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -66,7 +66,7 @@ export default class MediaControl extends UIObject {
 
   get template() { return template(mediaControlHTML) }
 
-  get stylesheet() { return Styler.getStyleFor(mediaControlStyle, {baseUrl: this.options.baseUrl}) }
+  get stylesheet() { return Styler.getStyleFor(mediaControlStyle) }
 
   get volume() { return (this.container && this.container.isReady) ? this.container.volume : this.intendedVolume }
   get muted() { return this.volume === 0 }

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -12,6 +12,7 @@ import Loader from 'components/loader'
 import PlayerInfo from 'components/player_info'
 import $ from 'clappr-zepto'
 import find from 'lodash.find'
+import Log from 'plugins/log'
 
 /**
  * @class Player
@@ -177,7 +178,12 @@ export default class Player extends BaseObject {
    */
   constructor(options) {
     super(options)
-    var defaultOptions = {playerId: uniqueId(""), persistConfig: true, width: 640, height: 360, allowUserInteraction: Browser.isMobile}
+    // TODO remove baseUrl in next major version
+    var defaultOptions = {playerId: uniqueId(""), persistConfig: true, width: 640, height: 360, baseUrl: '', allowUserInteraction: Browser.isMobile}
+    if (options.baseUrl) {
+      Log.warn("The 'baseUrl' option is deprecated and will be removed in the next version. Look at https://github.com/clappr/clappr#installing-for-production")
+      options.baseUrl = options.baseUrl+"/";
+    }
     this.options = $.extend(defaultOptions, options)
     this.options.sources = this._normalizeSources(options)
     if (!this.options.chromeless) {

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import {uniqueId, currentScriptUrl} from 'base/utils'
+import {uniqueId} from 'base/utils'
 
 import BaseObject from 'base/base_object'
 import Events from 'base/events'
@@ -12,8 +12,6 @@ import Loader from 'components/loader'
 import PlayerInfo from 'components/player_info'
 import $ from 'clappr-zepto'
 import find from 'lodash.find'
-
-var baseUrl = currentScriptUrl().replace(/\/[^\/]+$/, "")
 
 /**
  * @class Player
@@ -179,7 +177,7 @@ export default class Player extends BaseObject {
    */
   constructor(options) {
     super(options)
-    var defaultOptions = {playerId: uniqueId(""), persistConfig: true, width: 640, height: 360, baseUrl: baseUrl, allowUserInteraction: Browser.isMobile}
+    var defaultOptions = {playerId: uniqueId(""), persistConfig: true, width: 640, height: 360, allowUserInteraction: Browser.isMobile}
     this.options = $.extend(defaultOptions, options)
     this.options.sources = this._normalizeSources(options)
     if (!this.options.chromeless) {

--- a/src/playbacks/base_flash_playback/base_flash_playback.js
+++ b/src/playbacks/base_flash_playback/base_flash_playback.js
@@ -51,6 +51,8 @@ export default class BaseFlashPlayback extends Playback {
     this.$el.html(this.template({
       cid: this.cid,
       swfPath: this.swfPath,
+      // TODO remove in next major version
+      baseUrl: this.baseUrl,
       playbackId: this.uniqueId,
       wmode: this.wmode,
       callbackName: `window.Clappr.flashlsCallbacks.${this.cid}`})

--- a/src/playbacks/base_flash_playback/base_flash_playback.js
+++ b/src/playbacks/base_flash_playback/base_flash_playback.js
@@ -51,7 +51,6 @@ export default class BaseFlashPlayback extends Playback {
     this.$el.html(this.template({
       cid: this.cid,
       swfPath: this.swfPath,
-      baseUrl: this.baseUrl,
       playbackId: this.uniqueId,
       wmode: this.wmode,
       callbackName: `window.Clappr.flashlsCallbacks.${this.cid}`})

--- a/src/playbacks/flash/flash.js
+++ b/src/playbacks/flash/flash.js
@@ -16,7 +16,8 @@ var MAX_ATTEMPTS = 60
 
 export default class Flash extends BaseFlashPlayback {
   get name() { return 'flash' }
-  get swfPath() { return flashSwf }
+  // TODO remove this._baseUrl in next major version
+  get swfPath() { return this._baseUrl+flashSwf }
 
   /**
    * Determine if the playback has ended.

--- a/src/playbacks/flash/flash.js
+++ b/src/playbacks/flash/flash.js
@@ -7,7 +7,6 @@ import {seekStringToSeconds} from 'base/utils'
 import BaseFlashPlayback from 'playbacks/base_flash_playback'
 import Browser from 'components/browser'
 import Mediator from 'components/mediator'
-import template from 'base/template'
 import $ from 'clappr-zepto'
 import Events from 'base/events'
 import Playback from 'base/playback'
@@ -17,7 +16,7 @@ var MAX_ATTEMPTS = 60
 
 export default class Flash extends BaseFlashPlayback {
   get name() { return 'flash' }
-  get swfPath() { return template(flashSwf)({baseUrl: this._baseUrl}) }
+  get swfPath() { return flashSwf }
 
   /**
    * Determine if the playback has ended.

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -17,7 +17,8 @@ const AUTO = -1
 
 export default class FlasHLS extends BaseFlashPlayback {
   get name() { return 'flashls' }
-  get swfPath() { return hlsSwf }
+  // TODO remove this._baseUrl in next major version
+  get swfPath() { return this._baseUrl+hlsSwf }
 
   get levels() { return this._levels || [] }
   get currentLevel() {

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -4,7 +4,6 @@
 
 import BaseFlashPlayback from 'playbacks/base_flash_playback'
 import Events from 'base/events'
-import template from 'base/template'
 import Playback from 'base/playback'
 import Mediator from 'components/mediator'
 import Browser from 'components/browser'
@@ -18,7 +17,7 @@ const AUTO = -1
 
 export default class FlasHLS extends BaseFlashPlayback {
   get name() { return 'flashls' }
-  get swfPath() { return template(hlsSwf)({baseUrl: this._baseUrl}) }
+  get swfPath() { return hlsSwf }
 
   get levels() { return this._levels || [] }
   get currentLevel() {

--- a/src/plugins/dvr_controls/dvr_controls.js
+++ b/src/plugins/dvr_controls/dvr_controls.js
@@ -80,7 +80,7 @@ export default class DVRControls extends UICorePlugin {
   }
 
   render() {
-    this.style = this.style || Styler.getStyleFor(dvrStyle, { baseUrl: this.core.options.baseUrl })
+    this.style = this.style || Styler.getStyleFor(dvrStyle)
     this.$el.html(this.template())
     this.$el.append(this.style)
     if (this.shouldRender()) {

--- a/src/plugins/poster/poster.js
+++ b/src/plugins/poster/poster.js
@@ -108,7 +108,7 @@ export default class PosterPlugin extends UIContainerPlugin {
     if (!this.shouldRender) {
       return
     }
-    var style = Styler.getStyleFor(posterStyle, {baseUrl: this.options.baseUrl})
+    var style = Styler.getStyleFor(posterStyle)
     this.$el.html(this.template())
     this.$el.append(style)
     if (this.options.poster) {

--- a/test/player_spec.js
+++ b/test/player_spec.js
@@ -19,7 +19,7 @@ describe('Player', function() {
 
     it('uses the baseUrl passed from initialization', function() {
       var player = new Player({source: '/playlist.m3u8', baseUrl: 'http://cdn.clappr.io/latest'})
-      expect(player.options.baseUrl).to.be.equal('http://cdn.clappr.io/latest')
+      expect(player.options.baseUrl).to.be.equal('http://cdn.clappr.io/latest/')
     })
 
     it('persists config by default', function() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,11 @@ var webpack = require('webpack');
 var Clean = require('clean-webpack-plugin');
 
 var webpackConfig = require("./webpack-base-config");
-webpackConfig.entry = path.resolve(__dirname, 'src/main.js');
+webpackConfig.entry = [
+  path.resolve(__dirname, 'src/bootstrap.js'),
+  // This will get exported.
+  path.resolve(__dirname, 'src/main.js')
+];
 
 if (process.env.npm_lifecycle_event === 'release') {
   webpackConfig.plugins.push(new webpack.optimize.UglifyJsPlugin({
@@ -16,7 +20,11 @@ if (process.env.npm_lifecycle_event === 'release') {
 
 webpackConfig.output = {
   path: path.resolve(__dirname, 'dist'),
-  publicPath: '<%=baseUrl%>/',
+  // https://webpack.github.io/docs/configuration.html#output-publicpath
+  // assume that assets are in the same directory that the build script is loaded from
+  // i.e if "http://example.com/assets/clappr.js", then "http://example.com/assets/someicon.svg"
+  // This can be overriden at runtime. Look at src/bootstrap.js
+  publicPath: '',
   filename: 'clappr.js',
   library: 'Clappr',
   libraryTarget: 'umd',


### PR DESCRIPTION
It looked like where baseUrl was referenced before it never had any effect, as this changed when we switched to webpack.

The proper way of setting the assets base url at runtime is in the webpack documentation:
https://webpack.github.io/docs/configuration.html#output-publicpath.

I have added an extra entry point which looks to see if the user wants a custom base url, and sets it if they do before the main app loads.
This uses a global because I don't think there's another way.