### PR TITLE
Fix currentScriptUrl when scripts list is empty

### DIFF
--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -203,7 +203,7 @@ export function isNumber(value) {
 
 export function currentScriptUrl() {
   const scripts = document.getElementsByTagName('script')
-  return scripts[scripts.length - 1].src
+  return scripts.length ? scripts[scripts.length - 1].src : ''
 }
 
 export const requestAnimationFrame = (window.requestAnimationFrame ||


### PR DESCRIPTION
There are cases when clappr is loaded via XHR (with subsequent eval) and no script tag is present in DOM. In such situation `currentScriptUrl` from `base\utils.js` will fail. I encountered this case when I run a project based on [Aurelia skeleton](https://github.com/aurelia/skeleton-navigation) `skeleton-typescript` (I suppose the problem is related to SystemJS loader but I'm not sure).
The proposed change fixes the problem.
