### PR TITLE
Prevents wrong PLAYBACK_BUFFERFULL triggering

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -95,6 +95,7 @@ export default class HTML5Video extends Playback {
     super(...args)
     this._destroyed = false
     this._loadStarted = false
+    this._bufferingState = false
     this._playheadMoving = false
     this._playheadMovingTimer = null
     this._stopped = false

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -88,14 +88,14 @@ export default class HTML5Video extends Playback {
    * @type Boolean
    */
   get buffering() {
-    return !!this._bufferingState
+    return this._isBuffering
   }
 
   constructor(...args) {
     super(...args)
     this._destroyed = false
     this._loadStarted = false
-    this._bufferingState = false
+    this._isBuffering = false
     this._playheadMoving = false
     this._playheadMovingTimer = null
     this._stopped = false
@@ -353,8 +353,8 @@ export default class HTML5Video extends Playback {
   _handleBufferingEvents() {
     const playheadShouldBeMoving = !this.el.ended && !this.el.paused
     const buffering = this._loadStarted && !this.el.ended && !this._stopped && ((playheadShouldBeMoving && !this._playheadMoving) || this.el.readyState < this.el.HAVE_FUTURE_DATA)
-    if (this._bufferingState !== buffering) {
-      this._bufferingState = buffering
+    if (this._isBuffering !== buffering) {
+      this._isBuffering = buffering
       if (buffering) {
         this.trigger(Events.PLAYBACK_BUFFERING, this.name)
       }

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -198,9 +198,7 @@ describe('HTML5Video playback', function() {
 
       let builtInEvents = ['loadedmetadata', 'progress', 'timeupdate'].map(
         function(label) {
-          let event = document.createEvent('HTMLEvents')
-          event.initEvent(label, true, true)
-          return event
+          return new Event(label)
         }
       )
 

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -190,6 +190,14 @@ describe('HTML5Video playback', function() {
       expect(progress.current).to.be.equal(end[1])
     })
 
+    it('does not trigger PLAYBACK_BUFFERFULL when playback is initialized', function() {
+      let callback = sinon.spy()
+      this.playback.on(Events.PLAYBACK_BUFFERFULL, callback)
+      this.playback._handleBufferingEvents()
+
+      callback.should.not.have.been.called
+    })
+
     it('should return an array of buffer segments as {start, end} objects', function() {
       start = [0, 50, 180]
       end = [30, 90, 280]

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -190,11 +190,27 @@ describe('HTML5Video playback', function() {
       expect(progress.current).to.be.equal(end[1])
     })
 
-    it('does not trigger PLAYBACK_BUFFERFULL when playback is initialized', function() {
-      let callback = sinon.spy()
-      this.playback.on(Events.PLAYBACK_BUFFERFULL, callback)
-      this.playback._handleBufferingEvents()
+    it('does not trigger buffer event when the playback is initialized', function() {
+      /*
+        Only trigger buffer events when buffer state change. 
+        The default value for _bufferState is false.
+      */
 
+      let builtInEvents = ['loadedmetadata', 'progress', 'timeupdate'].map(
+        function(label) {
+          let event = document.createEvent('HTMLEvents')
+          event.initEvent(label, true, true)
+          return event
+        }
+      )
+
+      let callback = sinon.spy()
+      let playback = new HTML5Video(this.options)
+
+      playback.on(Events.PLAYBACK_BUFFERING, callback)
+      playback.on(Events.PLAYBACK_BUFFERFULL, callback)
+
+      builtInEvents.map(function(event) { playback.el.dispatchEvent(event) })
       callback.should.not.have.been.called
     })
 


### PR DESCRIPTION
Without this change, every time the `HTML5Video` playback is initialized and the variable `_bufferingState` is `undefined` it will trigger (incorrectly) the `PLAYBACK_BUFFERFULL` event.