### PR TITLE
use babel transform runtime plugin to avoid duplicate babel helpers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "presets": ["es2015"],
   "plugins": [
     "add-module-exports",
-    ["transform-es2015-classes", {"loose": true}]
+    ["transform-es2015-classes", {"loose": true}],
+    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-loader": "^7.0.0",
     "babel-plugin-add-module-exports": "^0.2.0",
     "babel-plugin-transform-es2015-classes": "^6.6.4",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.5.0",
     "chai": "^3.2.0",
     "check-dependencies": "^1.0.1",


### PR DESCRIPTION
refs #1395
470kb ⇨ 465kb

babel inlines the helper functions multiple times this plugin avoids that