### PR TITLE
Add support to a seeked event

### DIFF
--- a/src/base/events.js
+++ b/src/base/events.js
@@ -674,6 +674,13 @@ Events.CONTAINER_MOUSE_LEAVE = 'container:mouseleave'
  * @param {Number} time the current time in seconds
  */
 Events.CONTAINER_SEEK = 'container:seek'
+/**
+ * Fired when the container was finished the seek video
+ *
+ * @event CONTAINER_SEEKED
+ * @param {Number} time the current time in seconds
+ */
+Events.CONTAINER_SEEKED = 'container:seeked'
 Events.CONTAINER_VOLUME = 'container:volume'
 Events.CONTAINER_FULLSCREEN = 'container:fullscreen'
 /**

--- a/src/base/events.js
+++ b/src/base/events.js
@@ -482,6 +482,12 @@ Events.PLAYBACK_PLAY = 'playback:play'
  */
 Events.PLAYBACK_PAUSE = 'playback:pause'
 /**
+ * Fired when the media for a playback is seeked.
+ *
+ * @event PLAYBACK_SEEKED
+ */
+Events.PLAYBACK_SEEKED = 'playback:seeked'
+/**
  * Fired when the media for a playback is stopped.
  *
  * @event PLAYBACK_STOP

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -166,6 +166,7 @@ export default class Container extends UIObject {
     this.listenTo(this.playback, Events.PLAYBACK_DVR, this.playbackDvrStateChanged)
     this.listenTo(this.playback, Events.PLAYBACK_MEDIACONTROL_DISABLE, this.disableMediaControl)
     this.listenTo(this.playback, Events.PLAYBACK_MEDIACONTROL_ENABLE, this.enableMediaControl)
+    this.listenTo(this.playback, Events.PLAYBACK_SEEKED, this.onSeeked)
     this.listenTo(this.playback, Events.PLAYBACK_ENDED, this.onEnded)
     this.listenTo(this.playback, Events.PLAYBACK_PLAY, this.playing)
     this.listenTo(this.playback, Events.PLAYBACK_PAUSE, this.paused)
@@ -346,6 +347,10 @@ export default class Container extends UIObject {
   seek(time) {
     this.trigger(Events.CONTAINER_SEEK, time, this.name)
     this.playback.seek(time)
+  }
+
+  onSeeked() {
+    this.trigger(Events.CONTAINER_SEEKED, this.name)
   }
 
   seekPercentage(percentage) {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -64,7 +64,7 @@ export default class HTML5Video extends Playback {
       'playing': '_onPlaying',
       'progress': '_onProgress',
       'seeked': '_handleBufferingEvents',
-      'seeking': '_handleBufferingEvents',
+      'seeking': '_onSeeked',
       'stalled': '_handleBufferingEvents',
       'timeupdate': '_onTimeUpdate',
       'waiting': '_onWaiting'
@@ -337,6 +337,11 @@ export default class HTML5Video extends Playback {
     this._stopPlayheadMovingChecks()
     this._handleBufferingEvents()
     this.trigger(Events.PLAYBACK_PAUSE)
+  }
+
+  _onSeeked() {
+    this._handleBufferingEvents()
+    this.trigger(Events.PLAYBACK_SEEKED)
   }
 
   _onEnded() {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -63,8 +63,8 @@ export default class HTML5Video extends Playback {
       'pause': '_onPause',
       'playing': '_onPlaying',
       'progress': '_onProgress',
-      'seeked': '_handleBufferingEvents',
-      'seeking': '_onSeeked',
+      'seeking': '_handleBufferingEvents',
+      'seeked': '_onSeeked',
       'stalled': '_handleBufferingEvents',
       'timeupdate': '_onTimeUpdate',
       'waiting': '_onWaiting'

--- a/test/components/container_spec.js
+++ b/test/components/container_spec.js
@@ -1,5 +1,6 @@
 import Container from '../../src/components/container'
 import FakePlayback from '../../src/base/playback'
+import HTML5Playback from '../../src/playbacks/html5_video/index'
 import Playback from '../../src/base/playback'
 import Events from '../../src/base/events'
 
@@ -61,6 +62,21 @@ describe('Container', function() {
     this.playback.trigger(Events.PLAYBACK_TIMEUPDATE, {current: 2, total: 40})
 
     assert.ok(this.container.timeUpdated.calledWith({current: 2, total: 40}))
+  })
+
+  it('listens to playback:seeked event', function(done) {
+    let playback = new HTML5Playback({src: '/base/test/fixtures/SampleVideo_360x240_1mb.mp4'})
+    let container = new Container({playback: playback})
+    let callback = sinon.spy()
+
+    container.bindEvents()
+    container.on(Events.CONTAINER_SEEKED, callback)
+    container.on(Events.CONTAINER_SEEKED, () => {
+      assert.ok(callback.called)
+      done()
+    })
+
+    playback.seek(2)
   })
 
   it('listens to playback:ready event', function() {

--- a/test/components/container_spec.js
+++ b/test/components/container_spec.js
@@ -65,6 +65,7 @@ describe('Container', function() {
   })
 
   it('listens to playback:seeked event', function(done) {
+    this.timeout(5000)
     let playback = new HTML5Playback({src: '/base/test/fixtures/SampleVideo_360x240_1mb.mp4'})
     let container = new Container({playback: playback})
     let callback = sinon.spy()
@@ -76,7 +77,7 @@ describe('Container', function() {
       done()
     })
 
-    playback.seek(2)
+    playback.el.dispatchEvent(new Event('seeked'))
   })
 
   it('listens to playback:ready event', function() {

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -48,6 +48,19 @@ describe('HTML5Video playback', function() {
     callback.should.have.been.calledOnce
   })
 
+  it('triggers PLAYBACK_SEEKED on media seeked event', function(done) {
+    const callback = sinon.spy()
+    const playback = new HTML5Video({src: '/base/test/fixtures/SampleVideo_360x240_1mb.mp4'})
+
+    playback.on(Events.PLAYBACK_SEEKED, callback)
+    playback.on(Events.PLAYBACK_SEEKED, () => {
+      callback.should.have.been.calledOnce
+      done()
+    }, this)
+
+    playback.seek(1)
+  })
+
   it('isPlaying() is true after constructor when autoPlay is true', function(done) {
     const playback = new HTML5Video({src: 'http://example.com/dash.ogg', autoPlay: true})
     process.nextTick(function(){

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -49,6 +49,7 @@ describe('HTML5Video playback', function() {
   })
 
   it('triggers PLAYBACK_SEEKED on media seeked event', function(done) {
+    this.timeout(5000)
     const callback = sinon.spy()
     const playback = new HTML5Video({src: '/base/test/fixtures/SampleVideo_360x240_1mb.mp4'})
 
@@ -58,7 +59,7 @@ describe('HTML5Video playback', function() {
       done()
     }, this)
 
-    playback.seek(1)
+    playback.el.dispatchEvent(new Event('seeked'))
   })
 
   it('isPlaying() is true after constructor when autoPlay is true', function(done) {


### PR DESCRIPTION
Today Clappr does not support 'seeked' event, sometime we need listen this event to realize one action when seek is finished.

I talked with @towerz and we discuss about the new architecture of Clappr, so we decided to implement this event only for playback.