### PR TITLE
Use Autoprefixer instead node-bourbon mixins

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "lolex": "^2.0.0",
     "mkdirp": "^0.5.1",
     "mocha": "^3.3.0",
-    "node-bourbon": "^4.2.8",
     "node-sass": "^4.5.3",
     "postcss-loader": "^2.0.9",
     "s3": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "mocha": "^3.3.0",
     "node-bourbon": "^4.2.8",
     "node-sass": "^4.5.3",
+    "postcss-loader": "^2.0.9",
     "s3": "^4.1.1",
     "sass-loader": "^6.0.2",
     "sinon": "^2.2.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    require('autoprefixer')
+  ]
+}

--- a/src/components/core/public/style.scss
+++ b/src/components/core/public/style.scss
@@ -1,7 +1,6 @@
 @import 'reset';
 @import 'noselect';
 @import 'fontsmoothing';
-@import 'bourbon';
 
 @font-face {
   font-family: "Roboto";
@@ -14,7 +13,7 @@
   @include nested-reset;
   @include no-select;
   @include font-smoothing;
-  @include transform(translate3d(0,0,0));
+  transform: translate3d(0,0,0);
   position: relative;
   margin: 0;
   padding: 0;

--- a/src/components/media_control/public/media-control.scss
+++ b/src/components/media_control/public/media-control.scss
@@ -1,7 +1,5 @@
-@import 'bourbon';
-
 .media-control-notransition {
-  @include transition(none !important);
+  transition: none !important;
 }
 
 .media-control[data-media-control] {
@@ -28,8 +26,8 @@
     height: 40%;
     width: 100%;
     bottom: 0;
-    @include background(linear-gradient(transparent, rgba(0, 0, 0, 0.9)));
-    @include transition(opacity 0.6s ease-out);
+    background: linear-gradient(transparent, rgba(0, 0, 0, 0.9));
+    transition: opacity 0.6s ease-out;
   }
 
   .media-control-icon {
@@ -40,7 +38,7 @@
     opacity: 0.5;
     vertical-align: middle;
     text-align: left;
-    @include transition(all 0.1s ease);
+    transition: all 0.1s ease;
   }
 
   .media-control-icon:hover {
@@ -71,7 +69,7 @@
     font-size: 0;
     vertical-align: middle;
     pointer-events: auto;
-    @include transition(bottom 0.4s ease-out);
+    transition: bottom 0.4s ease-out;
 
     .media-control-left-panel[data-media-control] {
       position: absolute;
@@ -142,12 +140,12 @@
         display: none;
         float: right;
         height: 100%;
-        
+
         &.enabled {
           display: block;
           opacity: 1.0;
 
-          &:hover { 
+          &:hover {
             opacity: 1.0;
             text-shadow: none;
           }
@@ -206,7 +204,7 @@
           width: 0;
           height: 100%;
           background-color: #c2c2c2;
-          @include transition(all 0.1s ease-out);
+          transition: all 0.1s ease-out;
         }
 
         .bar-fill-2[data-seekbar] {
@@ -216,7 +214,7 @@
           width: 0;
           height: 100%;
           background-color: #005aff;
-          @include transition(all 0.1s ease-out);
+          transition: all 0.1s ease-out;
         }
 
         .bar-hover[data-seekbar] {
@@ -226,7 +224,7 @@
           width: 5px;
           height: 7px;
           background-color: rgba(255,255,255,0.5);
-          @include transition(opacity 0.1s ease);
+          transition: opacity 0.1s ease;
         }
       }
 
@@ -251,13 +249,13 @@
 
       .bar-scrubber[data-seekbar] {
         position: absolute;
-        @include transform(translateX(-50%));
+        transform: translateX(-50%);
         top: 2px;
         left: 0;
         width: 20px;
         height: 20px;
         opacity: 1;
-        @include transition(all 0.1s ease-out);
+        transition: all 0.1s ease-out;
 
         .bar-scrubber-icon[data-seekbar] {
           position: absolute;
@@ -312,7 +310,7 @@
         width: 42px;
         height: 18px;
         padding: 3px 0;
-        @include transition(width .2s ease-out);
+        transition: width .2s ease-out;
 
         .bar-background[data-volume] {
           height: 1px;
@@ -328,7 +326,7 @@
             width: 0;
             height: 100%;
             background-color: #c2c2c2;
-            @include transition(all 0.1s ease-out);
+            transition: all 0.1s ease-out;
           }
 
           .bar-fill-2[data-volume] {
@@ -338,7 +336,7 @@
             width: 0;
             height: 100%;
             background-color: #005aff;
-            @include transition(all 0.1s ease-out);
+            transition: all 0.1s ease-out;
           }
 
           .bar-hover[data-volume] {
@@ -348,19 +346,19 @@
             width: 5px;
             height: 7px;
             background-color: rgba(255,255,255,0.5);
-            @include transition(opacity 0.1s ease);
+            transition: opacity 0.1s ease;
           }
         }
 
         .bar-scrubber[data-volume] {
           position: absolute;
-          @include transform(translateX(-50%));
+          transform: translateX(-50%);
           top: 0px;
           left: 0;
           width: 20px;
           height: 20px;
           opacity: 1;
-          @include transition(all 0.1s ease-out);
+          transition: all 0.1s ease-out;
 
           .bar-scrubber-icon[data-volume] {
             position: absolute;
@@ -381,8 +379,7 @@
           height: 12px;
           opacity: 0.5;
           box-shadow: inset 2px 0 0 white;
-
-          @include transition(transform .2s ease-out);
+          transition: transform .2s ease-out;
 
           &.fill {
             box-shadow: inset 2px 0 0 #fff;
@@ -394,7 +391,7 @@
           }
 
           &:hover {
-            @include transform(scaleY(1.5));
+            transform: scaleY(1.5);
           }
         }
       }

--- a/src/playbacks/no_op/public/style.scss
+++ b/src/playbacks/no_op/public/style.scss
@@ -1,5 +1,3 @@
-@import 'bourbon';
-
 [data-no-op] {
   position: absolute;
   height: 100%;
@@ -17,7 +15,7 @@
   padding: 10px;
   /* center vertically */
   top: 50%;
-  @include transform(translateY(-50%));
+  transform: translateY(-50%);
   max-height: 100%;
   overflow: auto;
 }

--- a/src/plugins/dvr_controls/public/dvr_controls.scss
+++ b/src/plugins/dvr_controls/public/dvr_controls.scss
@@ -1,5 +1,3 @@
-@import "bourbon";
-
 $live-color: #ff0101;
 $dvr-color: #fff;
 $vod-color: #005aff;
@@ -52,7 +50,7 @@ $circle-radius: 3.5px;
     opacity: 0.7;
     font-family: "Roboto", "Open Sans", Arial, sans-serif;
     text-transform: uppercase;
-    @include transition(all 0.1s ease);
+    transition: all 0.1s ease;
 
     &:before {
       content: "";

--- a/src/plugins/poster/public/poster.scss
+++ b/src/plugins/poster/public/poster.scss
@@ -1,9 +1,7 @@
-@import "bourbon";
-
 .player-poster[data-poster] {
-  @include display(flex);
-  @include justify-content(center);
-  @include align-items(center);
+  display: flex;
+  justify-content: center;
+  align-items: center;
   position: absolute;
   height: 100%;
   width: 100%;
@@ -23,7 +21,7 @@
     height: 25%;
     margin: 0 auto;
     opacity: 0.75;
-    @include transition(opacity 0.1s ease);
+    transition: opacity 0.1s ease;
     svg {
       height: 100%;
       path { fill: #fff; }

--- a/src/plugins/seek_time/public/seek_time.scss
+++ b/src/plugins/seek_time/public/seek_time.scss
@@ -1,5 +1,3 @@
-@import "bourbon";
-
 .seek-time[data-seek-time] {
   position: absolute;
   white-space: nowrap;
@@ -10,7 +8,7 @@
   bottom: 55px;
   background-color: rgba(2, 2, 2, 0.5);
   z-index: 9999;
-  @include transition(opacity 0.1s ease);
+  transition: opacity 0.1s ease;
 
   &.hidden[data-seek-time] {
     opacity: 0;

--- a/src/plugins/spinner_three_bounce/public/spinner.scss
+++ b/src/plugins/spinner_three_bounce/public/spinner.scss
@@ -1,5 +1,3 @@
-@import 'bourbon';
-
 .spinner-three-bounce[data-spinner] {
   position: absolute;
   margin: 0 auto;
@@ -12,7 +10,7 @@
   margin-right: auto;
   /* center vertically */
   top: 50%;
-  @include transform(translateY(-50%));
+  transform: translateY(-50%);
 
   &> div {
     width: 18px;
@@ -20,21 +18,21 @@
     background-color: #FFFFFF;
     border-radius: 100%;
     display: inline-block;
-    @include animation(bouncedelay 1.4s infinite ease-in-out);
+    animation: bouncedelay 1.4s infinite ease-in-out;
     /* Prevent first frame from flickering when animation starts */
-    @include animation-fill-mode(both);
+    animation-fill-mode: both;
   }
 
   [data-bounce1] {
-    @include animation-delay(-0.32s);
+    animation-delay: -0.32s;
   }
 
   [data-bounce2] {
-    @include animation-delay(-0.16s);
+    animation-delay: -0.16s;
   }
 }
 
-@include keyframes(bouncedelay) {
-  0%, 80%, 100% { @include transform(scale(0.0)); }
-  40% { @include transform(scale(1.0)); }
+@keyframes: bouncedelay {
+  0%, 80%, 100% { transform: scale(0.0); }
+  40% { transform: scale(1.0); }
 }

--- a/webpack-base-config.js
+++ b/webpack-base-config.js
@@ -25,6 +25,7 @@ module.exports = {
         loaders: ['css-loader', 'sass-loader?includePaths[]='
             + require('node-bourbon').includePaths
             + '&includePaths[]='
+        loaders: ['css-loader', 'postcss-loader', 'sass-loader?includePaths[]='
             + path.resolve(__dirname, './src/base/scss')
         ],
         include: path.resolve(__dirname, 'src')

--- a/webpack-base-config.js
+++ b/webpack-base-config.js
@@ -22,9 +22,6 @@ module.exports = {
       },
       {
         test: /\.scss$/,
-        loaders: ['css-loader', 'sass-loader?includePaths[]='
-            + require('node-bourbon').includePaths
-            + '&includePaths[]='
         loaders: ['css-loader', 'postcss-loader', 'sass-loader?includePaths[]='
             + path.resolve(__dirname, './src/base/scss')
         ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,15 @@ ajv@^4.7.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
+ajv@^5.0.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.0.tgz#eb2840746e9dc48bd5e063a36e3fd400c5eab5a9"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
 ajv@^5.1.5, ajv@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
@@ -1324,6 +1333,14 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chalk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 chalk@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
@@ -1672,6 +1689,18 @@ core-js@^2.2.0, core-js@^2.4.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-2.2.2.tgz#6173cebd56fac042c1f4390edf7af6c07c7cb892"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.1.0"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    require-from-string "^1.1.0"
 
 coveralls@^2.13.1:
   version "2.13.1"
@@ -2562,6 +2591,10 @@ fancy-log@^1.1.0:
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -3544,6 +3577,10 @@ is-descriptor@^0.1.0:
     kind-of "^3.0.2"
     lazy-cache "^1.0.3"
 
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+
 is-dotfile@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.2.tgz#2c132383f39199f8edc268ca01b9b007d205cc4d"
@@ -3819,6 +3856,13 @@ js-yaml@3.6.1, js-yaml@~3.6.1:
 js-yaml@3.x, js-yaml@^3.8.4:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.0.tgz#4ffbbf25c2ac963b8299dc74da7e3740de1c18ce"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.4.3:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -4808,12 +4852,6 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-bourbon@^4.2.8:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/node-bourbon/-/node-bourbon-4.2.8.tgz#e444f1f09434ab7650ea318c28e2e103d3f942cd"
-  dependencies:
-    bourbon "^4.2.6"
-
 node-gyp@^3.3.1:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.5.0.tgz#a8fe5e611d079ec16348a3eb960e78e11c85274a"
@@ -5459,6 +5497,38 @@ postcss-filter-plugins@^2.0.0:
     postcss "^5.0.4"
     uniqid "^4.0.0"
 
+postcss-load-config@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-1.2.0.tgz#539e9afc9ddc8620121ebf9d8c3673e0ce50d28a"
+  dependencies:
+    cosmiconfig "^2.1.0"
+    object-assign "^4.1.0"
+    postcss-load-options "^1.2.0"
+    postcss-load-plugins "^2.3.0"
+
+postcss-load-options@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-load-options/-/postcss-load-options-1.2.0.tgz#b098b1559ddac2df04bc0bb375f99a5cfe2b6d8c"
+  dependencies:
+    cosmiconfig "^2.1.0"
+    object-assign "^4.1.0"
+
+postcss-load-plugins@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz#745768116599aca2f009fad426b00175049d8d92"
+  dependencies:
+    cosmiconfig "^2.1.1"
+    object-assign "^4.1.0"
+
+postcss-loader@^2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-2.0.9.tgz#001fdf7bfeeb159405ee61d1bb8e59b528dbd309"
+  dependencies:
+    loader-utils "^1.1.0"
+    postcss "^6.0.0"
+    postcss-load-config "^1.2.0"
+    schema-utils "^0.3.0"
+
 postcss-merge-idents@^2.1.5:
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz#4c5530313c08e1d5b3bbf3d2bbc747e278eea270"
@@ -5635,6 +5705,14 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     js-base64 "^2.1.9"
     source-map "^0.5.6"
     supports-color "^3.2.3"
+
+postcss@^6.0.0:
+  version "6.0.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.14.tgz#5534c72114739e75d0afcf017db853099f562885"
+  dependencies:
+    chalk "^2.3.0"
+    source-map "^0.6.1"
+    supports-color "^4.4.0"
 
 postcss@^6.0.1:
   version "6.0.2"
@@ -6096,6 +6174,10 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
+require-from-string@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -6237,6 +6319,12 @@ sax@0.4.2:
 sax@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+
+schema-utils@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.3.0.tgz#f5877222ce3e931edae039f17eb3716e7137f8cf"
+  dependencies:
+    ajv "^5.0.0"
 
 select-hose@^2.0.0:
   version "2.0.0"
@@ -6524,6 +6612,10 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
 source-map@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
@@ -6750,6 +6842,12 @@ supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.2.3:
 supports-color@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.0.tgz#ad986dc7eb2315d009b4d77c8169c2231a684037"
+  dependencies:
+    has-flag "^2.0.0"
+
+supports-color@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,10 +1072,6 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bourbon@^4.2.6:
-  version "4.2.7"
-  resolved "https://registry.yarnpkg.com/bourbon/-/bourbon-4.2.7.tgz#48a805dff475fbf61e002a64e1e4db68d2f82fba"
-
 bower-config@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/bower-config/-/bower-config-1.4.0.tgz#16c38c1135f8071c19f25938d61b0d8cbf18d3f1"


### PR DESCRIPTION
At the time of build for the project start or to run the test stack, warnings are appearing for me about mixins that Bourbon will deprecated in its new version `5.x.x`. 

In the repository of wrapper for Bourbon `node-bourbon` [has a issue about it](https://github.com/lacroixdesign/node-bourbon/issues/37) and it seems that the project is not using the most current version of Bourbon.

In the Bourbon repository there is an [issue talking about the project option](https://github.com/thoughtbot/bourbon/issues/702) and, according to them, `... we've decided to remove browser prefixing features from Bourbon.`

Alternatively, they suggest post-processors and the [Autoprefixer](https://github.com/postcss/autoprefixer) are best for this.

With this, I configured [postcss-loader](https://github.com/postcss/postcss-loader) in the project and removed the node-bourbon dependency.