### PR TITLE
Do not call _fillLevels when receive a playlist (_updatePlaybackType)

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -348,7 +348,6 @@ export default class HLS extends HTML5VideoPlayback {
 
   _updatePlaybackType(evt, data) {
     this._playbackType = data.details.live ? Playback.LIVE : Playback.VOD
-    this._fillLevels()
     this._onLevelUpdated(evt, data)
   }
 


### PR DESCRIPTION
Whenever the player receives a playlist, the fillLevels method is executed, which causes the list of levels to be closed (if open) when using the default selection plugin. The user can't change level if stream server send playlists in low interval.

The playlist does not contain information about the video (bitrate), just the next chunks, because of that I removed the execution of the fillLevels method in _updatePlaybackType called by hls.js event LEVEL_LOADED.