### PR TITLE
Add missing dvrEnabled getter in flashls playback.

### DIFF
--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -675,6 +675,10 @@ export default class FlasHLS extends BaseFlashPlayback {
     }
   }
 
+  get dvrEnabled() {
+    return this._dvrEnabled
+  }
+
   _createCallbacks() {
     if (!window.Clappr) {
       window.Clappr = {}


### PR DESCRIPTION
Without this getter, it always return false because of `!!` operator in [isDvrEnabled()](https://github.com/clappr/clappr/blob/master/src/components/container/container.js#L168) container method.

Tested on Internet Explorer 11 with Windows 7. _(which use flash hls instead of hls.js)_