### PR TITLE
Html5Video: remove src on stop() and re-add on play()

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -5,12 +5,10 @@
 import {seekStringToSeconds} from 'base/utils'
 
 import Playback from 'base/playback'
-import template from 'base/template'
 import Styler from 'base/styler'
 import Browser from 'components/browser'
 import Events from 'base/events'
 import tagStyle from './public/style.scss'
-import sourceHTML from './public/index.html'
 import find from 'lodash.find'
 import $ from 'clappr-zepto'
 
@@ -39,7 +37,6 @@ const KNOWN_AUDIO_MIMETYPES = Object.keys(AUDIO_MIMETYPES).reduce((acc, k) => [.
 export default class HTML5Video extends Playback {
   get name() { return 'html5_video' }
   get tagName() { return this.isAudioOnly ? 'audio' : 'video' }
-  get template() { return template(sourceHTML) }
 
   get isAudioOnly() {
     const resourceUrl = this.options.src
@@ -132,6 +129,9 @@ export default class HTML5Video extends Playback {
    * @param {String} srcUrl The source URL.
    */
   _setupSrc(srcUrl) {
+    if (this.el.src === srcUrl) {
+      return
+    }
     this._src = srcUrl
     this.el.src = srcUrl
   }
@@ -181,6 +181,7 @@ export default class HTML5Video extends Playback {
   play() {
     this.trigger(Events.PLAYBACK_PLAY_INTENT)
     this._stopped = false
+    this._setupSrc(this._src)
     this._handleBufferingEvents()
     this.el.play()
   }
@@ -192,7 +193,8 @@ export default class HTML5Video extends Playback {
   stop() {
     this.pause()
     this._stopped = true
-    this.el.currentTime = 0
+    // src will be added again in play()
+    this.el.removeAttribute('src')
     this._stopPlayheadMovingChecks()
     this._handleBufferingEvents()
     this.trigger(Events.PLAYBACK_STOP)
@@ -396,8 +398,6 @@ export default class HTML5Video extends Playback {
 
   render() {
     const style = Styler.getStyleFor(tagStyle)
-
-    this._src && this.$el.html(this.template({ src: this._src, type: this.options.mimeType || this._typeFor(this._src) }))
 
     if (this.options.playback.disableContextMenu) {
       this.$el.on('contextmenu', () => {

--- a/src/playbacks/html5_video/public/index.html
+++ b/src/playbacks/html5_video/public/index.html
@@ -1,1 +1,0 @@
-<source src="<%=src%>" type="<%=type%>">

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -164,37 +164,28 @@ describe('HTML5Video playback', function() {
     })
   })
 
-  describe('sources', function() {
-    it('should set up source tag with values from options', function() {
+  describe('video element', function() {
+    it('should set src url from options', function() {
       const options = {
         src: 'http://example.com/some_source?query_string=here',
         mimeType: 'application/x-mpegURL'
       }
       const html5Video = new HTML5Video(options)
       html5Video.render()
-      const sourceEl = html5Video.$el.find('source')[0]
-      expect(sourceEl.src).to.be.equal(options.src)
-      expect(sourceEl.type).to.be.equal(options.mimeType)
+      expect(html5Video.el.getAttribute('src')).to.be.equal(options.src)
     })
 
-    it('should set up source tag with inferred values when not set by options', function() {
+    it('should have src attribute removed after stop, and then added after play', function() {
       const options = {
         src: 'http://example.com/video.mp4'
       }
       const html5Video = new HTML5Video(options)
       html5Video.render()
-      const sourceEl = html5Video.$el.find('source')[0]
-      expect(sourceEl.src).to.be.equal(options.src)
-      expect(sourceEl.type).to.be.equal('video/mp4')
-    })
-
-    it('should set up source tag with value extracted from url when mimeType parameter is not set', function() {
-      const options = {src: 'http://example.com/video.m3u8'}
-      const html5Video = new HTML5Video(options)
-      html5Video.render()
-      const sourceEl = html5Video.$el.find('source')[0]
-      expect(sourceEl.src).to.be.equal(options.src)
-      expect(sourceEl.type).to.be.equal('application/x-mpegurl')
+      html5Video.play()
+      html5Video.stop()
+      expect(html5Video.el.hasAttribute('src')).to.be.false
+      html5Video.play()
+      expect(html5Video.el.getAttribute('src')).to.be.equal(options.src)
     })
   })
 


### PR DESCRIPTION
Removed adding `<source>` as I don't think this was necessary. I think the browser would look at the source list to determine what url to assign to the video tag itself, which we are always doing in `setupUrl()`. The video tag itself doesn't have a 'type' attribute which is why I think this.

This might be a solution to #1158 

**Edit:** After reading around a bit more it appears browsers get the type from the `content-type` header returned with the file. `type` exists on the `<source>`'s list so that the browser doesn't have to request each file to get the mime type header (which it would do if the `<source>`'s had the `type` missing).