### PR TITLE
Fix disappearing hd indicator after render

### DIFF
--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -518,6 +518,7 @@ export default class MediaControl extends UIObject {
   }
 
   highDefinitionUpdate(isHD) {
+    this.isHD = isHD
     const method = isHD ? 'addClass' : 'removeClass'
     this.$hdIndicator[method]('enabled')
   }
@@ -689,7 +690,7 @@ export default class MediaControl extends UIObject {
     })
 
     this.parseColors()
-    this.highDefinitionUpdate()
+    this.highDefinitionUpdate(this.isHD)
 
     this.rendered = true
     this.updateVolumeUI()


### PR DESCRIPTION
HD indicator disappears after calling render in case of settings update.
But it appears after stopping and starting playback.