### PR TITLE
Fix for flexbox container layout issues on older browsers

### DIFF
--- a/src/plugins/poster/public/poster.scss
+++ b/src/plugins/poster/public/poster.scss
@@ -1,21 +1,15 @@
 @import "bourbon";
 
 .player-poster[data-poster] {
+  @include display(flex);
+  @include justify-content(center);
+  @include align-items(center);
   position: absolute;
   height: 100%;
   width: 100%;
   z-index: 998;
   top: 0;
   left: 0;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   background-color: #000;
   background-size: cover;
   background-repeat: no-repeat;

--- a/src/plugins/poster/public/poster.scss
+++ b/src/plugins/poster/public/poster.scss
@@ -7,8 +7,14 @@
   z-index: 998;
   top: 0;
   left: 0;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
   justify-content: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
   align-items: center;
   background-color: #000;
   background-size: cover;


### PR DESCRIPTION
Confirmed affected browsers:
Internet Explorer 10
Safari on iOS 8.4 (iPad Air 2)

The container for the player poster did not have the Play button vertically aligned in the center.

Before:
https://www.dropbox.com/s/2hoae0yssccroc5/Screenshot%202016-08-08%2014.14.27.png?dl=0

After:
https://www.dropbox.com/s/ujv85f01xi75hzt/Screenshot%202016-08-08%2014.14.01.png?dl=0

When using flexbox with an older browser that implements an older version of the flexbox specification, prefixes must be added, in some cases, default values are different as well. See link:
https://msdn.microsoft.com/en-us/library/hh673531(v=vs.85).aspx

Prefixed values were generated with Autoprefixer: https://autoprefixer.github.io/