### PR TITLE
Fix core style element creation.

### DIFF
--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -338,8 +338,9 @@ export default class Core extends UIObject {
   }
 
   render() {
-    const style = Styler.getStyleFor(coreStyle, {baseUrl: this.options.baseUrl})
-    this.$el.append(style)
+    this.$style && this.$style.remove()
+    this.$style = Styler.getStyleFor(coreStyle, {baseUrl: this.options.baseUrl})
+    this.$el.append(this.$style)
     this.$el.append(this.mediaControl.render().el)
 
     this.options.width = this.options.width || this.$el.width()


### PR DESCRIPTION
A bug happen when you load another source multiple times without destroying the player : it append another style element in DOM for each loaded source.

This fix prevents it by keeping a reference and properly remove existing element each render call.
