### PR TITLE
ensuring that isAudioOnly does not pass true for video types

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -42,7 +42,7 @@ export default class HTML5Video extends Playback {
   get isAudioOnly() {
     let resourceUrl = this.options.src
     let mimeType = this.options.mimeType
-    return this.options.playback && this.options.playback.audioOnly || HTML5Video._canPlay('audio', AUDIO_MIMETYPES, resourceUrl, mimeType)
+    return this.options.playback && this.options.playback.audioOnly || (HTML5Video._canPlay('audio', AUDIO_MIMETYPES, resourceUrl, mimeType) && !HTML5Video._canPlay('video', MIMETYPES, resourceUrl, mimeType))
   }
 
   get attributes() {


### PR DESCRIPTION
Making sure that 'video' mimetype does not pass validation in `isAudioOnly()` function.