### PR TITLE
Fix url seek in HTML5 video playback.

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -337,7 +337,7 @@ export default class HTML5Video extends Playback {
   }
 
   _checkInitialSeek() {
-    const seekTime = seekStringToSeconds(window.location.href)
+    const seekTime = seekStringToSeconds()
     if (seekTime !== 0) {
       this.seek(seekTime)
     }


### PR DESCRIPTION
Should fixes #1262 and maybe also deprecates #1254 .