### PR TITLE
Optionnaly build with inline source maps (debug embedded bundle)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "release": "MINIMIZE=true webpack --progress",
     "release:plainhtml5": "MINIMIZE=true CLAPPR_PLAIN_HTML5_ONLY=true webpack --progress",
     "build": "webpack --progress",
+    "build:debug": "CLAPPR_INLINE_DEBUG=true webpack --progress",
     "build:plainhtml5": "CLAPPR_PLAIN_HTML5_ONLY=true webpack --progress",
     "watch": "webpack --progress --watch",
     "test": "karma start --single-run",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const webpackConfig = require('./webpack-base-config')
 const voidModulePath = path.resolve('./src/base/void');
 
 const minimize = !!process.env.MINIMIZE;
+const forceInlineDebug = !!process.env.CLAPPR_INLINE_DEBUG
 const plainHtml5Only = !!process.env.CLAPPR_PLAIN_HTML5_ONLY;
 const devServer = (process.env.npm_lifecycle_event === 'start');
 
@@ -43,9 +44,18 @@ if (plainHtml5Only) {
     );
 }
 
+if (forceInlineDebug) {
+  console.log('NOTE: Enabling inline source-maps - this may not be suitable for production usage')
+  webpackConfig.devtool = 'inline-source-map'
+}
+
+
+const filename =
+  `clappr${ distroFlavor ? '.' + distroFlavor : '' }${ forceInlineDebug ? '.debug' : '' }${ minimize ? '.min' : '' }.js`
+
 webpackConfig.output = {
   path: path.resolve(__dirname, 'dist'),
-  filename: `clappr${ distroFlavor ? '.' + distroFlavor : '' }${ minimize ? '.min' : '' }.js`,
+  filename,
   library: 'Clappr',
   libraryTarget: 'umd'
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,7 @@ if (forceInlineDebug) {
   webpackConfig.devtool = 'inline-source-map'
 }
 
+console.log('\n')
 
 const filename =
   `clappr${ distroFlavor ? '.' + distroFlavor : '' }${ forceInlineDebug ? '.debug' : '' }${ minimize ? '.min' : '' }.js`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,8 @@ webpackConfig.entry = path.resolve(__dirname, 'src/main.js')
 
 if (minimize) {
 
+  console.log('NOTE: Enabled minifying bundle (uglify)')
+
   webpackConfig.plugins.push(new webpack.LoaderOptionsPlugin({ minimize, debug: !minimize }))
   webpackConfig.plugins.push(new webpack.optimize.UglifyJsPlugin({
     compress: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,8 @@ if (minimize) {
   }))
 
 } else if (!devServer) {
-  webpackConfig.plugins.push(new CleanPlugin(['dist'], {verbose: false}))
+  // Cleans up whole dist folder before building
+  webpackConfig.plugins.push(new CleanPlugin(['dist'], {verbose: true}))
 }
 
 if (plainHtml5Only) {


### PR DESCRIPTION
Optionnaly builds with `devtool: 'inline-source-map'` webpack option.

Allows to debug with source-map even when bundle is embedded in consumer app and no Clappr sources are around. This is generally much more robust then plain source-maps when one wants to debug the package in the environment it gets shipped to as otherwise source paths of various dependencies may conflict or be collapsed over each others.

This adds a script `builld:debug` which will result in a *big* build that includes all the source-maps.

There is a log warning that this isn't suitable for prod. We probably don't need to commit this to the repo, it's only really necessary for debugging purpose in the specific situations described.

```
npm run build:debug

> clappr@0.2.80 build:debug clappr
> CLAPPR_INLINE_DEBUG=true webpack --progress

NOTE: Enabling inline source-maps - this may not be suitable for production usage


clean-webpack-plugin: clappr/dist has been removed.
Hash: c2dd51147a2e8912cf62                                                              
Version: webpack 3.10.0
Time: 6415ms
                               Asset       Size  Chunks                    Chunk Names
a8c874b93b3d848f39a71260c57e3863.cur  326 bytes          [emitted]         
38861cba61c66739c1452c3a71e39852.ttf    32.7 kB          [emitted]         
4b76590b32dab62bc95c1b7951efae78.swf     3.2 kB          [emitted]         
8fa12a459188502b9f0d39b8a67d9e6c.swf    63.5 kB          [emitted]         
                     clappr.debug.js    3.16 MB       0  [emitted]  [big]  main
   [4] ./src/base/events.js 23.6 kB {0} [built]
   [5] ./src/base/utils.js 10.5 kB {0} [built]
   [8] ./src/base/template.js 3.5 kB {0} [built]
   [9] ./src/base/playback.js 8.19 kB {0} [built]
  [16] ./src/base/base_object.js 2.08 kB {0} [built]
  [21] ./src/base/ui_object.js 6.83 kB {0} [built]
  [29] ./src/base/core_plugin.js 1.91 kB {0} [built]
  [35] ./src/playbacks/html5_video/index.js 360 bytes {0} [built]
  [36] ./src/base/ui_container_plugin.js 2.22 kB {0} [built]
  [37] ./src/base/container_plugin.js 2.03 kB {0} [built]
  [38] ./src/base/ui_core_plugin.js 2.02 kB {0} [built]
  [55] ./src/plugins/log/index.js 320 bytes {0} [built]
  [56] ./src/vendor/index.js 335 bytes {0} [built]
  [59] ./src/playbacks/base_flash_playback/index.js 168 bytes {0} [built]
  [89] ./src/main.js 4.68 kB {0} [built]
    + 215 hidden modules
```
  