### PR TITLE
feat(media_control): allow mute/unmute video with Safari on mobile

### DIFF
--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -685,8 +685,14 @@ export default class MediaControl extends UIObject {
       this.hide()
     }
 
+    // Video volume cannot be changed with Safari on mobile devices
+    // Display mute/unmute icon only if Safari version >= 10
     if(Browser.isSafari && Browser.isMobile) {
-      this.$volumeContainer.css('display','none')
+      if (Browser.version < 10) {
+        this.$volumeContainer.css('display','none')
+      } else {
+        this.$volumeBarContainer.css('display','none')
+      }
     }
 
     this.$seekBarPosition.addClass('media-control-notransition')


### PR DESCRIPTION
Because of #1432 it is now possible to display at least the mute/unmute icon on media controls with Safari browser on mobile devices.
(_for example, it allow user to unmute video if autoplayed with mute option to true_).
