### PR TITLE
Feature/error component

### DIFF
--- a/src/base/events.js
+++ b/src/base/events.js
@@ -282,7 +282,7 @@ Events.PLAYER_SEEK = 'seek'
  * @event PLAYER_ERROR
  * @param {Object} error the error
  */
-Events.PLAYER_ERROR = 'error'
+Events.PLAYER_ERROR = 'playererror'
 /**
  * Fired when the time is updated on player
  *

--- a/src/base/events.js
+++ b/src/base/events.js
@@ -289,6 +289,18 @@ Events.PLAYER_ERROR = 'playererror'
  * @event ERROR
  * @param {Object} error
  * the error with the following format `{code, description, level, raw, origin, scope}`
+ * @param {String} [options.code]
+ * error's code: code to identify error in the following format: origin:code
+ * @param {String} [options.description]
+ * error's description: description of the error
+ * @param {String} [options.level]
+ * error's level: FATAL or WARN.
+ * @param {String} [options.origin]
+ * error's origin. Example: hls, html5, etc
+ * @param {String} [options.scope]
+ * error's scope. Example: playback, container, etc
+ * @param {String} [options.raw]
+ * raw error: the initial error received
  */
 Events.ERROR = 'error'
 /**

--- a/src/base/events.js
+++ b/src/base/events.js
@@ -284,6 +284,14 @@ Events.PLAYER_SEEK = 'seek'
  */
 Events.PLAYER_ERROR = 'playererror'
 /**
+ * Fired when there is an error
+ *
+ * @event ERROR
+ * @param {Object} error
+ * the error with the following format `{code, description, level, raw, origin, scope}`
+ */
+Events.ERROR = 'error'
+/**
  * Fired when the time is updated on player
  *
  * @event PLAYER_TIMEUPDATE

--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -1,5 +1,6 @@
 import { extend } from './utils'
 import UIObject from './ui_object'
+import PlayerError from '../components/error'
 
 /**
  * An abstraction to represent a generic playback, it's like an interface to be implemented by subclasses.
@@ -85,6 +86,30 @@ export default class Playback extends UIObject {
    * @method stop
    */
   stop() {}
+
+  /**
+   * creates playback error.
+   * @method createError
+   * @param {Object} error should be an object with code, description, level and raw error.
+   * @return {Object} Object with formatted error data including origin and scope
+   */
+  createError(error) {
+    const defaultError = {
+      description: '',
+      level: PlayerError.Levels.FATAL,
+      origin: this.name,
+      scope: 'playback',
+      raw: {},
+    }
+
+    const errorData = Object.assign(defaultError, error, {
+      code: `${this.name}:${error.code || 'unknown'}`
+    })
+
+    PlayerError.error(errorData)
+
+    return errorData
+  }
 
   /**
    * seeks the playback to a given `time` in seconds

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -11,6 +11,7 @@ import ContainerFactory from '../../components/container_factory'
 import MediaControl from '../../components/media_control'
 import Mediator from '../../components/mediator'
 import PlayerInfo from '../../components/player_info'
+import PlayerError from '../../components/error'
 
 import Styler from '../../base/styler'
 
@@ -77,6 +78,7 @@ export default class Core extends UIObject {
     $(document).bind('MSFullscreenChange', this._boundFullscreenHandler)
     $(document).bind('mozfullscreenchange', this._boundFullscreenHandler)
     Browser.isMobile && $(window).bind('resize', (o) => { this.handleWindowResize(o) })
+    PlayerError.setCore(this)
   }
 
   configureDomRecycler() {

--- a/src/components/error/error.js
+++ b/src/components/error/error.js
@@ -1,0 +1,46 @@
+import Events from '../../base/events'
+import BaseObject from '../../base/base_object'
+
+/**
+ * The PlayerError is responsible to receive and propagate errors.
+ * @class PlayerError
+ * @constructor
+ * @extends BaseObject
+ * @module components
+ */
+class PlayerError extends BaseObject {
+  get name() { return 'error' }
+
+  /**
+   * @property Levels
+   * @type {Object} object with error levels
+   */
+  get Levels() {
+    return {
+      FATAL: 'FATAL',
+      WARN: 'WARN'
+    }
+  }
+
+  constructor(options={}) {
+    super(options)
+  }
+
+  /**
+   * creates and trigger an error.
+   * @method error
+   * @param {Object} err should be an object with code, description, level, origin, scope and raw error.
+   */
+  error(err) {
+    this.core.trigger(Events.ERROR, err)
+  }
+
+  setCore(core) {
+    this.core = core
+  }
+
+}
+
+const playerError = new PlayerError()
+
+export default playerError

