### PR TITLE
Manage _ready() state on HLS playback

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -15,6 +15,7 @@ export default class HLS extends HTML5VideoPlayback {
   get name() { return 'hls' }
 
   get levels() { return this._levels || [] }
+
   get currentLevel() {
     if (this._currentLevel === null || this._currentLevel === undefined) {
       return AUTO
@@ -22,6 +23,11 @@ export default class HLS extends HTML5VideoPlayback {
       return this._currentLevel //0 is a valid level ID
     }
   }
+
+  get isReady() {
+    return this._isReadyState
+  }
+
   set currentLevel(id) {
     this._currentLevel = id
     this.trigger(Events.PLAYBACK_LEVEL_SWITCH_START)
@@ -153,6 +159,15 @@ export default class HLS extends HTML5VideoPlayback {
     this._hls.on(HLSJS.Events.SUBTITLE_TRACK_LOADED, (evt, data) => this._onSubtitleLoaded(evt, data))
     this._hls.on(HLSJS.Events.SUBTITLE_TRACKS_UPDATED, () => this._ccTracksUpdated = true)
     this._hls.attachMedia(this.el)
+    this._ready()
+  }
+
+  _ready() {
+    if (!this._hls) {
+      return
+    }
+    this._isReadyState = true
+    this.trigger(Events.PLAYBACK_READY, this.name)
   }
 
   _recover(evt, data) {

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -140,7 +140,7 @@ export default class HLS extends HTML5VideoPlayback {
     this._startTimeUpdateTimer()
   }
 
-  _setupHls() {
+  _setup() {
     this._ccIsSetup = false
     this._ccTracksUpdated = false
     this._hls = new HLSJS(this.options.playback.hlsjsConfig || {})
@@ -338,7 +338,7 @@ export default class HLS extends HTML5VideoPlayback {
 
   play() {
     if (!this._hls) {
-      this._setupHls()
+      this._setup()
     }
     super.play()
   }

--- a/test/playbacks/hls_spec.js
+++ b/test/playbacks/hls_spec.js
@@ -48,7 +48,7 @@ describe('HLS playback', () => {
         }
       }
       const playback = new HLS(options)
-      playback._setupHls()
+      playback._setup()
       expect(playback._hls.config.someHlsjsOption).to.be.equal('value')
       expect(playback._hls.config).not.to.include.keys('hlsMinimumDvrSize')
     })
@@ -62,7 +62,7 @@ describe('HLS playback', () => {
         }
       }
       const playback = new HLS(options)
-      playback._setupHls()
+      playback._setup()
       expect(playback._hls.config.someHlsjsOption).to.be.equal('value')
       expect(playback._hls.config).not.to.include.keys('hlsMinimumDvrSize')
     })


### PR DESCRIPTION
Playback ready state treatment for not use html5 playback method.

Also, this pull request normalize the name of the setup methods between playbacks. The [dash playback](https://github.com/clappr/dash-shaka-playback) plugin already follows [this naming](https://github.com/clappr/dash-shaka-playback/blob/master/src/clappr-dash-shaka-playback.js#L257).