### PR TITLE
fix(build): add templated public path to Webpack url-loader module config

### DIFF
--- a/src/playbacks/base_flash_playback/base_flash_playback.js
+++ b/src/playbacks/base_flash_playback/base_flash_playback.js
@@ -40,6 +40,7 @@ export default class BaseFlashPlayback extends Playback {
   }
 
   render() {
+    this.$el.attr('data', this.swfPath)
     this.$el.html(this.template({
       cid: this.cid,
       swfPath: this.swfPath,

--- a/test/playbacks/flash_spec.js
+++ b/test/playbacks/flash_spec.js
@@ -40,4 +40,11 @@ describe('Flash playback', function() {
     this.callback.should.have.been.calledOnce
     expect(this.flash.isReady).to.be.true
   })
+
+  it('should update data element attribute with base url on render', function() {
+    const playback = new Flash({baseUrl: '/foo/bar'})
+    expect(playback.el.getAttribute('data')).to.not.match(/^\/foo\/bar/)
+    playback.render()
+    expect(playback.el.getAttribute('data')).to.match(/^\/foo\/bar/)
+  })
 })

--- a/test/playbacks/flashls_spec.js
+++ b/test/playbacks/flashls_spec.js
@@ -72,5 +72,12 @@ describe('HLS playback', function() {
       expect(window.Clappr.flashlsCallbacks).to.be.a('object')
       expect(window.Clappr.flashlsCallbacks[this.hls.cid]).to.be.a('function')
     })
+
+    it('should update data element attribute with base url on render', function() {
+      const playback = new FlasHLS({baseUrl: '/foo/bar'})
+      expect(playback.el.getAttribute('data')).to.not.match(/^\/foo\/bar/)
+      playback.render()
+      expect(playback.el.getAttribute('data')).to.match(/^\/foo\/bar/)
+    })
   })
 })

--- a/webpack-base-config.js
+++ b/webpack-base-config.js
@@ -30,7 +30,12 @@ module.exports = {
         include: path.resolve(__dirname, 'src')
       },
       {
-        test: /\.(png|woff|eot|ttf|swf|cur)/, loader: 'url-loader?limit=1'
+        test: /\.(png|woff|eot|ttf|swf|cur)/,
+        loader: 'url-loader',
+        options: {
+          limit: 1,
+          publicPath: '<%=baseUrl%>/'
+        },
       },
       {
         test: /\.svg/, loader: 'svg-inline-loader'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,6 @@ if (process.env.npm_lifecycle_event === 'release') {
 
 webpackConfig.output = {
   path: path.resolve(__dirname, 'dist'),
-  publicPath: '<%=baseUrl%>/',
   filename: 'clappr.js',
   library: 'Clappr',
   libraryTarget: 'umd'


### PR DESCRIPTION
Should fix #1480.

Previously it was working because the `url-loader` module internally use the `file-loader` module where public path default to webpack `__webpack_public_path__` global variable (_which is Webpack `output.publicPath` value_).

It seems that if you set the `publicPath` configuration parameter to `url-loader`, it is also passed to `file-loader`. So we can pass here the templated value and it is resolved at runtime instead of compilation time if set in `output.publicPath` (_i think it is because Clappr is writted in ES6_).
