### PR TITLE
[PROPOSITION] user consent playback feature for mobile devices

### DIFF
--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -59,6 +59,12 @@ export default class Playback extends UIObject {
   }
 
   /**
+   * Gives user consent to playback (mobile devices).
+   * @method consent
+   */
+  consent() {}
+
+  /**
    * plays the playback.
    * @method play
    */

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -363,6 +363,16 @@ export default class Player extends BaseObject {
   }
 
   /**
+   * Gives user consent to playback. Required by mobile device after a click event before Player.load().
+   * @method consent
+   * @return {Player} itself
+   */
+  consent() {
+    this.core.getCurrentPlayback().consent()
+    return this
+  }
+
+  /**
    * plays the current video (`source`).
    * @method play
    * @return {Player} itself

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -180,6 +180,12 @@ export default class HTML5Video extends Playback {
     return false
   }
 
+  // On mobile device, HTML5 video element "retains" user action consent if
+  // load() method is called. See Player.consent().
+  consent() {
+    !this.isPlaying() && this.el.load()
+  }
+
   play() {
     this.trigger(Events.PLAYBACK_PLAY_INTENT)
     this._stopped = false


### PR DESCRIPTION
__NOTE:__  this change is an addition to #1318 and therefore is only usefull if #1318 is merged.

This proposition targets mobile and tablet devices and does not change current player behaviours.

> On iOS and Android, playback of video must be initialized with a user action, meaning a tap or click. Once the <video> element has been activated within a user action, it will remain usable for programmatic control later.



These changes adds a `consent()` method to player which "capture" user action if called just after a tap or click event.

After method is called, you can perform any sync or async task before autoplay (even load another source and autoplay).

Initial goal of #1318 and this PR is to allow Clappr to behave like, for example, [Dailymotion](http://www.dailymotion.com/). (ie: load and autostart playback on mobile with single tap on thumbnail)

__Exemple usage :__

```javascript
let player = new Clappr.Player({
  parent: '.player',
  autoPlay: false,
  source: 'somefile.mp4',
  playback: { recycleVideo: true } // Enable recycle video feature
})

$('.change-source-button')
  .on('click', function() {
    player.consent()

    // Here you can do any sync or async task
    // ie:  perform an AJAX HTTP request to get video source

    // Load new source (with autoplay)
    player.load('another.mp4', null, true)
  })
```

EDIT: updated code example to use new playback `recycleVideo` option added in #1318 
EDIT2: updated feature explanations.