### PR TITLE
Fix - Configure ignoring options when has source attribute

### DIFF
--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -340,13 +340,12 @@ export default class Core extends UIObject {
     this.configureDomRecycler()
     const sources = options.source || options.sources
 
-    if (sources) { this.load(sources, options.mimeType || this.options.mimeType) } else {
-      this.trigger(Events.CORE_OPTIONS_CHANGE)
+    if (sources) this.load(sources, options.mimeType || this.options.mimeType)
 
-      this.containers.forEach((container) => {
-        container.configure(this.options)
-      })
-    }
+    this.trigger(Events.CORE_OPTIONS_CHANGE)
+    this.containers.forEach((container) => {
+      container.configure(this.options)
+    })
   }
 
   appendToParent() {

--- a/test/components/core_spec.js
+++ b/test/components/core_spec.js
@@ -1,0 +1,44 @@
+import Core from '../../src/components/core'
+import Events from '../../src/base/events'
+
+describe('Core', function() {
+  describe('When configure', function() {
+    beforeEach(function () {
+      this.core = new Core({})
+      this.core.load = sinon.spy()
+    })
+
+    it('should update option', function() {
+      const newOptions = {
+        autoPlay: true
+      }
+      this.core.configure(newOptions)
+
+      expect(this.core.options.autoPlay).to.equal(newOptions.autoPlay)
+    })
+
+    it('should update option and load source', function() {
+      const newOptions = {
+        source: 'some/path/to/media.mp4',
+        mute: true
+      }
+      this.core.configure(newOptions)
+
+      assert.ok(this.core.load.called)
+      expect(this.core.options.mute).to.equal(newOptions.mute)
+    })
+
+    it('shoud trigger options change event', function () {
+      let callback = sinon.spy()
+      this.core.on(Events.CORE_OPTIONS_CHANGE, callback)
+
+      const newOptions = {
+        autoPlay: false
+      }
+      this.core.configure(newOptions)
+
+      assert.ok(callback.called)
+      expect(this.core.options.autoPlay).to.equal(newOptions.autoPlay)
+    })
+  })
+})


### PR DESCRIPTION
TL/DR: The current implementation ignores the options object if it has a `source` or `sources` attribute.

This will cause an incorrect behavior: when user want to reconfigure some options and load a new source (at the same time), this will not happen, because the configure method will ignore the options in favor of loading the source.

This change will ensure that the two actions (load/configure) happen.