### PR TITLE
media_control: listens to stop container to toggle play

### DIFF
--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -113,6 +113,7 @@ export default class MediaControl extends UIObject {
       Mediator.on(`${this.options.playerId}:${Events.PLAYER_RESIZE}`, this.playerResize, this)
       this.listenTo(this.container, Events.CONTAINER_PLAY, this.changeTogglePlay)
       this.listenTo(this.container, Events.CONTAINER_PAUSE, this.changeTogglePlay)
+      this.listenTo(this.container, Events.CONTAINER_STOP, this.changeTogglePlay)
       this.listenTo(this.container, Events.CONTAINER_DBLCLICK, this.toggleFullscreen)
       this.listenTo(this.container, Events.CONTAINER_TIMEUPDATE, this.onTimeUpdate)
       this.listenTo(this.container, Events.CONTAINER_PROGRESS, this.updateProgressBar)


### PR DESCRIPTION
Steps:

* disable the poster plugin
* play an HLS with no DVR (with stop button)
* stop the streaming
* expects media control to be hidden current behavior media control is shown

Thank @jkarder for this PR