### PR TITLE
Fix hls.js playback destroy.

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -339,6 +339,10 @@ export default class HLS extends HTML5VideoPlayback {
 
   destroy() {
     this._stopTimeUpdateTimer()
+    if (this._hls) {
+      this._hls.destroy()
+      delete this._hls
+    }
     super.destroy()
   }
 


### PR DESCRIPTION
Hi,

this fix an issue where hls.js instance is not properly destroyed if you destroy Clappr player while still playing video.

Currently, if you destroy Clappr player while playing, the hls.js still work and download http chunks (until the JS engine eventually garbage it).

Also i am ensure about using "delete" to nullify the instance (see [here](https://github.com/clappr/clappr/blob/master/src/playbacks/hls/hls.js#L336)).
