### PR TITLE
chore(webpack): avoid to load Clean plugin with npm run start

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ if (process.env.npm_lifecycle_event === 'release') {
     output: {comments: false}
   })
   )
-} else {
+} else if (process.env.npm_lifecycle_event !== 'start') {
   webpackConfig.plugins.push(new Clean(['dist'], {verbose: false}))
 }
 


### PR DESCRIPTION
Fix an annoying issue where files in dist folder are deleted each time you run webpack dev server. (ie: `npm run start`).