### PR TITLE
Allow to pass a custom background to poster plugin

### DIFF
--- a/src/plugins/poster/poster.js
+++ b/src/plugins/poster/poster.js
@@ -116,13 +116,14 @@ export default class PosterPlugin extends UIContainerPlugin {
     let style = Styler.getStyleFor(posterStyle, {baseUrl: this.options.baseUrl})
     this.$el.html(this.template())
     this.$el.append(style)
-    if (this.options.poster) {
-      if (this.options.poster.custom) {
-        this.$el.css({'background': this.options.poster.custom})
-      } else {
-        const posterUrl = this.options.poster.url || this.options.poster
-        this.$el.css({'background-image': 'url(' + posterUrl + ')'})
-      }
+
+    const isRegularPoster = this.options.poster && this.options.poster.custom == undefined
+
+    if (isRegularPoster) {
+      const posterUrl = this.options.poster.url || this.options.poster
+      this.$el.css({'background-image': 'url(' + posterUrl + ')'})
+    } else if (this.options.poster) {
+      this.$el.css({'background': this.options.poster.custom})
     }
     this.container.$el.append(this.el)
     this.$playWrapper = this.$el.find('.play-wrapper')

--- a/src/plugins/poster/poster.js
+++ b/src/plugins/poster/poster.js
@@ -117,8 +117,12 @@ export default class PosterPlugin extends UIContainerPlugin {
     this.$el.html(this.template())
     this.$el.append(style)
     if (this.options.poster) {
-      const posterUrl = this.options.poster.url || this.options.poster
-      this.$el.css({'background-image': 'url(' + posterUrl + ')'})
+      if (this.options.poster.custom) {
+        this.$el.css({'background': this.options.poster.custom})
+      } else {
+        const posterUrl = this.options.poster.url || this.options.poster
+        this.$el.css({'background-image': 'url(' + posterUrl + ')'})
+      }
     }
     this.container.$el.append(this.el)
     this.$playWrapper = this.$el.find('.play-wrapper')

--- a/test/plugins/poster_spec.js
+++ b/test/plugins/poster_spec.js
@@ -95,4 +95,14 @@ describe('Poster', function() {
     expect(this.poster.shouldHideOnPlay()).to.equal(false)
   })
 
+  it('renders custom background', function() {
+    this.container = new Container({
+      playback: this.playback,
+      poster: {custom: 'linear-gradient(rgb(238, 238, 238), rgb(153, 153, 153))'}
+    })
+    this.poster = new Poster(this.container)
+    this.container.addPlugin(this.poster)
+    this.poster.render()
+    expect($(this.poster.$el).css('background')).include('linear-gradient(rgb(238, 238, 238), rgb(153, 153, 153))')
+  })
 })

--- a/test/plugins/poster_spec.js
+++ b/test/plugins/poster_spec.js
@@ -102,7 +102,6 @@ describe('Poster', function() {
     })
     this.poster = new Poster(this.container)
     this.container.addPlugin(this.poster)
-    this.poster.render()
     expect($(this.poster.$el).css('background')).include('linear-gradient(rgb(238, 238, 238), rgb(153, 153, 153))')
   })
 })


### PR DESCRIPTION
Adds an ability to specify a custom background for the poster plugin so people can not only specify an image, but do all kind of stuff like patterns, gradients or plain colors. I think it would be a good addition.

I guessed that I don't need to check if `poster.custom` is a string (it's implied) because there's no such checks for `poster` or `poster.url`.

Closes #1231