### PR TITLE
Export with UMD as 'clappr' and 'Clappr'

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ webpackConfig.output = {
   path: path.resolve(__dirname, 'dist'),
   publicPath: '<%=baseUrl%>/',
   filename: 'clappr.js',
-  library: 'Clappr',
+  library: ['clappr', 'Clappr'],
   libraryTarget: 'umd'
 }
 


### PR DESCRIPTION
If it doesn't export as the same value in package.json `main` it gets complicated when using the library in another project.

E.g. In an external library webpack can set Clappr as `externals: {clappr: 'Clappr'}`. When the built dist is then loaded in a browser it ends up using `window["Clappr"]`. However, if built with another module builder and `define` or `exports` exists, then webpack inserts `require('Clappr')` instead which is wrong.

If in the external library it could be set to `externals: {clappr: 'clappr'}`, this issue wouldn't exist.

Here's an example of the top of a build which is broken (if it is included inside another module builder):

```javascript
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory(require("Clappr"));
	else if(typeof define === 'function' && define.amd)
		define(["Clappr"], factory);
	else if(typeof exports === 'object')
		exports["ClapprMarkersPlugin"] = factory(require("Clappr"));
	else
		root["ClapprMarkersPlugin"] = factory(root["Clappr"]);
})(this, function(__WEBPACK_EXTERNAL_MODULE_1__) {
return /******/ (function(modules) { // webpackBootstrap
/******/ 	// The module cache
/******/ 	var installedModules = {};

/******/ 	// The require function
/******/ 	function __webpack_require__(moduleId) {
```

if `Clappr` was `clappr` here I think it would be fine.