### PR TITLE
Add HTML5 video element recycle feature.

### DIFF
--- a/doc/BUILTIN_PLUGINS.md
+++ b/doc/BUILTIN_PLUGINS.md
@@ -80,7 +80,8 @@ The configuration for the playback, it's still only compatible with `html5_video
     preload: 'metadata',
     controls: true,
     playInline: true, // allows inline playback when running on iOS UIWebview
-    crossOrigin: 'use-credentials'
+    crossOrigin: 'use-credentials',
+    recycleVideo: true // Recycle <video> element for mobile device. (default is false)
   }
 }
 ```

--- a/src/base/ui_object.js
+++ b/src/base/ui_object.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import {uniqueId} from './utils'
+import {uniqueId, DomRecycler} from './utils'
 import $ from 'clappr-zepto'
 import result from 'lodash.result'
 import BaseObject from './base_object'
@@ -195,7 +195,7 @@ export default class UIObject extends BaseObject {
       const attrs = $.extend({}, result(this, 'attributes'))
       if (this.id) {attrs.id = result(this, 'id')}
       if (this.className) {attrs['class'] = result(this, 'className')}
-      const $el = $('<' + result(this, 'tagName') + '>').attr(attrs)
+      const $el = DomRecycler.create(result(this, 'tagName')).attr(attrs)
       this.setElement($el, false)
     } else {
       this.setElement(result(this, 'el'), false)

--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -4,6 +4,7 @@
 /*jshint -W079 */
 
 import Browser from 'components/browser'
+import $ from 'clappr-zepto'
 
 function assign(obj, source) {
   if (source) {
@@ -235,10 +236,36 @@ export function removeArrayItem(arr, item) {
   }
 }
 
+// Simple Zepto element factory with video recycle feature.
+const videoStack = []
+
+export class DomRecycler {
+  static configure(options) {
+    this.options = $.extend(this.options, options)
+  }
+
+  static create(name) {
+    if (this.options.recycleVideo && name === 'video' && videoStack.length > 0) {
+      return videoStack.shift()
+    }
+    return $('<' + name + '>')
+  }
+
+  static garbage($el) {
+    // Expect Zepto collection with single element (does not iterate!)
+    if (!this.options.recycleVideo || $el[0].tagName.toUpperCase() !== 'VIDEO') return
+    $el.children().remove()
+    videoStack.push($el)
+  }
+}
+
+DomRecycler.options = { recycleVideo: false }
+
 export default {
   Config,
   Fullscreen,
   QueryString,
+  DomRecycler,
   extend,
   formatTime,
   seekStringToSeconds,

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import {isNumber,Fullscreen} from 'base/utils'
+import {isNumber, Fullscreen, DomRecycler} from 'base/utils'
 
 import Events from 'base/events'
 import Styler from 'base/styler'
@@ -61,6 +61,7 @@ export default class Core extends UIObject {
 
   constructor(options) {
     super(options)
+    this.configureDomRecycler()
     this.playerInfo = PlayerInfo.getInstance(options.playerId)
     this.firstResize = true
     this.plugins = []
@@ -71,6 +72,13 @@ export default class Core extends UIObject {
     $(document).bind('fullscreenchange', this._boundFullscreenHandler)
     $(document).bind('MSFullscreenChange', this._boundFullscreenHandler)
     $(document).bind('mozfullscreenchange', this._boundFullscreenHandler)
+  }
+
+  configureDomRecycler() {
+    let recycleVideo = (this.options && this.options.playback && this.options.playback.recycleVideo) ? true : false
+    DomRecycler.configure({
+      recycleVideo: recycleVideo
+    })
   }
 
   createContainers(options) {
@@ -315,6 +323,7 @@ export default class Core extends UIObject {
    */
   configure(options) {
     this._options = $.extend(this._options, options)
+    this.configureDomRecycler()
     const sources = options.source || options.sources
 
     if (sources) {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import {seekStringToSeconds} from 'base/utils'
+import {seekStringToSeconds, DomRecycler} from 'base/utils'
 
 import Playback from 'base/playback'
 import Styler from 'base/styler'
@@ -325,6 +325,7 @@ export default class HTML5Video extends Playback {
     this.$el.remove()
     this.el.src = ''
     this._src = null
+    DomRecycler.garbage(this.$el)
   }
 
   seek(time) {

--- a/test/base/utils_spec.js
+++ b/test/base/utils_spec.js
@@ -1,4 +1,5 @@
 import * as utils from '../../src/base/utils'
+import  $ from 'clappr-zepto'
 
 const pushUrl = function(path) {
   window.history.pushState({},'', path)
@@ -178,6 +179,35 @@ describe('Utils', function() {
 
     it('returns undefined for unknown key', function() {
       expect(utils.Config.restore('unknown.key.CAFE')).to.be.equal(undefined)
+    })
+  })
+
+  describe('DomRecycler', function() {
+    it('can be configured', function() {
+      utils.DomRecycler.configure({foo: 'bar'})
+      expect(utils.DomRecycler.options.foo).to.be.equal('bar')
+      expect(utils.DomRecycler.options.recycleVideo).to.be.false
+    })
+
+    it('create a Zepto collection object', function() {
+      const $el = utils.DomRecycler.create('div')
+      // Zepto collection assertion : https://github.com/madrobby/zepto/issues/349#issuecomment-4985091
+      expect($.zepto.isZ($el)).to.be.true
+    })
+
+    it('does not recycle video tag by default', function(){
+      const video1 = utils.DomRecycler.create('video')
+      utils.DomRecycler.garbage(video1)
+      const video2 = utils.DomRecycler.create('video')
+      expect(video1[0]).to.not.be.equal(video2[0])
+    })
+
+    it('recycle video tag if recycleVideo option is set', function(){
+      utils.DomRecycler.configure({recycleVideo: true})
+      const video1 = utils.DomRecycler.create('video')
+      utils.DomRecycler.garbage(video1)
+      const video2 = utils.DomRecycler.create('video')
+      expect(video1[0]).to.be.equal(video2[0])
     })
   })
 })


### PR DESCRIPTION
See #1319 for example usage and technical explanations.

This change targets mobile devices and does not change current player behaviours.

Just set the `recycleVideo` playback option to `true` to enable this feature.

It should fixes a lot of issues on mobile and tablet devices (_single tap playback source load with autoplay, advert plugins, playlist plugins, ..._)

_EDIT: merged to single commit and updated explanations._
