### PR TITLE
fix(utils): allow iOS device to exit fullscreen programmatically

### DIFF
--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -72,19 +72,21 @@ export const Fullscreen = {
       el.msRequestFullscreen()
     } else if (el.querySelector && el.querySelector('video') && el.querySelector('video').webkitEnterFullScreen) {
       el.querySelector('video').webkitEnterFullScreen()
+    } else if (el.webkitEnterFullScreen) {
+      el.webkitEnterFullScreen()
     }
   },
-  cancelFullscreen: function() {
-    if(document.exitFullscreen) {
-      document.exitFullscreen()
-    } else if(document.webkitCancelFullScreen) {
-      document.webkitCancelFullScreen()
-    } else if(document.webkitExitFullscreen) {
-      document.webkitExitFullscreen()
-    } else if(document.mozCancelFullScreen) {
-      document.mozCancelFullScreen()
-    } else if(document.msExitFullscreen) {
-      document.msExitFullscreen()
+  cancelFullscreen: function(el=document) {
+    if(el.exitFullscreen) {
+      el.exitFullscreen()
+    } else if(el.webkitCancelFullScreen) {
+      el.webkitCancelFullScreen()
+    } else if(el.webkitExitFullscreen) {
+      el.webkitExitFullscreen()
+    } else if(el.mozCancelFullScreen) {
+      el.mozCancelFullScreen()
+    } else if(el.msExitFullscreen) {
+      el.msExitFullscreen()
     }
   },
   fullscreenEnabled: function() {


### PR DESCRIPTION
On iOS device (_playing HTML5 video_) if you call `Utils.Fullscreen.cancelFullscreen()` it will fail.

This fix allow you, to exit full screen programmatically. For example :

```javascript
const video = player.core.getCurrentPlayback().el // Assume <video> element
Utils.Fullscreen.cancelFullscreen(video)
```

It does **not** introduce any regression or breaking change.

_Tested on iPhone (Safari, Chrome), iPad (Safari, Chrome), MacOSX (Safari, Chrome, Firefox), Linux Debian (Chrome, Firefox); Window 7 (IE11, Chrome, Firefox), Windows 10 (Edge, Chrome, Firefox)._

