### PR TITLE
mute or unmute video on volume change (muted autostart on mobile devices)

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -224,8 +224,10 @@ export default class HTML5Video extends Playback {
   volume(value) {
     if (value === 0) {
       this.$el.attr({muted: 'true'})
-    } else if (this.el.volume === 0) {
+      this.el.muted = true
+    } else {
       this.$el.attr({muted: null})
+      this.el.muted = false
     }
     this.el.volume = value / 100
   }

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -222,6 +222,11 @@ export default class HTML5Video extends Playback {
   }
 
   volume(value) {
+    if (value === 0) {
+      this.$el.attr({muted: 'true'})
+    } else if (this.el.volume === 0) {
+      this.$el.attr({muted: null})
+    }
     this.el.volume = value / 100
   }
 

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -80,14 +80,17 @@ describe('HTML5Video playback', function() {
     expect(playback.el.controls).to.be.true
   })
 
-  it('adds or remove muted attribute when volume is changed', function() {
+  it('mute or unmute video element when volume is changed', function() {
     const playback = new HTML5Video(this.options)
 
     expect(playback.el.getAttribute('muted')).to.be.null
+    expect(playback.el.muted).to.be.false
     playback.volume(0)
     expect(playback.el.getAttribute('muted')).equal('true')
+    expect(playback.el.muted).to.be.true
     playback.volume(0.5)
     expect(playback.el.getAttribute('muted')).to.be.null
+    expect(playback.el.muted).to.be.false
   })
 
   describe('progress', function() {

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -80,6 +80,16 @@ describe('HTML5Video playback', function() {
     expect(playback.el.controls).to.be.true
   })
 
+  it('adds or remove muted attribute when volume is changed', function() {
+    const playback = new HTML5Video(this.options)
+
+    expect(playback.el.getAttribute('muted')).to.be.null
+    playback.volume(0)
+    expect(playback.el.getAttribute('muted')).equal('true')
+    playback.volume(0.5)
+    expect(playback.el.getAttribute('muted')).to.be.null
+  })
+
   describe('progress', function() {
     let start, end, currentTime
     const duration = 300


### PR DESCRIPTION
These changes allow autoplay on mobile devices when `mute` player option is set to true. (_and playback `playInline` is set to true on iOS_).

Thank you to @tomas2387 for original pull request #1260.

Example usage :

```javascript
var player = new Clappr.Player({
  parentId: '#player-wrapper',
  source: 'http://clappr.io/highline.mp4',
  poster: 'http://clappr.io/poster.png',
  mute: true,
  autoPlay: true,
  playback: { playInline: true }, // Required only by iOS
  height: 360,
  width: 640
});
```

Requirements :

* iOS version >= 10
* Android with Chrome version >= 53

supersede #1260, should fixes #1314
