### PR TITLE
Improve no-op playback styling

### DIFF
--- a/src/playbacks/no_op/public/style.scss
+++ b/src/playbacks/no_op/public/style.scss
@@ -15,10 +15,12 @@
   left: 0;
   right: 0;
   color: white;
-  margin: 10px;
+  padding: 10px;
   /* center vertically */
   top: 50%;
   @include transform(translateY(-50%));
+  max-height: 100%;
+  overflow: auto;
 }
 
 [data-no-op] canvas[data-no-op-canvas] {


### PR DESCRIPTION
Wasn't perfectly centred when using margin. Works when using padding.

Overflow and max-height setting means if the message is longer than the player the user will be able to scroll to see the entire message.