### PR TITLE
Add type="button" to prevent form submission from embedded player

### DIFF
--- a/src/components/media_control/public/media-control.html
+++ b/src/components/media_control/public/media-control.html
@@ -33,7 +33,7 @@
       <div class="media-control-indicator" data-<%= name %>></div>
   <% }; %>
   <% var renderButton = function(name) { %>
-      <button class="media-control-button media-control-icon" data-<%= name %>></button>
+      <button type="button" class="media-control-button media-control-icon" data-<%= name %>></button>
   <% }; %>
   <%  var templates = {
         bar: renderBar,

--- a/src/plugins/dvr_controls/public/index.html
+++ b/src/plugins/dvr_controls/public/index.html
@@ -1,2 +1,2 @@
 <div class="live-info"><%= live %></div>
-<button class="live-button"><%= backToLive %></button>
+<button type="button" class="live-button"><%= backToLive %></button>


### PR DESCRIPTION
***2 Upvotes*** If the player is embedded inside a `<form>` element (e.g. on an ASP.NET site where the whole page is a giant form), trying to press one of the media control buttons could fire the form submission unexpectedly, which results in strange behavior on full-screen, back to live, etc.

By changing the button type to "button" (instead of default of "submit"), tapping the button does not submit the form any more.