### PR TITLE
avoids call destroy twice

### DIFF
--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -175,7 +175,6 @@ export default class Container extends UIObject {
   destroy() {
     this.trigger(Events.CONTAINER_DESTROYED, this, this.name)
     this.stopListening()
-    this.playback.destroy()
     this.plugins.forEach((plugin) => plugin.destroy())
     this.$el.remove()
   }

--- a/test/components/container_spec.js
+++ b/test/components/container_spec.js
@@ -17,6 +17,22 @@ describe('Container', function() {
     expect(this.container.getPlaybackType()).to.equal(Playback.NO_OP)
   })
 
+  it('treats the playback as a plugin', function() {
+    expect(this.container.plugins[0]).to.equal(this.playback)
+  })
+
+  it('call destroys in all the plugins once', function() {
+    var fakePlugin = {destroy: function(){}}
+    sinon.spy(this.playback, 'destroy')
+    sinon.spy(fakePlugin, 'destroy')
+
+    this.container.addPlugin(fakePlugin)
+    this.container.destroy()
+
+    assert.ok(this.playback.destroy.calledOnce)
+    assert.ok(fakePlugin.destroy.calledOnce)
+  })
+
   it('listens to playback:progress event', function() {
     sinon.spy(this.container, 'progress')
 

--- a/test/components/container_spec.js
+++ b/test/components/container_spec.js
@@ -21,16 +21,23 @@ describe('Container', function() {
     expect(this.container.plugins[0]).to.equal(this.playback)
   })
 
-  it('call destroys in all the plugins once', function() {
+  it('destroys all the plugins', function() {
     var fakePlugin = {destroy: function(){}}
+
     sinon.spy(this.playback, 'destroy')
     sinon.spy(fakePlugin, 'destroy')
-
+    sinon.spy(this.container, 'stopListening')
+    sinon.spy(this.container, 'trigger')
+    sinon.spy(this.container.$el, 'remove')
     this.container.addPlugin(fakePlugin)
+
     this.container.destroy()
 
+    assert.ok(this.container.trigger.calledWith(Events.CONTAINER_DESTROYED, this.container, this.container.name))
+    assert.ok(this.container.stopListening.calledOnce)
     assert.ok(this.playback.destroy.calledOnce)
     assert.ok(fakePlugin.destroy.calledOnce)
+    assert.ok(this.container.$el.remove.calledOnce)
   })
 
   it('listens to playback:progress event', function() {


### PR DESCRIPTION
I noticed that calling `destroy` on core calls `destroy` twice on playback.

https://github.com/clappr/dash-shaka-playback/issues/14

Do you see any problem in this fix? I mean, only if the plugins order would matter, if we destroy a X plugin before the Playback.