### PR TITLE
Build adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "description": "An extensible media player for the web",
   "main": "./dist/clappr.js",
   "scripts": {
-    "release": "node_modules/.bin/webpack --progress -d --optimize-mangle --optimize-dedupe --optimize-occurence-order --output-filename clappr.min.js",
-    "build": "node_modules/.bin/webpack --progress",
-    "watch": "node_modules/.bin/webpack --progress --watch",
-    "test": "node_modules/.bin/karma start --single-run",
-    "lint": "node_modules/.bin/eslint src/ test/",
-    "check_code_style": "node_modules/.bin/jscs src/ --esnext",
-    "fix_code_style": "node_modules/.bin/jscs src/ --esnext --fix",
-    "start": "node_modules/.bin/webpack-dev-server --host 0.0.0.0 --content-base public/ --output-public-path latest/ --hot",
+    "release": "webpack --progress -d --optimize-mangle --optimize-dedupe --optimize-occurence-order --output-filename clappr.min.js",
+    "build": "webpack --progress",
+    "watch": "webpack --progress --watch",
+    "test": "karma start --single-run",
+    "lint": "eslint src/ test/",
+    "check_code_style": "jscs src/ --esnext",
+    "fix_code_style": "jscs src/ --esnext --fix",
+    "start": "webpack-dev-server --host 0.0.0.0 --content-base public/ --output-public-path latest/ --hot",
     "lock": "rm -rf npm-shrinkwrap.json node_modules && npm install --silent && npm shrinkwrap"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,5 @@
     "webpack": "^1.12.1",
     "webpack-dev-server": "^1.14.0",
     "yargs": "^6.4.0"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
c963ca0 (able travis to cache `node_modules`)

Note: fa6371e decision is based on `travis` tests point to newest nodejs version.

We use `npm v4.1.2` on tests/CI