### PR TITLE
Update jsDelivr CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Add the following script on your HTML:
 ```html
 <head>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/clappr/clappr@latest/dist/clappr.min.js"></script>
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js"></script>
 </head>
 ```
 Now, create the player:
@@ -37,7 +37,7 @@ Test it at [cdn.clappr.io.](http://cdn.clappr.io/?src=http://www.streambox.fr/pl
 
 ## CDN
 
-You can use the latest published version at `https://cdn.jsdelivr.net/gh/clappr/clappr@latest/dist/clappr.min.js`
+You can use the latest published version at `https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js`
 
 ## Vendors
 


### PR DESCRIPTION
First, congrats - [clappr receives more than 400 M requests per month at jsDelivr](https://www.jsdelivr.com/package/npm/clappr), which makes it the 11th most popular package we host!

While our new back-end supports serving files from both npm and GitHub, we recommend always using only one of these methods for every package, with npm being the preferred one (using only npm means you can get detailed package usage statistics and npm packages are also searchable on our website).

I updated the links to use our npm endpoint.