### PR TITLE
HTML5 Video: Avoid empty source error on destroy

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -390,7 +390,7 @@ export default class HTML5Video extends Playback {
     this._destroyed = true
     this.handleTextTrackChange && this.el.textTracks.removeEventListener('change', this.handleTextTrackChange)
     this.$el.remove()
-    this.el.src = ''
+    delete this.el.src
     this._src = null
     DomRecycler.garbage(this.$el)
   }


### PR DESCRIPTION
Delete src attribute on destroy instead set empty source.
This change will avoid the following HTML5 Video error:
```Code: 4, MEDIA_ELEMENT_ERROR: Empty src attribute```

![screen shot 2018-03-27 at 5 43 42 pm](https://user-images.githubusercontent.com/1696024/37994180-2381a508-31e7-11e8-8d42-b0447b387c45.png)
