### PR TITLE
fix(loader): update removeDups() to priorize external plugins

### DIFF
--- a/src/components/loader/loader.js
+++ b/src/components/loader/loader.js
@@ -78,6 +78,7 @@ export default class Loader extends BaseObject {
 
   removeDups(list) {
     const groupUp = (plugins, plugin) => {
+      plugins[plugin.prototype.name] && delete plugins[plugin.prototype.name]
       plugins[plugin.prototype.name] = plugin
       return plugins
     }

--- a/test/components/loader_spec.js
+++ b/test/components/loader_spec.js
@@ -50,7 +50,7 @@ describe('Loader', function() {
     })
 
     it('should prioritize external plugins if their names collide', function() {
-      const spinnerPlugin = ContainerPlugin.extend({container: {},  name: 'spinner'})
+      const spinnerPlugin = ContainerPlugin.extend({container: {},  name: 'spinner', myprop: 'myvalue'})
       const loader = new Loader()
       expect(loader.containerPlugins.filter((plugin) => {
         return plugin.prototype.name === 'spinner'
@@ -58,9 +58,9 @@ describe('Loader', function() {
 
       loader.addExternalPlugins({container: [spinnerPlugin]})
 
-      expect(loader.containerPlugins.filter((plugin) => {
-        return plugin.prototype.name === 'spinner'
-      })[0]).to.be.equal(spinnerPlugin)
+      const firstLoadedPlugin = loader.containerPlugins[0]
+      expect(firstLoadedPlugin).to.be.equal(spinnerPlugin)
+      expect(firstLoadedPlugin.prototype.myprop).to.be.equal('myvalue')
     })
 
     it('should allow only a plugin with a given name', function() {


### PR DESCRIPTION
This fix plugin order when using external plugins.

EDIT:

Let's assume this code :

```javascript
class Toto extends FlasHLS {
  // [...]
}
```

By adding `plugins: [Toto]` to player option, current loader removeDups() method will return :

```javascript
[ HLS(), HTML5Video(), HTML5Audio(), Flash(), Toto(), HTMLImg(), NoOp() ]
```

With fix :

```javascript
[ Toto(), HLS(), HTML5Video(), HTML5Audio(), Flash(), HTMLImg(), NoOp() ]
```
