### PR TITLE
Allow configure new events

### DIFF
--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -186,9 +186,9 @@ export default class Core extends UIObject {
     this.containers.forEach((container) => container.destroy())
     this.mediaControl.container = null
     this.containerFactory.options = $.extend(this.options, { sources })
-    this.containerFactory.createContainers().then((containers) => {
-      this.setupContainers(containers)
-    })
+    this.containerFactory.createContainers()
+      .then((containers) => this.setupContainers(containers))
+      .then((containers) => this.resolveOnContainersReady(containers))
   }
 
   destroy() {

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -257,12 +257,16 @@ export default class Player extends BaseObject {
     return this
   }
 
-  _registerOptionEventListeners() {
-    const userEvents = this.options.events || {}
-    Object.keys(userEvents).forEach((userEvent) => {
+  _registerOptionEventListeners(events = {}, newEvents = {}) {
+    Object.keys(events).forEach((userEvent) => {
+      const eventType = this.eventsMapping[userEvent]
+      eventType && this.off(eventType)
+    })
+
+    Object.keys(newEvents).forEach((userEvent) => {
       const eventType = this.eventsMapping[userEvent]
       if (eventType) {
-        let eventFunction = userEvents[userEvent]
+        let eventFunction = newEvents[userEvent]
         eventFunction = typeof eventFunction === 'function' && eventFunction
         eventFunction && this.on(eventType, eventFunction)
       }
@@ -508,7 +512,8 @@ export default class Player extends BaseObject {
    * @param {Object} options all the options to change in form of a javascript object
    * @return {Player} itself
    */
-  configure(options) {
+  configure(options = {}) {
+    this._registerOptionEventListeners(this.options.events, options.events)
     this.core.configure(options)
     return this
   }

--- a/test/player_spec.js
+++ b/test/player_spec.js
@@ -67,4 +67,89 @@ describe('Player', function() {
       }
     })
   })
+
+  describe('register options event listeners', function () {
+    beforeEach(function () {
+      this.player = new Player({ source: '/video.mp4' })
+      const element = document.createElement('div')
+      this.player.attachTo(element)
+      sinon.spy(this.player, '_registerOptionEventListeners')
+    })
+
+    it('should register on configure', function () {
+      this.player.configure({
+        events: {
+          onPlay: () => {}
+        }
+      })
+
+      expect(this.player._registerOptionEventListeners).called.once
+    })
+
+    it('should call only last registered callback', function () {
+      const callbacks = {
+        callbackA: sinon.spy(),
+        callbackB: sinon.spy(),
+      }
+      this.player.configure({
+        events: {
+          onPlay: callbacks.callbackA
+        }
+      })
+
+      this.player.configure({
+        events: {
+          onPlay: callbacks.callbackB
+        }
+      })
+
+      this.player._onPlay()
+
+      expect(callbacks.callbackA).not.called
+      expect(callbacks.callbackB).called.once
+    })
+
+    it('should add a new event callback', function () {
+      const callbacks = {
+        callbackC: sinon.spy()
+      }
+      this.player.configure({
+        events: {}
+      })
+
+      this.player.configure({
+        events: {
+          onPause: callbacks.callbackC,
+        }
+      })
+
+      this.player._onPause()
+
+      expect(callbacks.callbackC).called.once
+    })
+
+    it('should remove previous event callbacks', function () {
+      const callbacks = {
+        callbackA: sinon.spy(),
+        callbackB: sinon.spy()
+      }
+      this.player.configure({
+        events: {
+          onPlay: callbacks.callbackA,
+        }
+      })
+
+      this.player.configure({
+        events: {
+          onPause: callbacks.callbackB,
+        }
+      })
+
+      this.player._onPlay()
+      this.player._onPause()
+
+      expect(callbacks.callbackA).not.called
+      expect(callbacks.callbackB).called.once
+    })
+  })
 })


### PR DESCRIPTION
In the current implementation it's only possible to define events callbacks on player constructor.

This PR changes will:

- Allow set new events on configure method;
- Remove previous option event listeners when configure is called with a net set of events;
- Add tests for register option events listeners;