### PR TITLE
Allow mocking of 'window'

### DIFF
--- a/src/base/kibo.js
+++ b/src/base/kibo.js
@@ -1,5 +1,7 @@
+import mocks from 'base/mocks'
+
 var Kibo = function(element) {
-  this.element = element || window.document;
+  this.element = element || mocks.window.document;
   this.initialize();
 };
 
@@ -27,32 +29,6 @@ Kibo.KEY_CODES_BY_NAME = {};
 })();
 
 Kibo.MODIFIERS = ['shift', 'ctrl', 'alt'];
-
-Kibo.registerEvent = (function() {
-  if(document.addEventListener) {
-    return function(element, eventName, func) {
-      element.addEventListener(eventName, func, false);
-    };
-  }
-  else if(document.attachEvent) {
-    return function(element, eventName, func) {
-      element.attachEvent('on' + eventName, func);
-    };
-  }
-})();
-
-Kibo.unregisterEvent = (function() {
-  if(document.removeEventListener) {
-    return function(element, eventName, func) {
-      element.removeEventListener(eventName, func, false);
-    };
-  }
-  else if(document.detachEvent) {
-    return function(element, eventName, func) {
-      element.detachEvent('on' + eventName, func);
-    };
-  }
-})();
 
 Kibo.stringContains = function(string, substring) {
   return string.indexOf(substring) !== -1;
@@ -137,6 +113,33 @@ Kibo.keyCode = function(keyName) {
 Kibo.prototype.initialize = function() {
   var i, that = this;
 
+  Kibo.registerEvent = (function() {
+    if(mocks.window.document.addEventListener) {
+      return function(element, eventName, func) {
+        element.addEventListener(eventName, func, false);
+      };
+    }
+    else if(mocks.window.document.attachEvent) {
+      return function(element, eventName, func) {
+        element.attachEvent('on' + eventName, func);
+      };
+    }
+  })();
+
+  Kibo.unregisterEvent = (function() {
+    if(mocks.window.document.removeEventListener) {
+      return function(element, eventName, func) {
+        element.removeEventListener(eventName, func, false);
+      };
+    }
+    else if(mocks.window.document.detachEvent) {
+      return function(element, eventName, func) {
+        element.detachEvent('on' + eventName, func);
+      };
+    }
+  })();
+
+
   this.lastKeyCode = -1;
   this.lastModifiers = {};
   for(i = 0; i < Kibo.MODIFIERS.length; i++) {
@@ -150,10 +153,10 @@ Kibo.prototype.initialize = function() {
 
   Kibo.registerEvent(this.element, 'keydown', this.downHandler);
   Kibo.registerEvent(this.element, 'keyup', this.upHandler);
-  Kibo.registerEvent(window, 'unload', function unloader() {
+  Kibo.registerEvent(mocks.window, 'unload', function unloader() {
     Kibo.unregisterEvent(that.element, 'keydown', that.downHandler);
     Kibo.unregisterEvent(that.element, 'keyup', that.upHandler);
-    Kibo.unregisterEvent(window, 'unload', unloader);
+    Kibo.unregisterEvent(mocks.window, 'unload', unloader);
   });
 };
 
@@ -162,7 +165,7 @@ Kibo.prototype.handler = function(upOrDown) {
   return function(e) {
     var i, registeredKeys, lastModifiersAndKey;
 
-    e = e || window.event;
+    e = e || mocks.window.event;
 
     that.lastKeyCode = e.keyCode;
     for(i = 0; i < Kibo.MODIFIERS.length; i++) {

--- a/src/base/mocks.js
+++ b/src/base/mocks.js
@@ -1,0 +1,23 @@
+var windowImpl = window || null
+var hasBeenAccessed = false
+
+var mocks = {};
+Object.defineProperty(mocks, 'window', {
+  get: function()  {
+    hasBeenAccessed = true
+    if (!windowImpl) {
+       throw new Error("Need an implementation of 'window' to run.")
+    }
+    return windowImpl
+  },
+  set: function(newWindowImpl) {
+    if (hasBeenAccessed) {
+       throw new Error("Cannot set window implementation after it has been accessed in the project.")
+    }
+    windowImpl = newWindowImpl
+  },
+  enumerable: true,
+  configurable: false
+})
+
+module.exports = mocks;

--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -4,6 +4,7 @@
 /*jshint -W079 */
 
 import Browser from 'components/browser'
+import mocks from 'base/mocks'
 import $ from 'clappr-zepto'
 
 function assign(obj, source) {
@@ -55,10 +56,10 @@ export function formatTime(time, paddedHours) {
 export var Fullscreen = {
   isFullscreen: function() {
     return !!(
-      document.webkitFullscreenElement ||
-      document.webkitIsFullScreen ||
-      document.mozFullScreen ||
-      document.msFullscreenElement
+      mocks.window.document.webkitFullscreenElement ||
+      mocks.window.document.webkitIsFullScreen ||
+      mocks.window.document.mozFullScreen ||
+      mocks.window.document.msFullscreenElement
     )
   },
   requestFullscreen: function(el) {
@@ -75,16 +76,16 @@ export var Fullscreen = {
     }
   },
   cancelFullscreen: function() {
-    if(document.exitFullscreen) {
-      document.exitFullscreen()
-    } else if(document.webkitCancelFullScreen) {
-      document.webkitCancelFullScreen()
-    } else if(document.webkitExitFullscreen) {
-      document.webkitExitFullscreen()
-    } else if(document.mozCancelFullScreen) {
-      document.mozCancelFullScreen()
-    } else if(document.msExitFullscreen) {
-      document.msExitFullscreen()
+    if(mocks.window.document.exitFullscreen) {
+      mocks.window.document.exitFullscreen()
+    } else if(mocks.window.document.webkitCancelFullScreen) {
+      mocks.window.document.webkitCancelFullScreen()
+    } else if(mocks.window.document.webkitExitFullscreen) {
+      mocks.window.document.webkitExitFullscreen()
+    } else if(mocks.window.document.mozCancelFullScreen) {
+      mocks.window.document.mozCancelFullScreen()
+    } else if(mocks.window.document.msExitFullscreen) {
+      mocks.window.document.msExitFullscreen()
     }
   }
 }
@@ -109,7 +110,7 @@ export class Config {
   }
 
   static _createKeyspace(key){
-    return `clappr.${document.domain}.${key}`
+    return `clappr.${mocks.window.document.domain}.${key}`
   }
 
   static restore(key) {
@@ -133,7 +134,7 @@ export class Config {
 
 export class QueryString {
   static get params() {
-    var query = window.location.search.substring(1)
+    var query = mocks.window.location.search.substring(1)
     if (query !== this.query) {
       this._urlParams = this.parse(query)
       this.query = query
@@ -142,7 +143,7 @@ export class QueryString {
   }
 
   static get hashParams() {
-    var hash = window.location.hash.substring(1)
+    var hash = mocks.window.location.hash.substring(1)
     if (hash !== this.hash) {
       this._hashParams = this.parse(hash)
       this.hash = hash
@@ -195,23 +196,31 @@ export function isNumber(value) {
 }
 
 export function currentScriptUrl() {
-  var scripts = document.getElementsByTagName('script')
+  // TODO issue here because this is called before new Clappr.player();
+  // think it's possible to remove. look at #1008
+  var scripts = window.document.getElementsByTagName('script')
   return scripts[scripts.length - 1].src
 }
 
-export var requestAnimationFrame = (window.requestAnimationFrame ||
-                            window.mozRequestAnimationFrame ||
-                            window.webkitRequestAnimationFrame ||
-                            function(fn) { window.setTimeout(fn, 1000/60) }).bind(window)
+export function requestAnimationFrame(callback) {
+  var fn = mocks.window.requestAnimationFrame ||
+            mocks.window.mozRequestAnimationFrame ||
+            mocks.window.webkitRequestAnimationFrame ||
+            function(callback) { mocks.window.setTimeout(callback, 1000/60) }
+  return fn(callback.bind(mocks.window))
+}
 
-export var cancelAnimationFrame = (window.cancelAnimationFrame ||
-                           window.mozCancelAnimationFrame ||
-                           window.webkitCancelAnimationFrame ||
-                           window.clearTimeout).bind(window)
+export function cancelAnimationFrame(callback) {
+  var fn = mocks.window.cancelAnimationFrame ||
+            mocks.window.cancelAnimationFrame ||
+            mocks.window.cancelAnimationFrame ||
+            function(callback) { mocks.window.clearTimeout(callback) }
+  return fn(callback.bind(mocks.window))
+}
 
 export function getBrowserLanguage() {
-  if (window.navigator && window.navigator.language) {
-    return window.navigator.language.toLowerCase()
+  if (mocks.window.navigator && mocks.window.navigator.language) {
+    return mocks.window.navigator.language.toLowerCase()
   }
   return null
 }

--- a/src/components/browser.js
+++ b/src/components/browser.js
@@ -1,13 +1,13 @@
 // Copyright 2014 Globo.com Player authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+import mocks from 'base/mocks'
 
-var Browser = {}
 
 var hasLocalstorage = function(){
   try {
-    localStorage.setItem('clappr', 'clappr')
-    localStorage.removeItem('clappr')
+    mocks.window.localStorage.setItem('clappr', 'clappr')
+    mocks.window.localStorage.removeItem('clappr')
     return true
   } catch(e) {
     return false
@@ -19,52 +19,61 @@ var hasFlash = function() {
     var fo = new ActiveXObject('ShockwaveFlash.ShockwaveFlash');
     return !!fo;
   } catch (e) {
-    return !!(navigator.mimeTypes && navigator.mimeTypes['application/x-shockwave-flash'] !== undefined &&
-        navigator.mimeTypes['application/x-shockwave-flash'].enabledPlugin);
+    return !!(mocks.window.navigator.mimeTypes && mocks.window.navigator.mimeTypes['application/x-shockwave-flash'] !== undefined &&
+        mocks.window.navigator.mimeTypes['application/x-shockwave-flash'].enabledPlugin);
   }
 }
+
+
+var browserInfo = null;
 
 var getBrowserInfo = function() {
-  var ua = navigator.userAgent
-  var parts = ua.match(/\b(playstation 4|nx|opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || []
-  var extra
-  if (/trident/i.test(parts[1])) {
-    extra = /\brv[ :]+(\d+)/g.exec(ua) || []
-    return { name: 'IE', version: parseInt(extra[1] || '') }
-  } else if (parts[1] === 'Chrome' ) {
-    extra = ua.match(/\bOPR\/(\d+)/)
-    if (extra != null) {
-      return { name:'Opera', version: parseInt(extra[1]) }
+  if (browserInfo) {
+    return browserInfo
+  }
+  browserInfo = (() => {
+    var ua = mocks.window.navigator.userAgent
+    var parts = ua.match(/\b(playstation 4|nx|opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || []
+    var extra
+    if (/trident/i.test(parts[1])) {
+      extra = /\brv[ :]+(\d+)/g.exec(ua) || []
+      return { name: 'IE', version: parseInt(extra[1] || '') }
+    } else if (parts[1] === 'Chrome' ) {
+      extra = ua.match(/\bOPR\/(\d+)/)
+      if (extra != null) {
+        return { name:'Opera', version: parseInt(extra[1]) }
+      }
     }
-  }
-  parts = parts[2] ? [parts[1], parts[2]] : [navigator.appName, navigator.appVersion, '-?']
+    parts = parts[2] ? [parts[1], parts[2]] : [mocks.window.navigator.appName, mocks.window.navigator.appVersion, '-?']
 
-  if ((extra = ua.match(/version\/(\d+)/i))) {
-    parts.splice(1, 1, extra[1])
-  }
-  return { name: parts[0], version: parseInt(parts[1]) }
+    if ((extra = ua.match(/version\/(\d+)/i))) {
+      parts.splice(1, 1, extra[1])
+    }
+    return { name: parts[0], version: parseInt(parts[1]) }
+  })()
+  return browserInfo
 }
 
-var browserInfo = getBrowserInfo()
 
-Browser.isSafari = /safari/i.test(navigator.userAgent) && navigator.userAgent.indexOf('Chrome') === -1
-Browser.isChrome = /chrome/i.test(navigator.userAgent)
-Browser.isFirefox = /firefox/i.test(navigator.userAgent)
-Browser.isLegacyIE = !!(window.ActiveXObject)
-Browser.isIE = Browser.isLegacyIE || /trident.*rv:1\d/i.test(navigator.userAgent)
-Browser.isIE11 = /trident.*rv:11/i.test(navigator.userAgent)
-Browser.isChromecast = Browser.isChrome && /CrKey/i.test(navigator.userAgent)
-Browser.isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone|IEMobile|Opera Mini/i.test(navigator.userAgent)
-Browser.isiOS = /iPad|iPhone|iPod/i.test(navigator.userAgent)
-Browser.isAndroid = /Android/i.test(navigator.userAgent)
-Browser.isWindowsPhone = /Windows Phone/i.test(navigator.userAgent)
-Browser.isWin8App = /MSAppHost/i.test(navigator.userAgent)
-Browser.isWiiU = /WiiU/i.test(navigator.userAgent)
-Browser.isPS4 = /PlayStation 4/i.test(navigator.userAgent)
-Browser.hasLocalstorage = hasLocalstorage()
-Browser.hasFlash = hasFlash()
-
-Browser.name = browserInfo.name
-Browser.version = browserInfo.version
+var Browser = {
+  get isSafari() {return /safari/i.test(mocks.window.navigator.userAgent) && mocks.window.navigator.userAgent.indexOf('Chrome') === -1},
+  get isChrome() {return /chrome/i.test(mocks.window.navigator.userAgent)},
+  get isFirefox() {return /firefox/i.test(mocks.window.navigator.userAgent)},
+  get isLegacyIE() {return !!(mocks.window.ActiveXObject)},
+  get isIE() {return Browser.isLegacyIE || /trident.*rv:1\d/i.test(mocks.window.navigator.userAgent)},
+  get isIE11() {return /trident.*rv:11/i.test(mocks.window.navigator.userAgent)},
+  get isChromecast() {return Browser.isChrome && /CrKey/i.test(mocks.window.navigator.userAgent)},
+  get isMobile() {return /Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone|IEMobile|Opera Mini/i.test(mocks.window.navigator.userAgent)},
+  get isiOS() {return /iPad|iPhone|iPod/i.test(mocks.window.navigator.userAgent)},
+  get isAndroid() {return /Android/i.test(mocks.window.navigator.userAgent)},
+  get isWindowsPhone() {return /Windows Phone/i.test(mocks.window.navigator.userAgent)},
+  get isWin8App() {return /MSAppHost/i.test(mocks.window.navigator.userAgent)},
+  get isWiiU() {return /WiiU/i.test(mocks.window.navigator.userAgent)},
+  get isPS4() {return /PlayStation 4/i.test(mocks.window.navigator.userAgent)},
+  get hasLocalstorage() {return hasLocalstorage()},
+  get hasFlash() {return hasFlash()},
+  get name() {return getBrowserInfo().name},
+  get version() {return getBrowserInfo().version}
+}
 
 export default Browser

--- a/src/components/container_factory/container_factory.js
+++ b/src/components/container_factory/container_factory.js
@@ -8,6 +8,7 @@
 
 import BaseObject from 'base/base_object'
 import Events from 'base/events'
+import mocks from 'base/mocks'
 import Container from 'components/container'
 import $ from 'clappr-zepto'
 
@@ -45,7 +46,7 @@ export default class ContainerFactory extends BaseObject {
       }
     }
     
-    if (!!resolvedSource.match(/^\/\//)) resolvedSource = window.location.protocol + resolvedSource
+    if (!!resolvedSource.match(/^\/\//)) resolvedSource = mocks.window.location.protocol + resolvedSource
 
     var options = $.extend({}, this.options, {
       src: resolvedSource,

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -7,6 +7,7 @@ import {isNumber,Fullscreen, requestAnimationFrame, cancelAnimationFrame} from '
 import Events from 'base/events'
 import Styler from 'base/styler'
 import UIObject from 'base/ui_object'
+import mocks from 'base/mocks'
 import Browser from 'components/browser'
 import ContainerFactory from 'components/container_factory'
 import MediaControl from 'components/media_control'
@@ -61,9 +62,9 @@ export default class Core extends UIObject {
     this.setupMediaControl(null)
     //FIXME fullscreen api sucks
     this._boundFullscreenHandler = () => this.handleFullscreenChange()
-    $(document).bind('fullscreenchange', this._boundFullscreenHandler)
-    $(document).bind('MSFullscreenChange', this._boundFullscreenHandler)
-    $(document).bind('mozfullscreenchange', this._boundFullscreenHandler)
+    $(mocks.window.document).bind('fullscreenchange', this._boundFullscreenHandler)
+    $(mocks.window.document).bind('MSFullscreenChange', this._boundFullscreenHandler)
+    $(mocks.window.document).bind('mozfullscreenchange', this._boundFullscreenHandler)
   }
 
   createContainers(options) {
@@ -89,14 +90,14 @@ export default class Core extends UIObject {
       this.$el.addClass('fullscreen')
       this.$el.removeAttr('style')
       this.playerInfo.previousSize = { width: this.options.width, height: this.options.height }
-      this.playerInfo.currentSize = { width: $(window).width(), height: $(window).height() }
+      this.playerInfo.currentSize = { width: $(mocks.window).width(), height: $(mocks.window).height() }
     }
   }
 
   setPlayerSize() {
     this.$el.removeClass('fullscreen')
     this.playerInfo.currentSize = this.playerInfo.previousSize
-    this.playerInfo.previousSize = { width: $(window).width(), height: $(window).height() }
+    this.playerInfo.previousSize = { width: $(mocks.window).width(), height: $(mocks.window).height() }
     this.resize(this.playerInfo.currentSize)
   }
 
@@ -177,9 +178,9 @@ export default class Core extends UIObject {
     this.plugins.forEach((plugin) => plugin.destroy())
     this.$el.remove()
     this.mediaControl.destroy()
-    $(document).unbind('fullscreenchange', this._boundFullscreenHandler)
-    $(document).unbind('MSFullscreenChange', this._boundFullscreenHandler)
-    $(document).unbind('mozfullscreenchange', this._boundFullscreenHandler)
+    $(mocks.window.document).unbind('fullscreenchange', this._boundFullscreenHandler)
+    $(mocks.window.document).unbind('MSFullscreenChange', this._boundFullscreenHandler)
+    $(mocks.window.document).unbind('mozfullscreenchange', this._boundFullscreenHandler)
   }
 
   handleFullscreenChange() {

--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -12,6 +12,7 @@ import Events from 'base/events'
 import Kibo from 'base/kibo'
 import Styler from 'base/styler'
 import UIObject from 'base/ui_object'
+import mocks from 'base/mocks'
 import Browser from 'components/browser'
 import Mediator from 'components/mediator'
 import template from 'base/template'
@@ -102,8 +103,8 @@ export default class MediaControl extends UIObject {
     }
     this.stopDragHandler = (event) => this.stopDrag(event)
     this.updateDragHandler = (event) => this.updateDrag(event)
-    $(document).bind('mouseup', this.stopDragHandler)
-    $(document).bind('mousemove', this.updateDragHandler)
+    $(mocks.window.document).bind('mouseup', this.stopDragHandler)
+    $(mocks.window.document).bind('mousemove', this.updateDragHandler)
   }
 
   addEventListeners() {
@@ -452,7 +453,7 @@ export default class MediaControl extends UIObject {
   show(event) {
     if (this.disabled) return
     var timeout = 2000
-    if (!event || (event.clientX !== this.lastMouseX && event.clientY !== this.lastMouseY) || navigator.userAgent.match(/firefox/i)) {
+    if (!event || (event.clientX !== this.lastMouseX && event.clientY !== this.lastMouseY) || mocks.window.navigator.userAgent.match(/firefox/i)) {
       clearTimeout(this.hideId)
       this.$el.show()
       this.trigger(Events.MEDIACONTROL_SHOW, this.name)
@@ -591,8 +592,8 @@ export default class MediaControl extends UIObject {
 
   destroy() {
     this.remove()
-    $(document).unbind('mouseup', this.stopDragHandler)
-    $(document).unbind('mousemove', this.updateDragHandler)
+    $(mocks.window.document).unbind('mouseup', this.stopDragHandler)
+    $(mocks.window.document).unbind('mousemove', this.updateDragHandler)
     this.unbindKeyEvents()
   }
 

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -6,6 +6,7 @@ import {uniqueId, currentScriptUrl} from 'base/utils'
 
 import BaseObject from 'base/base_object'
 import Events from 'base/events'
+import mocks from 'base/mocks'
 import Browser from 'components/browser'
 import CoreFactory from 'components/core_factory'
 import Loader from 'components/loader'
@@ -210,7 +211,7 @@ export default class Player extends BaseObject {
    * @return {Player} itself
    */
   setParentId(parentId) {
-    var el = document.querySelector(parentId)
+    var el = mocks.window.document.querySelector(parentId)
     if (el) {
       this.attachTo(el)
     }

--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,7 @@ import Poster from 'plugins/poster'
 import Log from 'plugins/log'
 import Styler from 'base/styler'
 import template from 'base/template'
+import mocks from 'base/mocks'
 
 import $ from 'clappr-zepto'
 
@@ -67,5 +68,6 @@ export default {
     Styler,
     version,
     template,
+    mocks,
     $
 }

--- a/src/playbacks/base_flash_playback/base_flash_playback.js
+++ b/src/playbacks/base_flash_playback/base_flash_playback.js
@@ -5,6 +5,7 @@
 import Playback from 'base/playback'
 import Styler from 'base/styler'
 import template from 'base/template'
+import mocks from 'base/mocks'
 import Browser from 'components/browser'
 
 import $ from 'clappr-zepto'
@@ -54,7 +55,7 @@ export default class BaseFlashPlayback extends Playback {
       baseUrl: this.baseUrl,
       playbackId: this.uniqueId,
       wmode: this.wmode,
-      callbackName: `window.Clappr.flashlsCallbacks.${this.cid}`})
+      callbackName: `mocks.window.Clappr.flashlsCallbacks.${this.cid}`})
     )
 
     if (Browser.isIE) {

--- a/src/playbacks/flash/flash.js
+++ b/src/playbacks/flash/flash.js
@@ -8,6 +8,7 @@ import BaseFlashPlayback from 'playbacks/base_flash_playback'
 import Browser from 'components/browser'
 import Mediator from 'components/mediator'
 import template from 'base/template'
+import mocks from 'base/mocks'
 import $ from 'clappr-zepto'
 import Events from 'base/events'
 import Playback from 'base/playback'
@@ -154,7 +155,7 @@ export default class Flash extends BaseFlashPlayback {
   }
 
   _checkInitialSeek() {
-    var seekTime = seekStringToSeconds(window.location.href)
+    var seekTime = seekStringToSeconds(mocks.window.location.href)
     if (seekTime !== 0) {
       this.seekSeconds(seekTime)
     }

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -6,6 +6,7 @@ import BaseFlashPlayback from 'playbacks/base_flash_playback'
 import Events from 'base/events'
 import template from 'base/template'
 import Playback from 'base/playback'
+import mocks from 'base/mocks'
 import Mediator from 'components/mediator'
 import Browser from 'components/browser'
 import HLSEvents from './flashls_events'
@@ -675,14 +676,14 @@ export default class FlasHLS extends BaseFlashPlayback {
   }
 
   _createCallbacks() {
-    if (!window.Clappr) {
-      window.Clappr = {}
+    if (!mocks.window.Clappr) {
+      mocks.window.Clappr = {}
     }
-    if (!window.Clappr.flashlsCallbacks) {
-      window.Clappr.flashlsCallbacks = {}
+    if (!mocks.window.Clappr.flashlsCallbacks) {
+      mocks.window.Clappr.flashlsCallbacks = {}
     }
     this.flashlsEvents = new HLSEvents(this.cid)
-    window.Clappr.flashlsCallbacks[this.cid] = (eventName, args) => {
+    mocks.window.Clappr.flashlsCallbacks[this.cid] = (eventName, args) => {
       this.flashlsEvents[eventName].apply(this.flashlsEvents, args)
     }
   }

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -9,6 +9,7 @@ import template from 'base/template'
 import Styler from 'base/styler'
 import Browser from 'components/browser'
 import Events from 'base/events'
+import mocks from 'base/mocks'
 import tagStyle from './public/style.scss'
 import sourceHTML from './public/index.html'
 import find from 'lodash.find'
@@ -311,7 +312,7 @@ export default class HTML5Video extends Playback {
   }
 
   _checkInitialSeek() {
-    var seekTime = seekStringToSeconds(window.location.href)
+    var seekTime = seekStringToSeconds(mocks.window.location.href)
     if (seekTime !== 0) {
       this.seek(seekTime)
     }
@@ -392,7 +393,7 @@ HTML5Video._canPlay = function(type, mimeTypesByExtension, resourceUrl, mimeType
   var mimeTypes = mimeType || mimeTypesByExtension[extension] || []
   mimeTypes = (mimeTypes.constructor === Array) ? mimeTypes : [mimeTypes]
 
-  var media = document.createElement(type)
+  var media = mocks.window.document.createElement(type)
   return !!find(mimeTypes, (mediaType) => !!media.canPlayType(mediaType).replace(/no/, ''))
 }
 

--- a/src/plugins/google_analytics/google_analytics.js
+++ b/src/plugins/google_analytics/google_analytics.js
@@ -4,6 +4,7 @@
 
 import ContainerPlugin from 'base/container_plugin';
 import Events from 'base/events'
+import mocks from 'base/mocks'
 
 export default class GoogleAnalytics extends ContainerPlugin {
   get name() { return 'google_analytics' }
@@ -19,13 +20,13 @@ export default class GoogleAnalytics extends ContainerPlugin {
   }
 
   embedScript() {
-    if (!window._gat) {
-      var script = document.createElement('script')
+    if (!mocks.window._gat) {
+      var script = mocks.window.document.createElement('script')
       script.setAttribute("type", "text/javascript")
       script.setAttribute("async", "async")
       script.setAttribute("src", "//www.google-analytics.com/ga.js")
       script.onload = () => this.addEventListeners()
-      document.body.appendChild(script)
+      mocks.window.document.body.appendChild(script)
     } else {
       this.addEventListeners()
     }

--- a/src/plugins/log/log.js
+++ b/src/plugins/log/log.js
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import Kibo from 'base/kibo'
+import mocks from 'base/mocks'
 
 var BOLD = 'font-weight: bold; font-size: 13px;'
 var INFO = 'color: #006600;' + BOLD
@@ -41,7 +42,7 @@ export default class Log {
       this.level = this.offLevel
     }
     // handle instances where console.log is unavailable
-    if (window.console && window.console.log) {
+    if (mocks.window.console && mocks.window.console.log) {
       console.log("%c[Clappr.Log] set log level to " + DESCRIPTIONS[this.level], WARN)
     }
   }
@@ -63,7 +64,7 @@ export default class Log {
     if (klass) {
       klassDescription = "[" + klass + "]"
     }
-    if (window.console && window.console.log) {
+    if (mocks.window.console && mocks.window.console.log) {
       console.log.apply(console, ["%c[" + DESCRIPTIONS[level] + "]" + klassDescription, color].concat(message))
     }
   }

--- a/test/base/mocks_spec.js
+++ b/test/base/mocks_spec.js
@@ -1,0 +1,12 @@
+import mocks from '../../src/base/mocks'
+import Clappr from '../../src/main'
+
+describe('Mocks', function() {
+  describe('window', function() {
+    it('should allow the user to set the new "window" object immediately after requiring Clappr', function() {
+      expect(function() {
+        mocks.window = {};
+      }).to.not.throw(Error)
+    })
+  })
+})


### PR DESCRIPTION
refs #1003 

Now that I've done this I'm wondering if it might actually make more sense not to have the "base\mocks" module and expect the developer to mock the global `window` variable when they run their tests instead?@clappr/core ?

This PR allows

```javascript
var Clappr = require("clappr");
Clappr.mocks.window = myFakeWindow;

var player = new Clappr.Player() //etc
```