### PR TITLE
Fix chromeless mobile

### DIFF
--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -483,8 +483,7 @@ export default class MediaControl extends UIObject {
   }
 
   hide(delay = 0) {
-    if (!this.isVisible() || (Browser.isMobile && !this.container.isPlaying()))
-      return
+    if (!this.isVisible()) return
 
     const timeout = delay || 2000
     clearTimeout(this.hideId)

--- a/test/components/media_control_spec.js
+++ b/test/components/media_control_spec.js
@@ -120,15 +120,23 @@ describe('MediaControl', function() {
     expect(mediaControl.disabled).to.be.false
   })
 
-  it('never appears when playback type is NO_OP', function() {
-    this.playback.getPlaybackType = function() {
-      return Playback.NO_OP
-    }
-    const mediaControl = new MediaControl({ container: this.container })
-    mediaControl.render()
-    mediaControl.enable()
-    expect(mediaControl.$el.hasClass('media-control-hide')).to.be.true
-    expect(mediaControl.disabled).to.be.true
+  describe('never appears when', function() {
+    it('playback type is NO_OP', function() {
+      this.playback.getPlaybackType = function() {
+        return Playback.NO_OP
+      }
+      const mediaControl = new MediaControl({ container: this.container })
+      mediaControl.render()
+      mediaControl.enable()
+      expect(mediaControl.$el.hasClass('media-control-hide')).to.be.true
+      expect(mediaControl.disabled).to.be.true
+    })
+
+    it('option chromeless has value true', function() {
+      const mediaControl = new MediaControl({ container: this.container, chromeless: true }).render()
+      expect(mediaControl.$el.hasClass('media-control-hide')).to.be.true
+      expect(mediaControl.disabled).to.be.true
+    })
   })
 
   describe('custom media control', function() {


### PR DESCRIPTION
resolve #1366 removing `this.container.isPlaying()` condition for mobile devices.
Add test on `media_control_spec.js` for chromeless option with value `true`.