### PR TITLE
Add clappr-nerd-stats plugin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Clappr is under heavy development but production-ready. Feel free to open issues
   <img src='https://raw.githubusercontent.com/clappr/clappr/master/images/youtube.jpg' width="280px"></img>
 </a> <a href="https://github.com/thiagopnts/clappr-video360/">
   <img src='https://raw.githubusercontent.com/thiagopnts/clappr-video360/master/360.gif' width="280" height="160"></img>
+</a> <a href="https://github.com/lucasrodcosta/clappr-nerd-stats/">
+  <img src='https://raw.githubusercontent.com/lucasrodcosta/clappr-nerd-stats/master/images/clappr-nerd-stats.png' width="280"></img>
 </a>
 
 ## [Supported Formats](doc/SUPPORTED_FORMATS.md)

--- a/doc/EXTERNAL_PLUGINS.md
+++ b/doc/EXTERNAL_PLUGINS.md
@@ -10,6 +10,7 @@
 |DASH with shaka| Ready | Yes | https://github.com/clappr/dash-shaka-playback |
 |Playback Speed | Ready | Yes | https://github.com/bikegriffith/clappr-playback-rate-plugin |
 |Clappr Stats | Ready | Yes | https://github.com/leandromoreira/clappr-stats |
+|Clappr Nerd Stats | Ready | Yes | https://github.com/lucasrodcosta/clappr-nerd-stats |
 |Pause while far| Ready | Yes | https://github.com/leandromoreira/clappr-pause-tab-visibility |
 |RTMP           | Ready | Yes | https://github.com/clappr/clappr-rtmp-plugin |
 |Picture-in-Picture | Ready | Yes | https://github.com/tjenkinson/clappr-pip-plugin |


### PR DESCRIPTION
Add image and link to [clappr-nerd-stats](https://github.com/lucasrodcosta/clappr-nerd-stats) plugin.

PS: Related to #711.