### PR TITLE
HLS live source closed caption support

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -482,7 +482,7 @@ export default class HTML5Video extends Playback {
     let textTracks = this.el.textTracks ? Array.from(this.el.textTracks) : []
 
     return textTracks
-      .filter(track => track.kind === 'subtitles')
+      .filter(track => track.kind === 'subtitles' || track.kind === 'captions')
       .map(track => { return {id: trackId(), name: track.label, track: track} })
   }
 

--- a/src/plugins/closed_captions/closed_captions.js
+++ b/src/plugins/closed_captions/closed_captions.js
@@ -43,7 +43,12 @@ export default class ClosedCaptions extends UICorePlugin {
     if (this.container) {
       this.listenTo(this.container, Events.CONTAINER_SUBTITLE_AVAILABLE, this.onSubtitleAvailable)
       this.listenTo(this.container, Events.CONTAINER_SUBTITLE_CHANGED, this.onSubtitleChanged)
+      this.listenTo(this.container, Events.CONTAINER_STOP, this.onContainerStop)
     }
+  }
+
+  onContainerStop() {
+    this.ccAvailable(false)
   }
 
   containerChanged() {


### PR DESCRIPTION
Should fix #1471.

This is an experimental feature, as these kind of subtitles seems to be partially handled by hls.js library.
By partially, i mean it is properly displayed, but not all events are triggered and internal properties like `subtitleTracks` are not updated. (_always empty array returned_).

With hls live source, text track data may not immediatly available (_same for video element TextTrack objects_).

Another issue is that TextTrack cannot be removed from TextTrackList object. Since Clappr player destroy hls instance on player stop for live stream, then the next hls.js instance add more TextTrack objects to video element. (_obviously, cannot be currently fixed, maybe later with future specs_)

So i managed to find a workaround using [this](https://www.tental.com/m3u8test/main.m3u8) source provided by @UnitedPeace 👍 

The only known issue with this fix is that closed captions are set to disabled each time you click on stop (_for this live source closed caption types only_). So you have to click on CC button again after each play to display subtitles again. (but at least it work !!! 😃 ).
