### PR TITLE
Allows HTML5 video to play inline on iOS

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -113,6 +113,8 @@ export default class HTML5Video extends Playback {
       'x-webkit-playsinline': playbackConfig.playInline
     })
 
+    playbackConfig.playInline && (this.$el.attr({playsinline: 'playsinline'}))
+
     // TODO should settings be private?
     this.settings = {default: ['seekbar']}
     this.settings.left = ['playpause', 'position', 'duration']

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -69,7 +69,9 @@ describe('HTML5Video playback', function() {
   it('enables inline playback for webviews when playInline flag is set', function() {
     const options = $.extend({playback: {playInline: true}}, this.options)
     const playback = new HTML5Video(options)
+
     expect(playback.el['x-webkit-playsinline']).to.be.true
+    expect(playback.el.getAttribute('playsinline')).equal('playsinline')
   })
 
   it('allows displaying default video tag controls', function() {


### PR DESCRIPTION
It adds HTML5 video element attributes to play video inline in web browsers on iOS device.
I also added a new playback option to allow Apple TV AirPlay.

@towerz i failed to find any information about `x-webkit-playsinline` parameter you added when playback `playInline` is set to true. Do you have any resource link to share please ?
