### PR TITLE
[PROPOSITION] Screen orientation detection for mobile device

### DIFF
--- a/src/base/events.js
+++ b/src/base/events.js
@@ -486,6 +486,13 @@ Events.PLAYBACK_LEVEL_SWITCH = 'playback:level:switch'
 Events.PLAYBACK_SUBTITLE_LOADED = 'playback:subtitle:loaded'
 
 
+// Core Events
+/**
+ * Fired when the containers are created
+ *
+ * @event CORE_CONTAINERS_CREATED
+ */
+Events.CORE_CONTAINERS_CREATED = 'core:containers:created'
 /**
  * Fired when the options were changed for the core
  *
@@ -501,10 +508,11 @@ Events.CORE_READY = 'core:ready'
 /**
  * Fired when the fullscreen state change
  *
+ * @event CORE_FULLSCREEN
  * @param {Boolean} whether or not the player is on fullscreen mode
- * @event CORE_READY
  */
 Events.CORE_FULLSCREEN = 'core:fullscreen'
+
 
 // Container Events
 /**
@@ -711,6 +719,3 @@ Events.MEDIACONTROL_NOTPLAYING = 'mediacontrol:notplaying'
  * @event MEDIACONTROL_CONTAINERCHANGED
  */
 Events.MEDIACONTROL_CONTAINERCHANGED = 'mediacontrol:containerchanged'
-
-// Core Events
-Events.CORE_CONTAINERS_CREATED = 'core:containers:created'

--- a/src/base/events.js
+++ b/src/base/events.js
@@ -512,6 +512,19 @@ Events.CORE_READY = 'core:ready'
  * @param {Boolean} whether or not the player is on fullscreen mode
  */
 Events.CORE_FULLSCREEN = 'core:fullscreen'
+/**
+ * Fired when the screen orientation has changed.
+ * This event is trigger only for mobile devices.
+ *
+ * @event CORE_SCREEN_ORIENTATION_CHANGED
+ * @param {Object} screen An object with screen orientation
+ * screen object
+ * @param {Object} [screen.event]
+ * window resize event object
+ * @param {String} [screen.orientation]
+ * screen orientation (ie: 'landscape' or 'portrait')
+ */
+Events.CORE_SCREEN_ORIENTATION_CHANGED = 'core:screen:orientation:changed'
 
 
 // Container Events

--- a/src/components/browser.js
+++ b/src/components/browser.js
@@ -47,8 +47,8 @@ const getBrowserInfo = function() {
 
 const browserInfo = getBrowserInfo()
 
-Browser.isSafari = /safari/i.test(navigator.userAgent) && navigator.userAgent.indexOf('Chrome') === -1
 Browser.isChrome = /chrome|CriOS/i.test(navigator.userAgent)
+Browser.isSafari = /safari/i.test(navigator.userAgent) && !Browser.isChrome
 Browser.isFirefox = /firefox/i.test(navigator.userAgent)
 Browser.isLegacyIE = !!(window.ActiveXObject)
 Browser.isIE = Browser.isLegacyIE || /trident.*rv:1\d/i.test(navigator.userAgent)

--- a/src/components/browser.js
+++ b/src/components/browser.js
@@ -48,7 +48,7 @@ const getBrowserInfo = function() {
 const browserInfo = getBrowserInfo()
 
 Browser.isSafari = /safari/i.test(navigator.userAgent) && navigator.userAgent.indexOf('Chrome') === -1
-Browser.isChrome = /chrome/i.test(navigator.userAgent) || /CriOS/i.test(navigator.userAgent)
+Browser.isChrome = /chrome|CriOS/i.test(navigator.userAgent)
 Browser.isFirefox = /firefox/i.test(navigator.userAgent)
 Browser.isLegacyIE = !!(window.ActiveXObject)
 Browser.isIE = Browser.isLegacyIE || /trident.*rv:1\d/i.test(navigator.userAgent)

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -72,6 +72,7 @@ export default class Core extends UIObject {
     $(document).bind('fullscreenchange', this._boundFullscreenHandler)
     $(document).bind('MSFullscreenChange', this._boundFullscreenHandler)
     $(document).bind('mozfullscreenchange', this._boundFullscreenHandler)
+    Browser.isMobile && $(window).bind('resize', (o) => {this.handleWindowResize(o)})
   }
 
   configureDomRecycler() {
@@ -201,6 +202,17 @@ export default class Core extends UIObject {
     this.trigger(Events.CORE_FULLSCREEN, Fullscreen.isFullscreen())
     this.updateSize()
     this.mediaControl.show()
+  }
+
+  handleWindowResize(event) {
+    let orientation = ($(window).width() > $(window).height()) ? 'landscape' : 'portrait'
+    if (this._screenOrientation === orientation) return
+    this._screenOrientation = orientation
+
+    this.trigger(Events.CORE_SCREEN_ORIENTATION_CHANGED, {
+      event: event,
+      orientation: this._screenOrientation
+    })
   }
 
   setMediaControlContainer(container) {


### PR DESCRIPTION
This introduce a new core event (_only triggered on mobile devices_) when screen orientation has changed.

Motivations: It's a requirement for a feature i am working on : fullscreen on orientation change.
(_please note this PR only add screen orientation core event, not the fullscreen feature_)

Currently, fullscreen on orientation change work only on iOS devices because it is not a "true" fullscreen.
But hopefully it may be allowed in future browser versions. (_so it may be usefull for Clappr to be ready for this_).