### PR TITLE
Handle uncaught (in promise) DOMException with Chrome browser

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -200,7 +200,11 @@ export default class HTML5Video extends Playback {
     this._stopped = false
     this._setupSrc(this._src)
     this._handleBufferingEvents()
-    this.el.play()
+    let promise = this.el.play()
+    // For more details, see https://developers.google.com/web/updates/2016/03/play-returns-promise
+    if (promise && promise.catch) {
+      promise.catch(() => {})
+    }
   }
 
   pause() {


### PR DESCRIPTION
In Google Chrome, `HTMLMediaElement.play()` returns a Promise which may trigger a DOMException when playback attempt has failed.

When it happen, it display the following error message in Google Chrome console :

```
Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause().
```

This fix simply catch the exception to avoid the error message to be displayed in console.

For more details, see [Google developers article](https://developers.google.com/web/updates/2016/03/play-returns-promise).

