### PR TITLE
Fix - Reset volume/mute on configure

### DIFF
--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -75,10 +75,9 @@ export default class MediaControl extends UIObject {
     this.container = options.container
     this.currentPositionValue = null
     this.currentDurationValue = null
-    const initialVolume = (this.persistConfig) ? Config.restore('volume') : 100
-    this.setVolume(this.options.mute ? 0 : initialVolume)
     this.keepVisible = false
     this.fullScreenOnVideoTagSupported = null // unknown
+    this.setInitialVolume()
     this.addEventListeners()
     this.settings = {
       left: ['play', 'stop', 'pause'],
@@ -119,6 +118,7 @@ export default class MediaControl extends UIObject {
       this.listenTo(this.container, Events.CONTAINER_MEDIACONTROL_ENABLE, this.enable)
       this.listenTo(this.container, Events.CONTAINER_ENDED, this.ended)
       this.listenTo(this.container, Events.CONTAINER_VOLUME, this.onVolumeChanged)
+      this.listenTo(this.container, Events.CONTAINER_OPTIONS_CHANGE, this.setInitialVolume)
       if (this.container.playback.el.nodeName.toLowerCase() === 'video') {
         // wait until the metadata has loaded and then check if fullscreen on video tag is supported
         this.listenToOnce(this.container, Events.CONTAINER_LOADEDMETADATA, this.onLoadedMetadataOnVideoTag)
@@ -148,6 +148,12 @@ export default class MediaControl extends UIObject {
 
   stop() {
     this.container.stop()
+  }
+
+  setInitialVolume() {
+    const initialVolume = (this.persistConfig) ? Config.restore('volume') : 100
+    const options = this.container && this.container.options || this.options
+    this.setVolume(options.mute ? 0 : initialVolume)
   }
 
   onVolumeChanged() {

--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -153,7 +153,7 @@ export default class MediaControl extends UIObject {
   setInitialVolume() {
     const initialVolume = (this.persistConfig) ? Config.restore('volume') : 100
     const options = this.container && this.container.options || this.options
-    this.setVolume(options.mute ? 0 : initialVolume)
+    this.setVolume(options.mute ? 0 : initialVolume, true)
   }
 
   onVolumeChanged() {
@@ -324,13 +324,13 @@ export default class MediaControl extends UIObject {
     this.setVolume(this.muted ? 100 : 0)
   }
 
-  setVolume(value) {
+  setVolume(value, isInitialVolume = false) {
     value = Math.min(100, Math.max(value, 0))
     // this will hold the intended volume
     // it may not actually get set to this straight away
     // if the container is not ready etc
     this.intendedVolume = value
-    this.persistConfig && Config.persist('volume', value)
+    this.persistConfig && !isInitialVolume && Config.persist('volume', value)
     const setWhenContainerReady = () => {
       if (this.container.isReady) { this.container.setVolume(value) } else {
         this.listenToOnce(this.container, Events.CONTAINER_READY, () => {
@@ -361,7 +361,7 @@ export default class MediaControl extends UIObject {
     Mediator.off(`${this.options.playerId}:${Events.PLAYER_RESIZE}`, this.playerResize, this)
     this.container = container
     // set the new container to match the volume of the last one
-    this.setVolume(this.intendedVolume)
+    this.setVolume(this.intendedVolume, true)
     this.changeTogglePlay()
     this.addEventListeners()
     this.settingsUpdate()

--- a/test/components/media_control_spec.js
+++ b/test/components/media_control_spec.js
@@ -91,6 +91,15 @@ describe('MediaControl', function() {
 
       expect(mediacontrol.volume).to.be.equal(100)
     })
+
+    it('do not persist when is initial volume', function () {
+      Config.persist = sinon.spy()
+
+      const container = new Container({ playback: this.playback, mute: false })
+      const mediacontrol = new MediaControl({ persistConfig: true, container })
+
+      Config.persist.should.not.have.been.called
+    })
   })
 
   it('persists volume when persistence is on', function() {

--- a/test/components/media_control_spec.js
+++ b/test/components/media_control_spec.js
@@ -18,7 +18,8 @@ describe('MediaControl', function() {
 
   describe('#constructor', function() {
     it('can be built muted', function() {
-      const mediaControl = new MediaControl({ mute: true, container: this.container })
+      const container = new Container({ playback: this.playback, mute: true })
+      const mediaControl = new MediaControl({ container })
       expect(mediaControl.muted).to.be.equal(true)
       expect(mediaControl.volume).to.be.equal(0)
     })
@@ -81,6 +82,15 @@ describe('MediaControl', function() {
 
       expect(Config.restore('volume')).to.be.equal(78)
     })
+
+    it('reset volume after configure', function () {
+      const container = new Container({ playback: this.playback, mute: true })
+      const mediacontrol = new MediaControl({ persistConfig: true, container })
+
+      container.configure({ mute: false })
+
+      expect(mediacontrol.volume).to.be.equal(100)
+    })
   })
 
   it('persists volume when persistence is on', function() {
@@ -119,7 +129,8 @@ describe('MediaControl', function() {
         constructor(options) { super(options) }
       }
 
-      const mediaControl = new MyMediaControl({ mute: true, container: this.container })
+      const container = new Container({ playback: this.playback, mute: true })
+      const mediaControl = new MyMediaControl({ container })
       mediaControl.render()
       expect(mediaControl.muted).to.be.equal(true)
       expect(mediaControl.volume).to.be.equal(0)


### PR DESCRIPTION
- **Issue 1:**

When reconfigure player, the mute option is ignored.
This change will allow reset the volume applying current mute option value.

- **Issue 2:**

Prevent the initial volume value from being persisted in the localStorage.
Possible issues: When a player instance is created with mute option enabled, the value 0 is persisted. When a new instance is created without this option (or mute=false), the 0 value will be restored as initial volume, causing an inconsistency.
