### PR TITLE
Avoid IE11 to download .swf file twice

### DIFF
--- a/src/playbacks/base_flash_playback/public/flash.html
+++ b/src/playbacks/base_flash_playback/public/flash.html
@@ -1,4 +1,4 @@
-<param name="movie" value="<%= swfPath %>?inline=1">
+<param name="movie" value="<%= swfPath %>">
 <param name="quality" value="autohigh">
 <param name="swliveconnect" value="true">
 <param name="allowScriptAccess" value="always">


### PR DESCRIPTION
This fixe remove an unused legacy query parameter in base flash playback template (_movie param_).

It avoid IE11 to download twice the swf file. (_on player creation, the swf is downloaded once and second request is aborted. On player.load() the .swf file is downloaded only once_)