### PR TITLE
Html5Video: explicit call play() when autoPlay option

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -49,7 +49,6 @@ export default class HLS extends HTML5VideoPlayback {
     // when this is false playableRegionDuration will be the actual duration
     // when this is true playableRegionDuration will exclude the time after the sync point
     this._durationExcludesAfterLiveSyncPoint = false
-    this.options.autoPlay && this._setupHls()
     this._recoverAttemptsRemaining = this.options.hlsRecoverAttempts || 16
   }
 

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -107,7 +107,6 @@ export default class HTML5Video extends Playback {
 
     $.extend(this.el, {
       loop: this.options.loop,
-      autoplay: this.options.autoPlay,
       poster: this.options.poster,
       preload: preload || 'metadata',
       controls: (playbackConfig.controls || this.options.useVideoTagDefaultControls) && 'controls',
@@ -119,6 +118,9 @@ export default class HTML5Video extends Playback {
     this.settings = {default: ['seekbar']}
     this.settings.left = ['playpause', 'position', 'duration']
     this.settings.right = ['fullscreen', 'volume', 'hd-indicator']
+
+    // https://github.com/clappr/clappr/issues/1076
+    this.options.autoPlay && this.play()
   }
 
   /**

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -51,6 +51,11 @@ describe('HTML5Video playback', function() {
     expect(thereWasPlayIntent).to.be.true
   })
 
+  it('isPlaying() is true immediately when autoPlay is true', function() {
+    const playback = new HTML5Video({src: 'http://example.com/dash.ogg', autoPlay: true})
+    expect(playback.isPlaying()).to.be.true
+  })
+
   it('setup crossorigin attribute', function() {
     const options = $.extend({playback: {crossOrigin: 'use-credentials'}}, this.options)
     const playback = new HTML5Video(options)


### PR DESCRIPTION
video.paused remains true initially even if autoplay attribute set, but flips to false immediately after a play() call.
Refs #1076