--- a/src/components/error/error.js
+++ b/src/components/error/error.js
@@ -1,5 +1,6 @@
 import Events from '../../base/events'
 import BaseObject from '../../base/base_object'
+import Log from '../../plugins/log'
 
 /**
  * The PlayerError is responsible to receive and propagate errors.
@@ -32,6 +33,10 @@ class PlayerError extends BaseObject {
    * @param {Object} err should be an object with code, description, level, origin, scope and raw error.
    */
   error(err) {
+    if (!this.core) {
+      Log.warn(this.name, 'Core is not setted. Error: ', err)
+      return
+    }
     this.core.trigger(Events.ERROR, err)
   }
 

--- a/src/components/error/index.js
+++ b/src/components/error/index.js
@@ -1,0 +1,2 @@
+import Error from './error'
+export default Error

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -8,6 +8,7 @@ import template from '../../base/template'
 import Playback from '../../base/playback'
 import Mediator from '../../components/mediator'
 import Browser from '../../components/browser'
+import PlayerError from '../../components/error'
 import HLSEvents from './flashls_events'
 import hlsSwf from './public/HLSPlayer.swf'
 import $ from 'clappr-zepto'
@@ -151,11 +152,17 @@ export default class FlasHLS extends BaseFlashPlayback {
       this.trigger(Events.PLAYBACK_READY, this.name)
     } else {
       this._bootstrapAttempts = this._bootstrapAttempts || 0
-      if (++this._bootstrapAttempts <= MAX_ATTEMPTS)
+      if (++this._bootstrapAttempts <= MAX_ATTEMPTS) {
         setTimeout(() => this._bootstrap(), 50)
-      else
+      } else {
+        this.createError({
+          code: `playerLoadFail_maxNumberAttemptsReached`,
+          description: `${this.name} error: Max number of attempts reached`,
+          level: PlayerError.Levels.FATAL,
+          raw: {},
+        })
         this.trigger(Events.PLAYBACK_ERROR, { message: 'Max number of attempts reached' }, this.name)
-
+      }
     }
   }
 
