### PR TITLE
Allows to automatically seek hls.js playback using 't' query parameter

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -8,7 +8,7 @@ import isEqual from 'lodash.isequal'
 import Events from 'base/events'
 import Playback from 'base/playback'
 import Browser from 'components/browser'
-import {now} from 'base/utils'
+import {now, seekStringToSeconds} from 'base/utils'
 import Log from 'plugins/log'
 
 const AUTO = -1
@@ -139,7 +139,11 @@ export default class HLS extends HTML5VideoPlayback {
   }
 
   _setupHls() {
-    this._hls = new HLSJS(this.options.playback.hlsjsConfig || {})
+    const autoSeekFromUrl = typeof(this.options.autoSeekFromUrl) === 'undefined' || this.options.autoSeekFromUrl
+    const startPosition = this.getPlaybackType() !== Playback.LIVE && autoSeekFromUrl && seekStringToSeconds();
+    const hlsjsConfig = Object.assign({}, this.options.playback.hlsjsConfig, {startPosition})
+
+    this._hls = new HLSJS(hlsjsConfig)
     this._hls.on(HLSJS.Events.MEDIA_ATTACHED, () => this._hls.loadSource(this.options.src))
     this._hls.on(HLSJS.Events.LEVEL_LOADED, (evt, data) => this._updatePlaybackType(evt, data))
     this._hls.on(HLSJS.Events.LEVEL_UPDATED, (evt, data) => this._onLevelUpdated(evt, data))

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -10,7 +10,7 @@ import Playback from 'base/playback'
 import Browser from 'components/browser'
 import {now, seekStringToSeconds} from 'base/utils'
 import Log from 'plugins/log'
-import $ from 'clappr-zepto';
+import $ from 'clappr-zepto'
 
 const AUTO = -1
 

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -135,15 +135,16 @@ export default class HLS extends HTML5VideoPlayback {
     // #EXT-X-PLAYLIST-TYPE
     this._playlistType = null
     this._recoverAttemptsRemaining = this.options.hlsRecoverAttempts || 16
+
+    const autoSeekFromUrl = typeof(this.options.autoSeekFromUrl) === 'undefined' || this.options.autoSeekFromUrl
+    const startPosition = this.getPlaybackType() !== Playback.LIVE && autoSeekFromUrl && seekStringToSeconds()
+    this._hlsjsConfig = Object.assign({}, this.options.playback.hlsjsConfig, {startPosition})
+
     this._startTimeUpdateTimer()
   }
 
   _setupHls() {
-    const autoSeekFromUrl = typeof(this.options.autoSeekFromUrl) === 'undefined' || this.options.autoSeekFromUrl
-    const startPosition = this.getPlaybackType() !== Playback.LIVE && autoSeekFromUrl && seekStringToSeconds()
-    const hlsjsConfig = Object.assign({}, this.options.playback.hlsjsConfig, {startPosition})
-
-    this._hls = new HLSJS(hlsjsConfig)
+    this._hls = new HLSJS(this._hlsjsConfig)
     this._hls.on(HLSJS.Events.MEDIA_ATTACHED, () => this._hls.loadSource(this.options.src))
     this._hls.on(HLSJS.Events.LEVEL_LOADED, (evt, data) => this._updatePlaybackType(evt, data))
     this._hls.on(HLSJS.Events.LEVEL_UPDATED, (evt, data) => this._onLevelUpdated(evt, data))

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -10,7 +10,6 @@ import Playback from 'base/playback'
 import Browser from 'components/browser'
 import {now, seekStringToSeconds} from 'base/utils'
 import Log from 'plugins/log'
-import $ from 'clappr-zepto'
 
 const AUTO = -1
 

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -10,6 +10,7 @@ import Playback from 'base/playback'
 import Browser from 'components/browser'
 import {now, seekStringToSeconds} from 'base/utils'
 import Log from 'plugins/log'
+import $ from 'clappr-zepto';
 
 const AUTO = -1
 
@@ -138,7 +139,7 @@ export default class HLS extends HTML5VideoPlayback {
 
     const autoSeekFromUrl = typeof(this.options.autoSeekFromUrl) === 'undefined' || this.options.autoSeekFromUrl
     const startPosition = this.getPlaybackType() !== Playback.LIVE && autoSeekFromUrl && seekStringToSeconds()
-    this._hlsjsConfig = Object.assign({}, this.options.playback.hlsjsConfig, {startPosition})
+    this._hlsjsConfig = $.extend({}, this.options.playback.hlsjsConfig, {startPosition})
 
     this._startTimeUpdateTimer()
   }

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -140,7 +140,7 @@ export default class HLS extends HTML5VideoPlayback {
 
   _setupHls() {
     const autoSeekFromUrl = typeof(this.options.autoSeekFromUrl) === 'undefined' || this.options.autoSeekFromUrl
-    const startPosition = this.getPlaybackType() !== Playback.LIVE && autoSeekFromUrl && seekStringToSeconds();
+    const startPosition = this.getPlaybackType() !== Playback.LIVE && autoSeekFromUrl && seekStringToSeconds()
     const hlsjsConfig = Object.assign({}, this.options.playback.hlsjsConfig, {startPosition})
 
     this._hls = new HLSJS(hlsjsConfig)


### PR DESCRIPTION
This PR makes hls.js playback behave like html5_video and flashls playbacks.

It's a bit out of place I think, where would be more suitable to put this code?

Closes #1246