### PR TITLE
remove lodash.once

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "karma-sinon-chai": "^1.1.0",
     "karma-webpack": "^2.0.1",
     "lodash.isplainobject": "^4.0.4",
-    "lodash.once": "^4.0.0",
     "lodash.result": "^4.3.0",
     "lolex": "^1.5.2",
     "mkdirp": "^0.5.1",

--- a/src/base/events.js
+++ b/src/base/events.js
@@ -4,7 +4,6 @@
 
 import Log from 'plugins/log'
 import {uniqueId} from './utils'
-import execOnce from 'lodash.once'
 
 const slice = Array.prototype.slice
 
@@ -84,11 +83,10 @@ export default class Events {
    */
   once(name, callback, context) {
     if (!eventsApi(this, 'once', name, [callback, context]) || !callback) {return this}
-    const self = this
-    const once = execOnce(function() {
-      self.off(name, once)
-      callback.apply(this, arguments)
-    })
+    const once = () => {
+      this.off(name, once)
+      callback.apply(context || this, arguments)
+    }
     once._callback = callback
     return this.on(name, once, context)
   }
@@ -558,7 +556,7 @@ Events.CONTAINER_LOADEDMETADATA = 'container:loadedmetadata'
 
 /**
  * Fired when a text track is loaded and available on container for display
- * 
+ *
  * @event CONTAINER_LOADEDTEXTTRACK
  */
 Events.CONTAINER_LOADEDTEXTTRACK = 'container:loadedtexttrack'

--- a/test/base/events_spec.js
+++ b/test/base/events_spec.js
@@ -85,10 +85,11 @@ describe('Events', function(){
   it('restricts to trigger only once', function(){
     let counter = 1
     const eventsCounter = function() {
+      expect(this === eventsCounter).to.be.true
       counter += 1
     }
 
-    this.events.once('clappr.any.event', eventsCounter)
+    this.events.once('clappr.any.event', eventsCounter, eventsCounter)
     expect(counter).to.be.equal(1)
 
     this.events.trigger('clappr.any.event')


### PR DESCRIPTION
refs #1395 
the last bunch of package updates merged has increased our bundle size by 5kb
it went from 466kb ⇨ 471kb
this PR goes:
471kb ⇨ 470kb

I will try to add a task that checks the bundle size on each build so we can keep track of these increases