### PR TITLE
adds new event play_intent

### DIFF
--- a/src/base/events.js
+++ b/src/base/events.js
@@ -430,6 +430,12 @@ Events.PLAYBACK_MEDIACONTROL_ENABLE = 'playback:mediacontrol:enable'
  */
 Events.PLAYBACK_ENDED = 'playback:ended'
 /**
+ * Fired when user requests `play()`
+ *
+ * @event PLAYBACK_PLAY_INTENT
+ */
+Events.PLAYBACK_PLAY_INTENT = 'playback:play:intent'
+/**
  * Fired when the media for a playback starts playing.
  * This is not necessarily when the user requests `play()`
  * The media may have to buffer first.

--- a/src/playbacks/flash/flash.js
+++ b/src/playbacks/flash/flash.js
@@ -161,6 +161,7 @@ export default class Flash extends BaseFlashPlayback {
   }
 
   play() {
+    this.trigger(Events.PLAYBACK_PLAY_INTENT)
     if (this._currentState === 'PAUSED' || this._currentState === 'PLAYING_BUFFERING') {
       this._currentState = "PLAYING"
       this.el.playerResume()

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -425,6 +425,7 @@ export default class FlasHLS extends BaseFlashPlayback {
   }
 
   play() {
+    this.trigger(Events.PLAYBACK_PLAY_INTENT)
     if(this._currentState === 'PAUSED') {
       this.el.playerResume()
     } else if (!this._srcLoaded && this._currentState !== "PLAYING") {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -157,6 +157,7 @@ export default class HTML5Video extends Playback {
   }
 
   play() {
+    this.trigger(Events.PLAYBACK_PLAY_INTENT)
     this._stopped = false
     this._handleBufferingEvents()
     this.el.play()

--- a/test/playbacks/flashls_spec.js
+++ b/test/playbacks/flashls_spec.js
@@ -10,6 +10,18 @@ describe('HLS playback', function() {
       this.hls.el.getType = function() { return 'live' }
     })
 
+  it('triggers PLAYBACK_PLAY_INTENT on play request', function() {
+    var thereWasPlayIntent = false
+
+    this.hls.on(Events.PLAYBACK_PLAY_INTENT, function() {
+      thereWasPlayIntent = true
+    })
+
+    this.hls.play()
+
+    expect(thereWasPlayIntent).to.be.true
+  })
+
     it('should trigger a buffering event on buffering states', function() {
       var buffering = false
       this.hls.on(Events.PLAYBACK_BUFFERING, function() { buffering = true })

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -1,4 +1,5 @@
 import HTML5Video from 'playbacks/html5_video'
+import Events from 'base/events.js'
 
 describe('HTML5Video playback', () => {
   it('checks if it can play a resource', () => {
@@ -33,6 +34,20 @@ describe('HTML5Video playback', () => {
     playback._ready()
 
     expect(playback.isReady).to.be.true
+  })
+
+  it('triggers PLAYBACK_PLAY_INTENT on play request', () => {
+    var thereWasPlayIntent = false
+    var options = {src: 'http://example.com/dash.ogg'}
+    var playback = new HTML5Video(options)
+
+    playback.on(Events.PLAYBACK_PLAY_INTENT, function() {
+      thereWasPlayIntent = true
+    })
+
+    playback.play()
+
+    expect(thereWasPlayIntent).to.be.true
   })
 
   it('setup crossorigin attribute', () => {


### PR DESCRIPTION
While working on a new [plugin](https://github.com/leandromoreira/clappr-stats) I tried to estimate the `startup` time but I couldn't, because the `PLAY` event happens after the first `BUFFERING` :P also @towerz is working in some things that will require this event.