### PR TITLE
Enhance hls.js playback fatal network error handling.

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -250,7 +250,7 @@ export default class HLS extends HTML5VideoPlayback {
           switch(data.details) {
           // The following network errors cannot be recovered with HLS.startLoad()
           // For more details, see https://github.com/video-dev/hls.js/blob/master/doc/design.md#error-detection-and-handling
-          // Note that level load error & timeout are fatal ONLY when media is not buffered and therefore unrecoverable. This happen with dynamic manifest and stream not yet available.
+          // For "level load" fatal errors, see https://github.com/video-dev/hls.js/issues/1138
           case HLSJS.ErrorDetails.MANIFEST_LOAD_ERROR:
           case HLSJS.ErrorDetails.MANIFEST_LOAD_TIMEOUT:
           case HLSJS.ErrorDetails.MANIFEST_PARSING_ERROR:

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -250,9 +250,12 @@ export default class HLS extends HTML5VideoPlayback {
           switch(data.details) {
           // The following network errors cannot be recovered with HLS.startLoad()
           // For more details, see https://github.com/video-dev/hls.js/blob/master/doc/design.md#error-detection-and-handling
+          // Note that level load error & timeout are fatal ONLY when media is not buffered and therefore unrecoverable. This happen with dynamic manifest and stream not yet available.
           case HLSJS.ErrorDetails.MANIFEST_LOAD_ERROR:
           case HLSJS.ErrorDetails.MANIFEST_LOAD_TIMEOUT:
           case HLSJS.ErrorDetails.MANIFEST_PARSING_ERROR:
+          case HLSJS.ErrorDetails.LEVEL_LOAD_ERROR:
+          case HLSJS.ErrorDetails.LEVEL_LOAD_TIMEOUT:
             Log.error(`hlsjs: unrecoverable network fatal error, evt ${evt}, data ${data} `)
             this.trigger(Events.PLAYBACK_ERROR, {evt, data}, this.name)
             break

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -248,18 +248,18 @@ export default class HLS extends HTML5VideoPlayback {
         switch (data.type) {
         case HLSJS.ErrorTypes.NETWORK_ERROR:
           switch(data.details) {
-            // The following network errors cannot be recovered with HLS.startLoad()
-            // For more details, see https://github.com/video-dev/hls.js/blob/master/doc/design.md#error-detection-and-handling
-            case HLSJS.ErrorDetails.MANIFEST_LOAD_ERROR:
-            case HLSJS.ErrorDetails.MANIFEST_LOAD_TIMEOUT:
-            case HLSJS.ErrorDetails.MANIFEST_PARSING_ERROR:
-              Log.error(`hlsjs: unrecoverable network fatal error, evt ${evt}, data ${data} `)
-              this.trigger(Events.PLAYBACK_ERROR, {evt, data}, this.name)
-              break;
-            default:
-              Log.warn(`hlsjs: trying to recover from network error, evt ${evt}, data ${data} `)
-              this._hls.startLoad()
-              break;
+          // The following network errors cannot be recovered with HLS.startLoad()
+          // For more details, see https://github.com/video-dev/hls.js/blob/master/doc/design.md#error-detection-and-handling
+          case HLSJS.ErrorDetails.MANIFEST_LOAD_ERROR:
+          case HLSJS.ErrorDetails.MANIFEST_LOAD_TIMEOUT:
+          case HLSJS.ErrorDetails.MANIFEST_PARSING_ERROR:
+            Log.error(`hlsjs: unrecoverable network fatal error, evt ${evt}, data ${data} `)
+            this.trigger(Events.PLAYBACK_ERROR, {evt, data}, this.name)
+            break
+          default:
+            Log.warn(`hlsjs: trying to recover from network error, evt ${evt}, data ${data} `)
+            this._hls.startLoad()
+            break
           }
           break
         case HLSJS.ErrorTypes.MEDIA_ERROR:

--- a/test/playbacks/hls_spec.js
+++ b/test/playbacks/hls_spec.js
@@ -1,4 +1,6 @@
+import Events from 'base/events.js'
 import HLS from 'playbacks/hls'
+import HLSJS from 'hls.js'
 
 describe('HLS playback', () => {
   // Disabled due to missing support for Firefox on Linux - breaks travis build
@@ -64,6 +66,17 @@ describe('HLS playback', () => {
       expect(playback._hls.config.someHlsjsOption).to.be.equal('value')
       expect(playback._hls.config).not.to.include.keys('hlsMinimumDvrSize')
     })
+  })
+
+  it('should trigger a playback error if source load failed', function(done) {
+    let options = {src: 'http://dns.will.fail/notfound.m3u8'}
+    const playback = new HLS(options)
+    playback.on(Events.PLAYBACK_ERROR, (e) => {
+      expect(e.data.type).to.be.equal(HLSJS.ErrorTypes.NETWORK_ERROR)
+      expect(e.data.details).to.be.equal(HLSJS.ErrorDetails.MANIFEST_LOAD_ERROR)
+      done()
+    })
+    playback.play()
   })
 
   xit('levels', function() {


### PR DESCRIPTION
Currently, if player try to load an HLS source playlist (_using hls.js playback_) which return a 40x or 50x error, then player is stalled.

The reason is that current code try to recover using `hls.startLoad()` on hls `NETWORK_ERROR`.
But according [documentation](https://github.com/video-dev/hls.js/blob/master/doc/design.md#error-detection-and-handling), the following network errors (_ErrorDetails_) cannot be recovered with `hls.startLoad()` : `MANIFEST_LOAD_ERROR`, `MANIFEST_LOAD_TIMEOUT` and `MANIFEST_PARSING_ERROR`.

This fix trigger a `PLAYBACK_ERROR` event to allow developer to decide how to handle the error. (_for example, using player `onError` configuration option_).

Usage example :

```javascript
var player = new Clappr.Player({
  source: 'http://some.bad/path/playlist.m3u8',
  events: {
    onError: function(e) {
      // Here decide what to do
      // player.load('http://another.good/fallback/playlist.m3u8', null, true);
    }
  }
});
```