@@ -632,6 +639,13 @@ export default class FlasHLS extends BaseFlashPlayback {
   }
 
   _flashPlaybackError(code, url, message) {
+    const error = {
+      code,
+      description: message,
+      level: PlayerError.Levels.FATAL,
+      raw: { code, url, message },
+    }
+    this.createError(error)
     this.trigger(Events.PLAYBACK_ERROR, { code: code, url: url, message: message })
     this.trigger(Events.PLAYBACK_STOP)
   }

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -155,13 +155,13 @@ export default class FlasHLS extends BaseFlashPlayback {
       if (++this._bootstrapAttempts <= MAX_ATTEMPTS) {
         setTimeout(() => this._bootstrap(), 50)
       } else {
-        this.createError({
-          code: `playerLoadFail_maxNumberAttemptsReached`,
+        const formattedError = this.createError({
+          code: 'playerLoadFail_maxNumberAttemptsReached',
           description: `${this.name} error: Max number of attempts reached`,
           level: PlayerError.Levels.FATAL,
           raw: {},
         })
-        this.trigger(Events.PLAYBACK_ERROR, { message: 'Max number of attempts reached' }, this.name)
+        this.trigger(Events.PLAYBACK_ERROR, formattedError)
       }
     }
   }
@@ -645,8 +645,8 @@ export default class FlasHLS extends BaseFlashPlayback {
       level: PlayerError.Levels.FATAL,
       raw: { code, url, message },
     }
-    this.createError(error)
-    this.trigger(Events.PLAYBACK_ERROR, { code: code, url: url, message: message })
+    const formattedError = this.createError(error)
+    this.trigger(Events.PLAYBACK_ERROR, formattedError)
     this.trigger(Events.PLAYBACK_STOP)
   }
 

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -294,7 +294,6 @@ export default class HLS extends HTML5VideoPlayback {
           case HLSJS.ErrorDetails.LEVEL_LOAD_ERROR:
           case HLSJS.ErrorDetails.LEVEL_LOAD_TIMEOUT:
             Log.error('hlsjs: unrecoverable network fatal error.', { evt, data })
-            error.level = PlayerError.Levels.FATAL
             formattedError = this.createError(error)
             this.trigger(Events.PLAYBACK_ERROR, formattedError)
             break
@@ -314,14 +313,12 @@ export default class HLS extends HTML5VideoPlayback {
           break
         default:
           Log.error('hlsjs: could not recover from error.', { evt, data })
-          error.level = PlayerError.Levels.FATAL
           formattedError = this.createError(error)
           this.trigger(Events.PLAYBACK_ERROR, formattedError)
           break
         }
       } else {
         Log.error('hlsjs: could not recover from error after maximum number of attempts.', { evt, data })
-        error.level = PlayerError.Levels.FATAL
         formattedError = this.createError(error)
         this.trigger(Events.PLAYBACK_ERROR, formattedError)
       }

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -184,8 +184,8 @@ export default class HLS extends HTML5VideoPlayback {
     } else {
       Log.error('hlsjs: failed to recover', { evt, data })
       error.level = PlayerError.Levels.FATAL
-      this.createError(error)
-      this.trigger(Events.PLAYBACK_ERROR, `hlsjs: could not recover from error, evt ${evt}, data ${data} `, this.name)
+      const formattedError = this.createError(error)
+      this.trigger(Events.PLAYBACK_ERROR, formattedError)
     }
   }
 
@@ -275,6 +275,7 @@ export default class HLS extends HTML5VideoPlayback {
       description: `${this.name} error: type: ${data.type}, details: ${data.details}`,
       raw: data,
     }
+    let formattedError
     if (data.response) error.description += `, response: ${JSON.stringify(data.response)}`
     // only report/handle errors if they are fatal
     // hlsjs should automatically handle non fatal errors
