### PR TITLE
Improve links in troubleshooting docs

### DIFF
--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -18,7 +18,7 @@ Very often people open issues related to: **stream not working, freezing, glitch
 
 * try to run the same example at [cdn](cdn.clappr.io)
 * check the [cors headers at your servers](https://github.com/clappr/clappr/issues/703)
-* try to run it on [hls.js demo page](http://dailymotion.github.io/hls.js/demo/)
+* try to run it on [hls.js demo page](https://video-dev.github.io/hls.js/demo/)
 * try to run it on [flashls. demo page](http://www.flashls.org/latest/examples/chromeless/)
 * try to run on your page the following source: `http://www.streambox.fr/playlists/x36xhzz/x36xhzz.m3u8`
 * try different browsers/OS's to see if the problems remain

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -22,7 +22,7 @@ Very often people open issues related to: **stream not working, freezing, glitch
 * try to run it on [flashls. demo page](http://www.flashls.org/latest/examples/chromeless/)
 * try to run on your page the following source: `http://www.streambox.fr/playlists/x36xhzz/x36xhzz.m3u8`
 * try different browsers/OS's to see if the problems remain
-* try to use a tool to check the health of your stream (both input, ie: RTMP, and segmentation, ie: DASH or HLS): like `mediainfo` (for instance you could: ` mediainfo http://www.example.com/my.m3u8`, `mediastreamvalidator`, [`hls-analyzer`](https://github.com/epiclabs-io/hls-analyzer) and etc.
+* try to use a tool to check the health of your stream (both input, ie: RTMP, and segmentation, ie: DASH or HLS): like [`mediainfo`](https://mediaarea.net/MediaInfo) (for instance you could: ` mediainfo http://www.example.com/my.m3u8`, Apple's [`mediastreamvalidator`](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StreamingMediaGuide/UsingHTTPLiveStreaming/UsingHTTPLiveStreaming.html) too, [`hls-analyzer`](https://github.com/epiclabs-io/hls-analyzer) and etc.
 
 ##### HLS-Analyzer usage example
 ```bash


### PR DESCRIPTION
This corrects the link to the hls.js demo and adds links to the other tools mentioned in the TROUBLESHOOTING doc page.