### PR TITLE
fix(webpack): fix webpack dev server configuration

### DIFF
--- a/webpack-base-config.js
+++ b/webpack-base-config.js
@@ -5,7 +5,7 @@ var webpack = require('webpack')
 var DirectoryNamedWebpackPlugin = require('directory-named-webpack-plugin')
 
 module.exports = {
-  node: { Buffer: false, global: false, process: true, setImmediate: false },
+  node: { Buffer: false, global: true, process: true, setImmediate: false },
   plugins: [
     new DirectoryNamedWebpackPlugin(true),
     new webpack.DefinePlugin({
@@ -45,5 +45,8 @@ module.exports = {
       'clappr-zepto': 'clappr-zepto/zepto.js'
     },
     modules: [path.resolve(__dirname, 'src'), 'node_modules']
+  },
+  devServer: {
+    disableHostCheck: true, // https://github.com/webpack/webpack-dev-server/issues/882
   }
 }


### PR DESCRIPTION
It fixes an issue introduced in new webpack dev server release.
Just be cautious about security warning described [here](https://github.com/webpack/webpack-dev-server/issues/882).

Also it seems that node `global` is required on dev player page, so i setted it to true.
