### PR TITLE
Improve seeking controls with keyboard

### DIFF
--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -597,10 +597,15 @@ export default class MediaControl extends UIObject {
     this.unbindKeyEvents()
     this.kibo = new Kibo(this.options.focusElement)
     this.kibo.down(['space'], () => this.togglePlayPause())
-    this.kibo.down(['left'], () => this.seekRelative(-15))
-    this.kibo.down(['right'], () => this.seekRelative(15))
+    this.kibo.down(['left'], () => this.show() || this.seekRelative(-5))
+    this.kibo.down(['right'], () => this.show() || this.seekRelative(5))
+    this.kibo.down(['ctrl left'], () => this.show() || this.seekRelative(-10))
+    this.kibo.down(['ctrl right'], () => this.show() || this.seekRelative(10))
+    this.kibo.down(['ctrl shift left'], () => this.show() || this.seekRelative(-15))
+    this.kibo.down(['ctrl shift right'], () => this.show() || this.seekRelative(15))
+    this.kibo.down([''])
     const keys = [1,2,3,4,5,6,7,8,9,0]
-    keys.forEach((i) => { this.kibo.down(i.toString(), () => this.settings.seekEnabled && this.container.seekPercentage(i * 10)) })
+    keys.forEach((i) => { this.kibo.down(i.toString(), () => this.show() || this.settings.seekEnabled && this.container.seekPercentage(i * 10)) })
   }
 
   unbindKeyEvents() {
@@ -608,6 +613,10 @@ export default class MediaControl extends UIObject {
       this.kibo.off('space')
       this.kibo.off('left')
       this.kibo.off('right')
+      this.kibo.off('ctrl left')
+      this.kibo.off('ctrl right')
+      this.kibo.off('ctrl shift left')
+      this.kibo.off('ctrl shift right')
       this.kibo.off([1,2,3,4,5,6,7,8,9,0])
     }
   }

--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -593,19 +593,27 @@ export default class MediaControl extends UIObject {
     this.container.seekPercentage(position)
   }
 
+  bindKeyAndShow(key, cb) {
+    this.kibo.down(key, () => {
+      this.show()
+      return cb()
+    })
+  }
+
   bindKeyEvents() {
     this.unbindKeyEvents()
     this.kibo = new Kibo(this.options.focusElement)
-    this.kibo.down(['space'], () => this.togglePlayPause())
-    this.kibo.down(['left'], () => this.show() || this.seekRelative(-5))
-    this.kibo.down(['right'], () => this.show() || this.seekRelative(5))
-    this.kibo.down(['ctrl left'], () => this.show() || this.seekRelative(-10))
-    this.kibo.down(['ctrl right'], () => this.show() || this.seekRelative(10))
-    this.kibo.down(['ctrl shift left'], () => this.show() || this.seekRelative(-15))
-    this.kibo.down(['ctrl shift right'], () => this.show() || this.seekRelative(15))
-    this.kibo.down([''])
-    const keys = [1,2,3,4,5,6,7,8,9,0]
-    keys.forEach((i) => { this.kibo.down(i.toString(), () => this.show() || this.settings.seekEnabled && this.container.seekPercentage(i * 10)) })
+
+    this.bindKeyAndShow('space', () => this.togglePlayPause())
+    this.bindKeyAndShow('left', () => this.seekRelative(-5))
+    this.bindKeyAndShow('right', () => this.seekRelative(5))
+    this.bindKeyAndShow('shift left', () => this.seekRelative(-10))
+    this.bindKeyAndShow('shift right', () => this.seekRelative(10))
+    this.bindKeyAndShow('shift ctrl left', () => this.seekRelative(-15))
+    this.bindKeyAndShow('shift ctrl right', () => this.seekRelative(15))
+    // this.kibo.down(['']) // should it be here?
+    const keys = ['1','2','3','4','5','6','7','8','9','0']
+    keys.forEach((i) => { this.bindKeyAndShow(i, () => this.settings.seekEnabled && this.container.seekPercentage(i * 10)) })
   }
 
   unbindKeyEvents() {
@@ -613,11 +621,11 @@ export default class MediaControl extends UIObject {
       this.kibo.off('space')
       this.kibo.off('left')
       this.kibo.off('right')
-      this.kibo.off('ctrl left')
-      this.kibo.off('ctrl right')
-      this.kibo.off('ctrl shift left')
-      this.kibo.off('ctrl shift right')
-      this.kibo.off([1,2,3,4,5,6,7,8,9,0])
+      this.kibo.off('shift left')
+      this.kibo.off('shift right')
+      this.kibo.off('shift ctrl left')
+      this.kibo.off('shift ctrl right')
+      this.kibo.off(['1','2','3','4','5','6','7','8','9','0'])
     }
   }
 


### PR DESCRIPTION
Show media control when any key that is associated with an event is pressed is a new feature and were added more options to seek with keyboard. Now left and right arrows skips -5 or 5 seconds instead of -15 or 15, shift + right or left arrow skips 10 and shift + ctrl + left or right skips 15 seconds. 