### PR TITLE
[PROPOSITION] Expose embedded hls.js library in hls playback.

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -7,7 +7,6 @@ import HLSJS from 'hls.js'
 import isEqual from 'lodash.isequal'
 import Events from 'base/events'
 import Playback from 'base/playback'
-import Browser from 'components/browser'
 import {now} from 'base/utils'
 import Log from 'plugins/log'
 
@@ -93,6 +92,10 @@ export default class HLS extends HTML5VideoPlayback {
       return 0
     }
     return this._extrapolatedWindowNumSegments * this._segmentTargetDuration
+  }
+
+  static get HLSJS() {
+    return HLSJS
   }
 
   constructor(...args) {


### PR DESCRIPTION
While working on #1374 i thinked it could be convenient to be able to access to Hls.js library for constants.

Example usage :

```javascript
import Clappr from 'clappr'

const HLSJS = Clappr.HLS.HLSJS

let player = new Clappr.Player({
  source: 'http://example.com/playlist.m3u8',
  events: {
    onError: e => {
      if (e.error && e.error.evt === HLSJS.Events.ERROR) {
        // Handle Hls.js error
      }
    }
  }
});
```