@@ -294,8 +295,8 @@ export default class HLS extends HTML5VideoPlayback {
           case HLSJS.ErrorDetails.LEVEL_LOAD_TIMEOUT:
             Log.error('hlsjs: unrecoverable network fatal error.', { evt, data })
             error.level = PlayerError.Levels.FATAL
-            this.createError(error)
-            this.trigger(Events.PLAYBACK_ERROR, { evt, data }, this.name)
+            formattedError = this.createError(error)
+            this.trigger(Events.PLAYBACK_ERROR, formattedError)
             break
           default:
             Log.warn('hlsjs: trying to recover from network error.', { evt, data })
@@ -314,15 +315,15 @@ export default class HLS extends HTML5VideoPlayback {
         default:
           Log.error('hlsjs: could not recover from error.', { evt, data })
           error.level = PlayerError.Levels.FATAL
-          this.createError(error)
-          this.trigger(Events.PLAYBACK_ERROR, `hlsjs: could not recover from error, evt ${evt}, data ${data} `, this.name)
+          formattedError = this.createError(error)
+          this.trigger(Events.PLAYBACK_ERROR, formattedError)
           break
         }
       } else {
         Log.error('hlsjs: could not recover from error after maximum number of attempts.', { evt, data })
         error.level = PlayerError.Levels.FATAL
-        this.createError(error)
-        this.trigger(Events.PLAYBACK_ERROR, { evt, data }, this.name)
+        formattedError = this.createError(error)
+        this.trigger(Events.PLAYBACK_ERROR, formattedError)
       }
     } else {
       error.level = PlayerError.Levels.WARN

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -182,7 +182,7 @@ export default class HLS extends HTML5VideoPlayback {
       this._hls.swapAudioCodec()
       this._hls.recoverMediaError()
     } else {
-      Log.error('hlsjs: failed to recover')
+      Log.error('hlsjs: failed to recover', { evt, data })
       error.level = PlayerError.Levels.FATAL
       this.createError(error)
       this.trigger(Events.PLAYBACK_ERROR, `hlsjs: could not recover from error, evt ${evt}, data ${data} `, this.name)
@@ -292,13 +292,13 @@ export default class HLS extends HTML5VideoPlayback {
           case HLSJS.ErrorDetails.MANIFEST_PARSING_ERROR:
           case HLSJS.ErrorDetails.LEVEL_LOAD_ERROR:
           case HLSJS.ErrorDetails.LEVEL_LOAD_TIMEOUT:
-            Log.error(`hlsjs: unrecoverable network fatal error, evt ${evt}, data ${data} `)
+            Log.error('hlsjs: unrecoverable network fatal error.', { evt, data })
             error.level = PlayerError.Levels.FATAL
             this.createError(error)
             this.trigger(Events.PLAYBACK_ERROR, { evt, data }, this.name)
             break
           default:
-            Log.warn(`hlsjs: trying to recover from network error, evt ${evt}, data ${data} `)
+            Log.warn('hlsjs: trying to recover from network error.', { evt, data })
             error.level = PlayerError.Levels.WARN
             this.createError(error)
             this._hls.startLoad()
@@ -306,20 +306,20 @@ export default class HLS extends HTML5VideoPlayback {
           }
           break
         case HLSJS.ErrorTypes.MEDIA_ERROR:
-          Log.warn(`hlsjs: trying to recover from media error, evt ${evt}, data ${data} `)
+          Log.warn('hlsjs: trying to recover from media error.', { evt, data })
           error.level = PlayerError.Levels.WARN
           this.createError(error)
           this._recover(evt, data, error)
           break
         default:
-          Log.error(`hlsjs: trying to recover from error, evt ${evt}, data ${data} `)
+          Log.error('hlsjs: could not recover from error.', { evt, data })
           error.level = PlayerError.Levels.FATAL
           this.createError(error)
           this.trigger(Events.PLAYBACK_ERROR, `hlsjs: could not recover from error, evt ${evt}, data ${data} `, this.name)
           break
         }
       } else {
-        Log.error(`hlsjs: could not recover from error after maximum number of attempts, evt ${evt}, data ${data} `)
+        Log.error('hlsjs: could not recover from error after maximum number of attempts.', { evt, data })
         error.level = PlayerError.Levels.FATAL
         this.createError(error)
         this.trigger(Events.PLAYBACK_ERROR, { evt, data }, this.name)
@@ -327,7 +327,7 @@ export default class HLS extends HTML5VideoPlayback {
     } else {
       error.level = PlayerError.Levels.WARN
       this.createError(error)
-      Log.warn(`hlsjs: non-fatal error occurred, evt ${evt}, data ${data} `)
+      Log.warn('hlsjs: non-fatal error occurred', { evt, data })
     }
   }
 

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -391,7 +391,7 @@ export default class HTML5Video extends Playback {
       raw: this.el.error,
     })
 
-    this.trigger(Events.PLAYBACK_ERROR, this.el.error, this.name)
+    this.trigger(Events.PLAYBACK_ERROR, formattedError)
   }
 
   destroy() {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -383,6 +383,14 @@ export default class HTML5Video extends Playback {
   }
 
   _onError() {
+    const { code, message } = this.el.error
+
+    const formattedError = this.createError({
+      code,
+      description: message,
+      raw: this.el.error,
+    })
+
     this.trigger(Events.PLAYBACK_ERROR, this.el.error, this.name)
   }
 


### PR DESCRIPTION
To normalize errors and create a pattern to them a new error component is being created. 

Initially only playback errors are being changed to this new format, but errors from other layers can adopt this new format too.

This component will trigger a new error event that contains data that can be useful to, for example, an error screen plugin render information to users.

This new error format contains: 

**code**: the error code
**description**: error description
**level**:  warn or fatal
**origin**: hls, html5, etc
**scope**: playback, container, etc
**raw error**: the error without modification