### PR TITLE
fix(mediacontrol): fix getSettings method (fix iOS fullscreen button)

### DIFF
--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -534,7 +534,7 @@ export default class MediaControl extends UIObject {
   }
 
   getSettings() {
-    return $.extend({}, this.container.settings)
+    return $.extend(true, {}, this.container.settings)
   }
 
   highDefinitionUpdate(isHD) {


### PR DESCRIPTION
Fixes #1410.
