### PR TITLE
Match by lowercase extensions in "_canPlay"

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -408,7 +408,7 @@ export default class HTML5Video extends Playback {
 
 HTML5Video._canPlay = function(type, mimeTypesByExtension, resourceUrl, mimeType) {
   var extension = (resourceUrl.split('?')[0].match(/.*\.(.*)$/) || [])[1]
-  var mimeTypes = mimeType || mimeTypesByExtension[extension] || []
+  var mimeTypes = mimeType || (extension && mimeTypesByExtension[extension.toLowerCase()]) || []
   mimeTypes = (mimeTypes.constructor === Array) ? mimeTypes : [mimeTypes]
 
   var media = document.createElement(type)


### PR DESCRIPTION
In case the URL contains a uppercase character, it'll help match the mediaType list (e.g. "MP4" vs "mp4)