### PR TITLE
favicon: Remove event listeners from old container on change

### DIFF
--- a/src/plugins/favicon/favicon.js
+++ b/src/plugins/favicon/favicon.js
@@ -13,6 +13,7 @@ export default class Favicon extends CorePlugin {
 
   constructor(core) {
     super(core)
+    this._container = null
     this.configure()
   }
 
@@ -37,12 +38,13 @@ export default class Favicon extends CorePlugin {
   }
 
   containerChanged() {
-    this.stopListening(this.core.mediaControl.container)
-    this.listenTo(this.core.mediaControl.container, Events.CONTAINER_PLAY, this.setPlayIcon)
-    this.listenTo(this.core.mediaControl.container, Events.CONTAINER_PAUSE, this.setPauseIcon)
-    this.listenTo(this.core.mediaControl.container, Events.CONTAINER_STOP, this.resetIcon)
-    this.listenTo(this.core.mediaControl.container, Events.CONTAINER_ENDED, this.resetIcon)
-    this.listenTo(this.core.mediaControl.container, Events.CONTAINER_ERROR, this.resetIcon)
+    this._container && this.stopListening(this._container)
+    this._container = this.core.mediaControl.container
+    this.listenTo(this._container, Events.CONTAINER_PLAY, this.setPlayIcon)
+    this.listenTo(this._container, Events.CONTAINER_PAUSE, this.setPauseIcon)
+    this.listenTo(this._container, Events.CONTAINER_STOP, this.resetIcon)
+    this.listenTo(this._container, Events.CONTAINER_ENDED, this.resetIcon)
+    this.listenTo(this._container, Events.CONTAINER_ERROR, this.resetIcon)
     this.resetIcon()
   }
 


### PR DESCRIPTION
previously the event listeners were removed off the new container which has no effect