### PR TITLE
Remove unnecessary files from node_modules

### DIFF
--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,44 @@
+# test directories
+__tests__
+test
+tests
+powered-test
+
+# asset directories
+docs
+doc
+website
+images
+
+# examples
+example
+examples
+
+# code coverage directories
+coverage
+.nyc_output
+
+# build scripts
+Makefile
+Gulpfile.js
+Gruntfile.js
+
+# configs
+appveyor.yml
+circle.yml
+codeship-services.yml
+codeship-steps.yml
+wercker.yml
+.tern-project
+.gitattributes
+.editorconfig
+.*ignore
+.eslintrc
+.jshintrc
+.flowconfig
+.documentup.json
+.yarn-metadata.json
+.travis.yml
+
+# misc
+*.md

--- a/.yarnclean
+++ b/.yarnclean
@@ -33,8 +33,6 @@ wercker.yml
 .gitattributes
 .editorconfig
 .*ignore
-.eslintrc
-.jshintrc
 .flowconfig
 .documentup.json
 .yarn-metadata.json


### PR DESCRIPTION
_The `autoclean` command frees up space by removing unnecessary files and folders from dependencies. It reduces the number of files in your project’s `node_modules` folder ..._

**ref.:** https://yarnpkg.com/lang/en/docs/cli/autoclean/

------
## Before
![screen shot 2018-03-03 at 12 46 08 pm](https://user-images.githubusercontent.com/5631063/36988998-299a6e6c-207f-11e8-9a7b-b6543ede0ca7.png)

## After
![screen shot 2018-03-03 at 12 46 21 pm](https://user-images.githubusercontent.com/5631063/36989039-459bbc38-207f-11e8-9709-df7287219973.png)
