### PR TITLE
Feature/error component

### DIFF
--- a/src/base/container_plugin.js
+++ b/src/base/container_plugin.js
@@ -1,5 +1,6 @@
 import BaseObject from './base_object'
 import { extend } from './utils'
+import ErrorMixin from './error_mixin'
 
 /**
  * The base class for a container plugin
@@ -9,6 +10,8 @@ import { extend } from './utils'
  * @module base
  */
 export default class ContainerPlugin extends BaseObject {
+  get playerError() { return this.container.playerError }
+
   constructor(container) {
     super(container.options)
     this.container = container
@@ -36,6 +39,8 @@ export default class ContainerPlugin extends BaseObject {
     this.stopListening()
   }
 }
+
+Object.assign(ContainerPlugin.prototype, ErrorMixin)
 
 ContainerPlugin.extend = function(properties) {
   return extend(ContainerPlugin, properties)

--- a/src/base/core_plugin.js
+++ b/src/base/core_plugin.js
@@ -1,7 +1,10 @@
 import { extend } from './utils'
 import BaseObject from './base_object'
+import ErrorMixin from './error_mixin'
 
 export default class CorePlugin extends BaseObject {
+  get playerError() { return this.core.playerError }
+
   constructor(core) {
     super(core.options)
     this.core = core
@@ -31,6 +34,8 @@ export default class CorePlugin extends BaseObject {
     this.stopListening()
   }
 }
+
+Object.assign(CorePlugin.prototype, ErrorMixin)
 
 CorePlugin.extend = function(properties) {
   return extend(CorePlugin, properties)

--- a/src/base/error_mixin.js
+++ b/src/base/error_mixin.js
@@ -1,0 +1,36 @@
+import Log from '../plugins/log'
+import PlayerError from '../components/error'
+
+const ErrorMixin = {
+  /**
+   * creates an error.
+   * @method createError
+   * @param {Object} error should be an object with code, description, level and raw error.
+   * @return {Object} Object with formatted error data including origin and scope
+   */
+  createError(error) {
+    !this.name && (this.name = this.constructor && this.constructor.type || 'errorMixin')
+    if (!this.playerError) {
+      Log.warn(this.name, 'PlayerError is not defined. Error: ', error)
+      return error
+    }
+
+    const defaultError = {
+      description: '',
+      level: PlayerError.Levels.FATAL,
+      origin: this.name,
+      scope: this.name,
+      raw: {},
+    }
+
+    const errorData = Object.assign({}, defaultError, error, {
+      code: `${this.name}:${error && error.code || 'unknown'}`
+    })
+
+    this.playerError.error(errorData)
+
+    return errorData
+  }
+}
+
+export default ErrorMixin

--- a/src/base/error_mixin.js
+++ b/src/base/error_mixin.js
@@ -9,7 +9,7 @@ const ErrorMixin = {
    * @return {Object} Object with formatted error data including origin and scope
    */
   createError(error) {
-    const scope = this.constructor && this.constructor.type || 'errorMixin'
+    const scope = this.constructor && this.constructor.type || ''
     const origin = this.name || scope
 
     const defaultError = {

--- a/src/base/error_mixin.js
+++ b/src/base/error_mixin.js
@@ -9,25 +9,25 @@ const ErrorMixin = {
    * @return {Object} Object with formatted error data including origin and scope
    */
   createError(error) {
-    !this.name && (this.name = this.constructor && this.constructor.type || 'errorMixin')
-    if (!this.playerError) {
-      Log.warn(this.name, 'PlayerError is not defined. Error: ', error)
-      return error
-    }
+    const scope = this.constructor && this.constructor.type || 'errorMixin'
+    const origin = this.name || scope
 
     const defaultError = {
       description: '',
       level: PlayerError.Levels.FATAL,
-      origin: this.name,
-      scope: this.name,
+      origin,
+      scope,
       raw: {},
     }
 
     const errorData = Object.assign({}, defaultError, error, {
-      code: `${this.name}:${error && error.code || 'unknown'}`
+      code: `${origin}:${error && error.code || 'unknown'}`
     })
 
-    this.playerError.error(errorData)
+    if (this.playerError)
+      this.playerError.error(errorData)
+    else
+      Log.warn(origin, 'PlayerError is not defined. Error: ', errorData)
 
     return errorData
   }

--- a/src/base/events.js
+++ b/src/base/events.js
@@ -282,7 +282,7 @@ Events.PLAYER_SEEK = 'seek'
  * @event PLAYER_ERROR
  * @param {Object} error the error
  */
-Events.PLAYER_ERROR = 'error'
+Events.PLAYER_ERROR = 'playererror'
 /**
  * Fired when the time is updated on player
  *

--- a/src/base/events.js
+++ b/src/base/events.js
@@ -289,6 +289,18 @@ Events.PLAYER_ERROR = 'playererror'
  * @event ERROR
  * @param {Object} error
  * the error with the following format `{code, description, level, raw, origin, scope}`
+ * @param {String} [options.code]
+ * error's code: code to identify error in the following format: origin:code
+ * @param {String} [options.description]
+ * error's description: description of the error
+ * @param {String} [options.level]
+ * error's level: FATAL or WARN.
+ * @param {String} [options.origin]
+ * error's origin. Example: hls, html5, etc
+ * @param {String} [options.scope]
+ * error's scope. Example: playback, container, etc
+ * @param {String} [options.raw]
+ * raw error: the initial error received
  */
 Events.ERROR = 'error'
 /**

--- a/src/base/events.js
+++ b/src/base/events.js
@@ -284,6 +284,14 @@ Events.PLAYER_SEEK = 'seek'
  */
 Events.PLAYER_ERROR = 'playererror'
 /**
+ * Fired when there is an error
+ *
+ * @event ERROR
+ * @param {Object} error
+ * the error with the following format `{code, description, level, raw, origin, scope}`
+ */
+Events.ERROR = 'error'
+/**
  * Fired when the time is updated on player
  *
  * @event PLAYER_TIMEUPDATE

--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -107,7 +107,10 @@ export default class Playback extends UIObject {
       code: `${this.name}:${error && error.code || 'unknown'}`
     })
 
-    this.playerError.error(errorData)
+    if (this.playerError)
+      this.playerError.error(errorData)
+    else
+      Log.warn(this.name, 'PlayerError is not defined. Error: ', err)
 
     return errorData
   }

--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -1,5 +1,6 @@
 import { extend } from './utils'
 import UIObject from './ui_object'
+import PlayerError from '../components/error'
 
 /**
  * An abstraction to represent a generic playback, it's like an interface to be implemented by subclasses.
@@ -85,6 +86,30 @@ export default class Playback extends UIObject {
    * @method stop
    */
   stop() {}
+
+  /**
+   * creates playback error.
+   * @method createError
+   * @param {Object} error should be an object with code, description, level and raw error.
+   * @return {Object} Object with formatted error data including origin and scope
+   */
+  createError(error) {
+    const defaultError = {
+      description: '',
+      level: PlayerError.Levels.FATAL,
+      origin: this.name,
+      scope: 'playback',
+      raw: {},
+    }
+
+    const errorData = Object.assign(defaultError, error, {
+      code: `${this.name}:${error.code || 'unknown'}`
+    })
+
+    PlayerError.error(errorData)
+
+    return errorData
+  }
 
   /**
    * seeks the playback to a given `time` in seconds

--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -104,7 +104,7 @@ export default class Playback extends UIObject {
     }
 
     const errorData = Object.assign(defaultError, error, {
-      code: `${this.name}:${error.code || 'unknown'}`
+      code: `${this.name}:${error && error.code || 'unknown'}`
     })
 
     PlayerError.error(errorData)

--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -1,6 +1,5 @@
 import { extend } from './utils'
 import UIObject from './ui_object'
-import PlayerError from '../components/error'
 
 /**
  * An abstraction to represent a generic playback, it's like an interface to be implemented by subclasses.
@@ -57,10 +56,11 @@ export default class Playback extends UIObject {
    * @param {Object} options the options object
    * @param {Strings} i18n the internationalization component
    */
-  constructor(options, i18n) {
+  constructor(options, i18n, playerError) {
     super(options)
     this.settings = {}
     this._i18n = i18n
+    this.playerError = playerError
   }
 
   /**
@@ -97,7 +97,7 @@ export default class Playback extends UIObject {
     !this.name && (this.name = 'playback')
     const defaultError = {
       description: '',
-      level: PlayerError.Levels.FATAL,
+      level: this.playerError.Levels.FATAL,
       origin: this.name,
       scope: 'playback',
       raw: {},
@@ -107,7 +107,7 @@ export default class Playback extends UIObject {
       code: `${this.name}:${error && error.code || 'unknown'}`
     })
 
-    PlayerError.error(errorData)
+    this.playerError.error(errorData)
 
     return errorData
   }

--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -1,6 +1,6 @@
 import { extend } from './utils'
 import UIObject from './ui_object'
-import PlayerError from '../components/error'
+import ErrorMixin from './error_mixin'
 
 /**
  * An abstraction to represent a generic playback, it's like an interface to be implemented by subclasses.
@@ -87,34 +87,6 @@ export default class Playback extends UIObject {
    * @method stop
    */
   stop() {}
-
-  /**
-   * creates playback error.
-   * @method createError
-   * @param {Object} error should be an object with code, description, level and raw error.
-   * @return {Object} Object with formatted error data including origin and scope
-   */
-  createError(error) {
-    !this.name && (this.name = 'playback')
-    const defaultError = {
-      description: '',
-      level: PlayerError.Levels.FATAL,
-      origin: this.name,
-      scope: 'playback',
-      raw: {},
-    }
-
-    const errorData = Object.assign(defaultError, error, {
-      code: `${this.name}:${error && error.code || 'unknown'}`
-    })
-
-    if (this.playerError)
-      this.playerError.error(errorData)
-    else
-      Log.warn(this.name, 'PlayerError is not defined. Error: ', err)
-
-    return errorData
-  }
 
   /**
    * seeks the playback to a given `time` in seconds
@@ -239,6 +211,8 @@ export default class Playback extends UIObject {
     this.$el.remove()
   }
 }
+
+Object.assign(Playback.prototype, ErrorMixin)
 
 Playback.extend = function(properties) {
   return extend(Playback, properties)

--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -94,6 +94,7 @@ export default class Playback extends UIObject {
    * @return {Object} Object with formatted error data including origin and scope
    */
   createError(error) {
+    !this.name && (this.name = 'playback')
     const defaultError = {
       description: '',
       level: PlayerError.Levels.FATAL,

--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -1,5 +1,6 @@
 import { extend } from './utils'
 import UIObject from './ui_object'
+import PlayerError from '../components/error'
 
 /**
  * An abstraction to represent a generic playback, it's like an interface to be implemented by subclasses.
@@ -97,7 +98,7 @@ export default class Playback extends UIObject {
     !this.name && (this.name = 'playback')
     const defaultError = {
       description: '',
-      level: this.playerError.Levels.FATAL,
+      level: PlayerError.Levels.FATAL,
       origin: this.name,
       scope: 'playback',
       raw: {},

--- a/src/base/ui_container_plugin.js
+++ b/src/base/ui_container_plugin.js
@@ -3,8 +3,8 @@
 // license that can be found in the LICENSE file.
 
 import { extend } from './utils'
-
 import UIObject from './ui_object'
+import ErrorMixin from './error_mixin'
 
 /**
  * The base class for an ui container plugin
@@ -14,6 +14,8 @@ import UIObject from './ui_object'
  * @module base
  */
 export default class UIContainerPlugin extends UIObject {
+  get playerError() { return this.container.playerError }
+
   constructor(container) {
     super(container.options)
     this.container = container
@@ -41,6 +43,8 @@ export default class UIContainerPlugin extends UIObject {
     this.remove()
   }
 }
+
+Object.assign(UIContainerPlugin.prototype, ErrorMixin)
 
 UIContainerPlugin.extend = function(properties) {
   return extend(UIContainerPlugin, properties)

--- a/src/base/ui_core_plugin.js
+++ b/src/base/ui_core_plugin.js
@@ -1,7 +1,10 @@
 import { extend } from './utils'
 import UIObject from './ui_object'
+import ErrorMixin from './error_mixin'
 
 export default class UICorePlugin extends UIObject {
+  get playerError() { return this.core.playerError }
+
   constructor(core) {
     super(core.options)
     this.core = core
@@ -36,6 +39,8 @@ export default class UICorePlugin extends UIObject {
     return this
   }
 }
+
+Object.assign(UICorePlugin.prototype, ErrorMixin)
 
 UICorePlugin.extend = function(properties) {
   return extend(UICorePlugin, properties)

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -112,12 +112,13 @@ export default class Container extends UIObject {
    * @param {Object} options the options object
    * @param {Strings} i18n the internationalization component
    */
-  constructor(options, i18n) {
+  constructor(options, i18n, playerError) {
     super(options)
     this._i18n = i18n
     this.currentTime = 0
     this.volume = 100
     this.playback = options.playback
+    this.playerError = playerError
     this.settings = $.extend({}, this.playback.settings)
     this.isReady = false
     this.mediaControlDisabled = false

--- a/src/components/container_factory/container_factory.js
+++ b/src/components/container_factory/container_factory.js
@@ -15,10 +15,11 @@ export default class ContainerFactory extends BaseObject {
   get options() { return this._options }
   set options(options) { this._options = options }
 
-  constructor(options, loader, i18n) {
+  constructor(options, loader, i18n, playerError) {
     super(options)
     this._i18n = i18n
     this.loader = loader
+    this.playerError = playerError
   }
 
   createContainers() {
@@ -51,11 +52,11 @@ export default class ContainerFactory extends BaseObject {
       mimeType: mimeType
     })
     const playbackPlugin = this.findPlaybackPlugin(resolvedSource, mimeType)
-    const playback = new playbackPlugin(options, this._i18n)
+    const playback = new playbackPlugin(options, this._i18n, this.playerError)
 
     options = $.extend({}, options, { playback: playback })
 
-    const container = new Container(options, this._i18n)
+    const container = new Container(options, this._i18n, this.playerError)
     const defer = $.Deferred()
     defer.promise(container)
     this.addContainerPlugins(container)

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -202,6 +202,7 @@ export default class Core extends UIObject {
     $(document).unbind('fullscreenchange', this._boundFullscreenHandler)
     $(document).unbind('MSFullscreenChange', this._boundFullscreenHandler)
     $(document).unbind('mozfullscreenchange', this._boundFullscreenHandler)
+    this.stopListening()
   }
 
   handleFullscreenChange() {

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -240,13 +240,13 @@ export default class Core extends UIObject {
     this.containers = this.containers.filter((c) => c !== container)
   }
 
-  appendContainer(container) {
+  setupContainer(container) {
     this.listenTo(container, Events.CONTAINER_DESTROYED, this.removeContainer)
     this.containers.push(container)
   }
 
   setupContainers(containers) {
-    containers.map(this.appendContainer.bind(this))
+    containers.map(this.setupContainer.bind(this))
     this.trigger(Events.CORE_CONTAINERS_CREATED)
     this.renderContainers()
     this.setupMediaControl(this.getCurrentContainer())
@@ -261,7 +261,7 @@ export default class Core extends UIObject {
 
   createContainer(source, options) {
     const container = this.containerFactory.createContainer(source, options)
-    this.appendContainer(container)
+    this.setupContainer(container)
     this.el.appendChild(container.render().el)
     return container
   }

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -66,6 +66,7 @@ export default class Core extends UIObject {
 
   constructor(options) {
     super(options)
+    this.playerError = new PlayerError(options, this)
     this.configureDomRecycler()
     this.playerInfo = PlayerInfo.getInstance(options.playerId)
     this.firstResize = true
@@ -78,7 +79,6 @@ export default class Core extends UIObject {
     $(document).bind('MSFullscreenChange', this._boundFullscreenHandler)
     $(document).bind('mozfullscreenchange', this._boundFullscreenHandler)
     Browser.isMobile && $(window).bind('resize', (o) => { this.handleWindowResize(o) })
-    PlayerError.setCore(this)
   }
 
   configureDomRecycler() {
@@ -91,7 +91,7 @@ export default class Core extends UIObject {
   createContainers(options) {
     this.defer = $.Deferred()
     this.defer.promise(this)
-    this.containerFactory = new ContainerFactory(options, options.loader, this.i18n)
+    this.containerFactory = new ContainerFactory(options, options.loader, this.i18n, this.playerError)
     this.containerFactory
       .createContainers()
       .then((containers) => this.setupContainers(containers))

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -246,7 +246,7 @@ export default class Core extends UIObject {
   }
 
   setupContainers(containers) {
-    containers.map(this.setupContainer.bind(this))
+    containers.forEach(this.setupContainer.bind(this))
     this.trigger(Events.CORE_CONTAINERS_CREATED)
     this.renderContainers()
     this.setupMediaControl(this.getCurrentContainer())
@@ -256,7 +256,7 @@ export default class Core extends UIObject {
   }
 
   renderContainers() {
-    this.containers.map((container) => this.el.appendChild(container.render().el))
+    this.containers.forEach((container) => this.el.appendChild(container.render().el))
   }
 
   createContainer(source, options) {

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -11,6 +11,7 @@ import ContainerFactory from '../../components/container_factory'
 import MediaControl from '../../components/media_control'
 import Mediator from '../../components/mediator'
 import PlayerInfo from '../../components/player_info'
+import PlayerError from '../../components/error'
 
 import Styler from '../../base/styler'
 
@@ -77,6 +78,7 @@ export default class Core extends UIObject {
     $(document).bind('MSFullscreenChange', this._boundFullscreenHandler)
     $(document).bind('mozfullscreenchange', this._boundFullscreenHandler)
     Browser.isMobile && $(window).bind('resize', (o) => { this.handleWindowResize(o) })
+    PlayerError.setCore(this)
   }
 
   configureDomRecycler() {

--- a/src/components/error/error.js
+++ b/src/components/error/error.js
@@ -36,7 +36,7 @@ class PlayerError extends BaseObject {
    */
   error(err) {
     if (!this.core) {
-      Log.warn(this.name, 'Core is not setted. Error: ', err)
+      Log.warn(this.name, 'Core is not set. Error: ', err)
       return
     }
     this.core.trigger(Events.ERROR, err)

--- a/src/components/error/error.js
+++ b/src/components/error/error.js
@@ -19,7 +19,8 @@ class PlayerError extends BaseObject {
   get Levels() {
     return {
       FATAL: 'FATAL',
-      WARN: 'WARN'
+      WARN: 'WARN',
+      INFO: 'INFO',
     }
   }
 

--- a/src/components/error/error.js
+++ b/src/components/error/error.js
@@ -1,0 +1,46 @@
+import Events from '../../base/events'
+import BaseObject from '../../base/base_object'
+
+/**
+ * The PlayerError is responsible to receive and propagate errors.
+ * @class PlayerError
+ * @constructor
+ * @extends BaseObject
+ * @module components
+ */
+class PlayerError extends BaseObject {
+  get name() { return 'error' }
+
+  /**
+   * @property Levels
+   * @type {Object} object with error levels
+   */
+  get Levels() {
+    return {
+      FATAL: 'FATAL',
+      WARN: 'WARN'
+    }
+  }
+
+  constructor(options={}) {
+    super(options)
+  }
+
+  /**
+   * creates and trigger an error.
+   * @method error
+   * @param {Object} err should be an object with code, description, level, origin, scope and raw error.
+   */
+  error(err) {
+    this.core.trigger(Events.ERROR, err)
+  }
+
+  setCore(core) {
+    this.core = core
+  }
+
+}
+
+const playerError = new PlayerError()
+
+export default playerError

--- a/src/components/error/error.js
+++ b/src/components/error/error.js
@@ -16,7 +16,7 @@ class PlayerError extends BaseObject {
    * @property Levels
    * @type {Object} object with error levels
    */
-  get Levels() {
+  static get Levels() {
     return {
       FATAL: 'FATAL',
       WARN: 'WARN',

--- a/src/components/error/error.js
+++ b/src/components/error/error.js
@@ -23,8 +23,9 @@ class PlayerError extends BaseObject {
     }
   }
 
-  constructor(options={}) {
+  constructor(options={}, core) {
     super(options)
+    this.core = core
   }
 
   /**
@@ -39,13 +40,6 @@ class PlayerError extends BaseObject {
     }
     this.core.trigger(Events.ERROR, err)
   }
-
-  setCore(core) {
-    this.core = core
-  }
-
 }
 
-const playerError = new PlayerError()
-
-export default playerError
+export default PlayerError

--- a/src/components/error/error.js
+++ b/src/components/error/error.js
@@ -1,5 +1,6 @@
 import Events from '../../base/events'
 import BaseObject from '../../base/base_object'
+import Log from '../../plugins/log'
 
 /**
  * The PlayerError is responsible to receive and propagate errors.
@@ -32,6 +33,10 @@ class PlayerError extends BaseObject {
    * @param {Object} err should be an object with code, description, level, origin, scope and raw error.
    */
   error(err) {
+    if (!this.core) {
+      Log.warn(this.name, 'Core is not setted. Error: ', err)
+      return
+    }
     this.core.trigger(Events.ERROR, err)
   }
 

--- a/src/components/error/index.js
+++ b/src/components/error/index.js
@@ -1,0 +1,2 @@
+import Error from './error'
+export default Error

--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -641,6 +641,7 @@ export default class MediaControl extends UIObject {
     $(document).unbind('mouseup', this.stopDragHandler)
     $(document).unbind('mousemove', this.updateDragHandler)
     this.unbindKeyEvents()
+    this.stopListening()
   }
 
   /**

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -413,6 +413,7 @@ export default class Player extends BaseObject {
    * @return {Player} itself
    */
   destroy() {
+    this.stopListening()
     this.core.destroy()
     return this
   }

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -8,6 +8,7 @@ import template from '../../base/template'
 import Playback from '../../base/playback'
 import Mediator from '../../components/mediator'
 import Browser from '../../components/browser'
+import PlayerError from '../../components/error'
 import HLSEvents from './flashls_events'
 import hlsSwf from './public/HLSPlayer.swf'
 import $ from 'clappr-zepto'
@@ -151,11 +152,17 @@ export default class FlasHLS extends BaseFlashPlayback {
       this.trigger(Events.PLAYBACK_READY, this.name)
     } else {
       this._bootstrapAttempts = this._bootstrapAttempts || 0
-      if (++this._bootstrapAttempts <= MAX_ATTEMPTS)
+      if (++this._bootstrapAttempts <= MAX_ATTEMPTS) {
         setTimeout(() => this._bootstrap(), 50)
-      else
+      } else {
+        this.createError({
+          code: `playerLoadFail_maxNumberAttemptsReached`,
+          description: `${this.name} error: Max number of attempts reached`,
+          level: PlayerError.Levels.FATAL,
+          raw: {},
+        })
         this.trigger(Events.PLAYBACK_ERROR, { message: 'Max number of attempts reached' }, this.name)
-
+      }
     }
   }
 
@@ -632,6 +639,13 @@ export default class FlasHLS extends BaseFlashPlayback {
   }
 
   _flashPlaybackError(code, url, message) {
+    const error = {
+      code,
+      description: message,
+      level: PlayerError.Levels.FATAL,
+      raw: { code, url, message },
+    }
+    this.createError(error)
     this.trigger(Events.PLAYBACK_ERROR, { code: code, url: url, message: message })
     this.trigger(Events.PLAYBACK_STOP)
   }

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -8,7 +8,6 @@ import template from '../../base/template'
 import Playback from '../../base/playback'
 import Mediator from '../../components/mediator'
 import Browser from '../../components/browser'
-import PlayerError from '../../components/error'
 import HLSEvents from './flashls_events'
 import hlsSwf from './public/HLSPlayer.swf'
 import $ from 'clappr-zepto'
@@ -158,7 +157,7 @@ export default class FlasHLS extends BaseFlashPlayback {
         const formattedError = this.createError({
           code: 'playerLoadFail_maxNumberAttemptsReached',
           description: `${this.name} error: Max number of attempts reached`,
-          level: PlayerError.Levels.FATAL,
+          level: this.playerError.Levels.FATAL,
           raw: {},
         })
         this.trigger(Events.PLAYBACK_ERROR, formattedError)
@@ -642,7 +641,7 @@ export default class FlasHLS extends BaseFlashPlayback {
     const error = {
       code,
       description: message,
-      level: PlayerError.Levels.FATAL,
+      level: this.playerError.Levels.FATAL,
       raw: { code, url, message },
     }
     const formattedError = this.createError(error)

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -155,13 +155,13 @@ export default class FlasHLS extends BaseFlashPlayback {
       if (++this._bootstrapAttempts <= MAX_ATTEMPTS) {
         setTimeout(() => this._bootstrap(), 50)
       } else {
-        this.createError({
-          code: `playerLoadFail_maxNumberAttemptsReached`,
+        const formattedError = this.createError({
+          code: 'playerLoadFail_maxNumberAttemptsReached',
           description: `${this.name} error: Max number of attempts reached`,
           level: PlayerError.Levels.FATAL,
           raw: {},
         })
-        this.trigger(Events.PLAYBACK_ERROR, { message: 'Max number of attempts reached' }, this.name)
+        this.trigger(Events.PLAYBACK_ERROR, formattedError)
       }
     }
   }
@@ -645,8 +645,8 @@ export default class FlasHLS extends BaseFlashPlayback {
       level: PlayerError.Levels.FATAL,
       raw: { code, url, message },
     }
-    this.createError(error)
-    this.trigger(Events.PLAYBACK_ERROR, { code: code, url: url, message: message })
+    const formattedError = this.createError(error)
+    this.trigger(Events.PLAYBACK_ERROR, formattedError)
     this.trigger(Events.PLAYBACK_STOP)
   }
 

--- a/src/playbacks/flashls/flashls.js
+++ b/src/playbacks/flashls/flashls.js
@@ -8,6 +8,7 @@ import template from '../../base/template'
 import Playback from '../../base/playback'
 import Mediator from '../../components/mediator'
 import Browser from '../../components/browser'
+import PlayerError from '../../components/error'
 import HLSEvents from './flashls_events'
 import hlsSwf from './public/HLSPlayer.swf'
 import $ from 'clappr-zepto'
@@ -157,7 +158,7 @@ export default class FlasHLS extends BaseFlashPlayback {
         const formattedError = this.createError({
           code: 'playerLoadFail_maxNumberAttemptsReached',
           description: `${this.name} error: Max number of attempts reached`,
-          level: this.playerError.Levels.FATAL,
+          level: PlayerError.Levels.FATAL,
           raw: {},
         })
         this.trigger(Events.PLAYBACK_ERROR, formattedError)
@@ -641,7 +642,7 @@ export default class FlasHLS extends BaseFlashPlayback {
     const error = {
       code,
       description: message,
-      level: this.playerError.Levels.FATAL,
+      level: PlayerError.Levels.FATAL,
       raw: { code, url, message },
     }
     const formattedError = this.createError(error)

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -294,7 +294,6 @@ export default class HLS extends HTML5VideoPlayback {
           case HLSJS.ErrorDetails.LEVEL_LOAD_ERROR:
           case HLSJS.ErrorDetails.LEVEL_LOAD_TIMEOUT:
             Log.error('hlsjs: unrecoverable network fatal error.', { evt, data })
-            error.level = PlayerError.Levels.FATAL
             formattedError = this.createError(error)
             this.trigger(Events.PLAYBACK_ERROR, formattedError)
             break
@@ -314,14 +313,12 @@ export default class HLS extends HTML5VideoPlayback {
           break
         default:
           Log.error('hlsjs: could not recover from error.', { evt, data })
-          error.level = PlayerError.Levels.FATAL
           formattedError = this.createError(error)
           this.trigger(Events.PLAYBACK_ERROR, formattedError)
           break
         }
       } else {
         Log.error('hlsjs: could not recover from error after maximum number of attempts.', { evt, data })
-        error.level = PlayerError.Levels.FATAL
         formattedError = this.createError(error)
         this.trigger(Events.PLAYBACK_ERROR, formattedError)
       }

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -184,8 +184,8 @@ export default class HLS extends HTML5VideoPlayback {
     } else {
       Log.error('hlsjs: failed to recover', { evt, data })
       error.level = PlayerError.Levels.FATAL
-      this.createError(error)
-      this.trigger(Events.PLAYBACK_ERROR, `hlsjs: could not recover from error, evt ${evt}, data ${data} `, this.name)
+      const formattedError = this.createError(error)
+      this.trigger(Events.PLAYBACK_ERROR, formattedError)
     }
   }
 
@@ -275,6 +275,7 @@ export default class HLS extends HTML5VideoPlayback {
       description: `${this.name} error: type: ${data.type}, details: ${data.details}`,
       raw: data,
     }
+    let formattedError
     if (data.response) error.description += `, response: ${JSON.stringify(data.response)}`
     // only report/handle errors if they are fatal
     // hlsjs should automatically handle non fatal errors
@@ -294,8 +295,8 @@ export default class HLS extends HTML5VideoPlayback {
           case HLSJS.ErrorDetails.LEVEL_LOAD_TIMEOUT:
             Log.error('hlsjs: unrecoverable network fatal error.', { evt, data })
             error.level = PlayerError.Levels.FATAL
-            this.createError(error)
-            this.trigger(Events.PLAYBACK_ERROR, { evt, data }, this.name)
+            formattedError = this.createError(error)
+            this.trigger(Events.PLAYBACK_ERROR, formattedError)
             break
           default:
             Log.warn('hlsjs: trying to recover from network error.', { evt, data })
@@ -314,15 +315,15 @@ export default class HLS extends HTML5VideoPlayback {
         default:
           Log.error('hlsjs: could not recover from error.', { evt, data })
           error.level = PlayerError.Levels.FATAL
-          this.createError(error)
-          this.trigger(Events.PLAYBACK_ERROR, `hlsjs: could not recover from error, evt ${evt}, data ${data} `, this.name)
+          formattedError = this.createError(error)
+          this.trigger(Events.PLAYBACK_ERROR, formattedError)
           break
         }
       } else {
         Log.error('hlsjs: could not recover from error after maximum number of attempts.', { evt, data })
         error.level = PlayerError.Levels.FATAL
-        this.createError(error)
-        this.trigger(Events.PLAYBACK_ERROR, { evt, data }, this.name)
+        formattedError = this.createError(error)
+        this.trigger(Events.PLAYBACK_ERROR, formattedError)
       }
     } else {
       error.level = PlayerError.Levels.WARN

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -182,7 +182,7 @@ export default class HLS extends HTML5VideoPlayback {
       this._hls.swapAudioCodec()
       this._hls.recoverMediaError()
     } else {
-      Log.error('hlsjs: failed to recover')
+      Log.error('hlsjs: failed to recover', { evt, data })
       error.level = PlayerError.Levels.FATAL
       this.createError(error)
       this.trigger(Events.PLAYBACK_ERROR, `hlsjs: could not recover from error, evt ${evt}, data ${data} `, this.name)
@@ -292,13 +292,13 @@ export default class HLS extends HTML5VideoPlayback {
           case HLSJS.ErrorDetails.MANIFEST_PARSING_ERROR:
           case HLSJS.ErrorDetails.LEVEL_LOAD_ERROR:
           case HLSJS.ErrorDetails.LEVEL_LOAD_TIMEOUT:
-            Log.error(`hlsjs: unrecoverable network fatal error, evt ${evt}, data ${data} `)
+            Log.error('hlsjs: unrecoverable network fatal error.', { evt, data })
             error.level = PlayerError.Levels.FATAL
             this.createError(error)
             this.trigger(Events.PLAYBACK_ERROR, { evt, data }, this.name)
             break
           default:
-            Log.warn(`hlsjs: trying to recover from network error, evt ${evt}, data ${data} `)
+            Log.warn('hlsjs: trying to recover from network error.', { evt, data })
             error.level = PlayerError.Levels.WARN
             this.createError(error)
             this._hls.startLoad()
@@ -306,20 +306,20 @@ export default class HLS extends HTML5VideoPlayback {
           }
           break
         case HLSJS.ErrorTypes.MEDIA_ERROR:
-          Log.warn(`hlsjs: trying to recover from media error, evt ${evt}, data ${data} `)
+          Log.warn('hlsjs: trying to recover from media error.', { evt, data })
           error.level = PlayerError.Levels.WARN
           this.createError(error)
           this._recover(evt, data, error)
           break
         default:
-          Log.error(`hlsjs: trying to recover from error, evt ${evt}, data ${data} `)
+          Log.error('hlsjs: could not recover from error.', { evt, data })
           error.level = PlayerError.Levels.FATAL
           this.createError(error)
           this.trigger(Events.PLAYBACK_ERROR, `hlsjs: could not recover from error, evt ${evt}, data ${data} `, this.name)
           break
         }
       } else {
-        Log.error(`hlsjs: could not recover from error after maximum number of attempts, evt ${evt}, data ${data} `)
+        Log.error('hlsjs: could not recover from error after maximum number of attempts.', { evt, data })
         error.level = PlayerError.Levels.FATAL
         this.createError(error)
         this.trigger(Events.PLAYBACK_ERROR, { evt, data }, this.name)
@@ -327,7 +327,7 @@ export default class HLS extends HTML5VideoPlayback {
     } else {
       error.level = PlayerError.Levels.WARN
       this.createError(error)
-      Log.warn(`hlsjs: non-fatal error occurred, evt ${evt}, data ${data} `)
+      Log.warn('hlsjs: non-fatal error occurred', { evt, data })
     }
   }
 

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -8,6 +8,7 @@ import Events from '../../base/events'
 import Playback from '../../base/playback'
 import { now, assign } from '../../base/utils'
 import Log from '../../plugins/log'
+import PlayerError from '../../components/error'
 
 const AUTO = -1
 
@@ -182,7 +183,7 @@ export default class HLS extends HTML5VideoPlayback {
       this._hls.recoverMediaError()
     } else {
       Log.error('hlsjs: failed to recover', { evt, data })
-      error.level = this.playerError.Levels.FATAL
+      error.level = PlayerError.Levels.FATAL
       const formattedError = this.createError(error)
       this.trigger(Events.PLAYBACK_ERROR, formattedError)
     }
@@ -298,7 +299,7 @@ export default class HLS extends HTML5VideoPlayback {
             break
           default:
             Log.warn('hlsjs: trying to recover from network error.', { evt, data })
-            error.level = this.playerError.Levels.WARN
+            error.level = PlayerError.Levels.WARN
             this.createError(error)
             this._hls.startLoad()
             break
@@ -306,7 +307,7 @@ export default class HLS extends HTML5VideoPlayback {
           break
         case HLSJS.ErrorTypes.MEDIA_ERROR:
           Log.warn('hlsjs: trying to recover from media error.', { evt, data })
-          error.level = this.playerError.Levels.WARN
+          error.level = PlayerError.Levels.WARN
           this.createError(error)
           this._recover(evt, data, error)
           break
@@ -322,7 +323,7 @@ export default class HLS extends HTML5VideoPlayback {
         this.trigger(Events.PLAYBACK_ERROR, formattedError)
       }
     } else {
-      error.level = this.playerError.Levels.WARN
+      error.level = PlayerError.Levels.WARN
       this.createError(error)
       Log.warn('hlsjs: non-fatal error occurred', { evt, data })
     }

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -8,7 +8,6 @@ import Events from '../../base/events'
 import Playback from '../../base/playback'
 import { now, assign } from '../../base/utils'
 import Log from '../../plugins/log'
-import PlayerError from '../../components/error'
 
 const AUTO = -1
 
@@ -183,7 +182,7 @@ export default class HLS extends HTML5VideoPlayback {
       this._hls.recoverMediaError()
     } else {
       Log.error('hlsjs: failed to recover', { evt, data })
-      error.level = PlayerError.Levels.FATAL
+      error.level = this.playerError.Levels.FATAL
       const formattedError = this.createError(error)
       this.trigger(Events.PLAYBACK_ERROR, formattedError)
     }
@@ -299,7 +298,7 @@ export default class HLS extends HTML5VideoPlayback {
             break
           default:
             Log.warn('hlsjs: trying to recover from network error.', { evt, data })
-            error.level = PlayerError.Levels.WARN
+            error.level = this.playerError.Levels.WARN
             this.createError(error)
             this._hls.startLoad()
             break
@@ -307,7 +306,7 @@ export default class HLS extends HTML5VideoPlayback {
           break
         case HLSJS.ErrorTypes.MEDIA_ERROR:
           Log.warn('hlsjs: trying to recover from media error.', { evt, data })
-          error.level = PlayerError.Levels.WARN
+          error.level = this.playerError.Levels.WARN
           this.createError(error)
           this._recover(evt, data, error)
           break
@@ -323,7 +322,7 @@ export default class HLS extends HTML5VideoPlayback {
         this.trigger(Events.PLAYBACK_ERROR, formattedError)
       }
     } else {
-      error.level = PlayerError.Levels.WARN
+      error.level = this.playerError.Levels.WARN
       this.createError(error)
       Log.warn('hlsjs: non-fatal error occurred', { evt, data })
     }

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -33,6 +33,8 @@ const AUDIO_MIMETYPES = {
 
 const KNOWN_AUDIO_MIMETYPES = Object.keys(AUDIO_MIMETYPES).reduce((acc, k) => [...acc, ...AUDIO_MIMETYPES[k]], [])
 
+const UNKNOWN_ERROR = { code: 'unknown', message: 'unknown' }
+
 // TODO: rename this Playback to HTML5Playback (breaking change, only after 0.3.0)
 export default class HTML5Video extends Playback {
   get name() { return 'html5_video' }
@@ -383,7 +385,7 @@ export default class HTML5Video extends Playback {
   }
 
   _onError() {
-    const { code, message } = this.el.error
+    const { code, message } = this.el.error || UNKNOWN_ERROR
 
     const formattedError = this.createError({
       code,

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -391,7 +391,7 @@ export default class HTML5Video extends Playback {
       raw: this.el.error,
     })
 
-    this.trigger(Events.PLAYBACK_ERROR, this.el.error, this.name)
+    this.trigger(Events.PLAYBACK_ERROR, formattedError)
   }
 
   destroy() {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -383,6 +383,14 @@ export default class HTML5Video extends Playback {
   }
 
   _onError() {
+    const { code, message } = this.el.error
+
+    const formattedError = this.createError({
+      code,
+      description: message,
+      raw: this.el.error,
+    })
+
     this.trigger(Events.PLAYBACK_ERROR, this.el.error, this.name)
   }
 

--- a/test/base/playback_spec.js
+++ b/test/base/playback_spec.js
@@ -65,14 +65,6 @@ describe('Playback', function() {
       expect(errorData.code).to.deep.equal(`${this.basePlayback.name}:${error.code}`)
     })
 
-    it('creates a code error on the following format: name:code', () => {
-      this.basePlayback.name = 'test'
-      const error = { code: '42' }
-      const errorData = this.basePlayback.createError(error)
-
-      expect(errorData.code).to.deep.equal(`${this.basePlayback.name}:${error.code}`)
-    })
-
     it('has default error level equals to FATAL', () => {
       const errorData = this.basePlayback.createError()
 

--- a/test/base/playback_spec.js
+++ b/test/base/playback_spec.js
@@ -1,5 +1,5 @@
 import Playback from 'base/playback'
-import PlayerError from '../../src/components/error'
+import Core from '../../src/components/core'
 
 describe('Playback', function() {
   beforeEach(() => {
@@ -35,61 +35,69 @@ describe('Playback', function() {
     expect(spy).to.have.been.calledOnce
   })
 
-  it('creates a default error if no error data is given', () => {
-    const errorData = this.basePlayback.createError()
-    const defaultError = {
-      description: '',
-      level: PlayerError.Levels.FATAL,
-      origin: 'playback',
-      scope: 'playback',
-      raw: {},
-      code: 'playback:unknown',
-    }
+  describe('error', () => {
+    beforeEach(() => {
+      this.core = new Core({})
+      this.basePlayback = new Playback({}, null, this.core.playerError)
+      this.playerError = this.basePlayback.playerError
+    })
 
-    expect(errorData).to.deep.equal(defaultError)
-  })
+    it('creates a default error if no error data is given', () => {
+      const errorData = this.basePlayback.createError()
+      const defaultError = {
+        description: '',
+        level: this.playerError.Levels.FATAL,
+        origin: 'playback',
+        scope: 'playback',
+        raw: {},
+        code: 'playback:unknown',
+      }
 
-  it('creates a code error on the following format: name:code', () => {
-    this.basePlayback.name = 'test'
-    const error = { code: '42' }
-    const errorData = this.basePlayback.createError(error)
+      expect(errorData).to.deep.equal(defaultError)
+    })
 
-    expect(errorData.code).to.deep.equal(`${this.basePlayback.name}:${error.code}`)
-  })
+    it('creates a code error on the following format: name:code', () => {
+      this.basePlayback.name = 'test'
+      const error = { code: '42' }
+      const errorData = this.basePlayback.createError(error)
 
-  it('creates a code error on the following format: name:code', () => {
-    this.basePlayback.name = 'test'
-    const error = { code: '42' }
-    const errorData = this.basePlayback.createError(error)
+      expect(errorData.code).to.deep.equal(`${this.basePlayback.name}:${error.code}`)
+    })
 
-    expect(errorData.code).to.deep.equal(`${this.basePlayback.name}:${error.code}`)
-  })
+    it('creates a code error on the following format: name:code', () => {
+      this.basePlayback.name = 'test'
+      const error = { code: '42' }
+      const errorData = this.basePlayback.createError(error)
 
-  it('default error level equals to FATAL', () => {
-    const errorData = this.basePlayback.createError()
+      expect(errorData.code).to.deep.equal(`${this.basePlayback.name}:${error.code}`)
+    })
 
-    expect(errorData.level).to.deep.equal(PlayerError.Levels.FATAL)
-  })
+    it('default error level equals to FATAL', () => {
+      const errorData = this.basePlayback.createError()
 
-  it('do not use default level when its setted on error', () => {
-    const error = { level: PlayerError.Levels.WARN }
-    const errorData = this.basePlayback.createError(error)
+      expect(errorData.level).to.deep.equal(this.playerError.Levels.FATAL)
+    })
 
-    expect(errorData.level).to.deep.equal(PlayerError.Levels.WARN)
-  })
+    it('do not use default level when its setted on error', () => {
+      const error = { level: this.playerError.Levels.WARN }
+      const errorData = this.basePlayback.createError(error)
 
-  it('always call error to trigger ERROR event', () => {
-    const defaultError = {
-      description: '',
-      level: PlayerError.Levels.FATAL,
-      origin: 'playback',
-      scope: 'playback',
-      raw: {},
-      code: 'playback:unknown',
-    }
-    const spy = sinon.spy(PlayerError, 'error')
-    this.basePlayback.createError()
+      expect(errorData.level).to.deep.equal(this.playerError.Levels.WARN)
+    })
 
-    expect(spy).to.have.been.calledWith(defaultError)
+    it('always call error to trigger ERROR event', () => {
+      const defaultError = {
+        description: '',
+        level: this.playerError.Levels.FATAL,
+        origin: 'playback',
+        scope: 'playback',
+        raw: {},
+        code: 'playback:unknown',
+      }
+      const spy = sinon.spy(this.playerError, 'error')
+      this.basePlayback.createError()
+
+      expect(spy).to.have.been.calledWith(defaultError)
+    })
   })
 })

--- a/test/base/playback_spec.js
+++ b/test/base/playback_spec.js
@@ -1,5 +1,6 @@
 import Playback from 'base/playback'
 import Core from '../../src/components/core'
+import PlayerError from '../../src/components/error'
 
 describe('Playback', function() {
   beforeEach(() => {
@@ -46,7 +47,7 @@ describe('Playback', function() {
       const errorData = this.basePlayback.createError()
       const defaultError = {
         description: '',
-        level: this.playerError.Levels.FATAL,
+        level: PlayerError.Levels.FATAL,
         origin: 'playback',
         scope: 'playback',
         raw: {},
@@ -72,23 +73,23 @@ describe('Playback', function() {
       expect(errorData.code).to.deep.equal(`${this.basePlayback.name}:${error.code}`)
     })
 
-    it('default error level equals to FATAL', () => {
+    it('has default error level equals to FATAL', () => {
       const errorData = this.basePlayback.createError()
 
-      expect(errorData.level).to.deep.equal(this.playerError.Levels.FATAL)
+      expect(errorData.level).to.deep.equal(PlayerError.Levels.FATAL)
     })
 
-    it('do not use default level when its setted on error', () => {
-      const error = { level: this.playerError.Levels.WARN }
+    it('does not use default level when its setted on error', () => {
+      const error = { level: PlayerError.Levels.WARN }
       const errorData = this.basePlayback.createError(error)
 
-      expect(errorData.level).to.deep.equal(this.playerError.Levels.WARN)
+      expect(errorData.level).to.deep.equal(PlayerError.Levels.WARN)
     })
 
     it('always call error to trigger ERROR event', () => {
       const defaultError = {
         description: '',
-        level: this.playerError.Levels.FATAL,
+        level: PlayerError.Levels.FATAL,
         origin: 'playback',
         scope: 'playback',
         raw: {},

--- a/test/base/playback_spec.js
+++ b/test/base/playback_spec.js
@@ -57,7 +57,7 @@ describe('Playback', function() {
       expect(errorData).to.deep.equal(defaultError)
     })
 
-    it('creates a code error on the following format: name:code', () => {
+    it('creates a error code on the following format: name:code', () => {
       this.basePlayback.name = 'test'
       const error = { code: '42' }
       const errorData = this.basePlayback.createError(error)
@@ -71,14 +71,14 @@ describe('Playback', function() {
       expect(errorData.level).to.deep.equal(PlayerError.Levels.FATAL)
     })
 
-    it('does not use default level when its setted on error', () => {
+    it('does not use default level when its set on error', () => {
       const error = { level: PlayerError.Levels.WARN }
       const errorData = this.basePlayback.createError(error)
 
       expect(errorData.level).to.deep.equal(PlayerError.Levels.WARN)
     })
 
-    it('always call error to trigger ERROR event', () => {
+    it('always calls error to trigger ERROR event', () => {
       const defaultError = {
         description: '',
         level: PlayerError.Levels.FATAL,

--- a/test/base/playback_spec.js
+++ b/test/base/playback_spec.js
@@ -1,4 +1,5 @@
 import Playback from 'base/playback'
+import PlayerError from '../../src/components/error'
 
 describe('Playback', function() {
   beforeEach(() => {
@@ -32,5 +33,63 @@ describe('Playback', function() {
     this.basePlayback.destroy()
 
     expect(spy).to.have.been.calledOnce
+  })
+
+  it('creates a default error if no error data is given', () => {
+    const errorData = this.basePlayback.createError()
+    const defaultError = {
+      description: '',
+      level: PlayerError.Levels.FATAL,
+      origin: 'playback',
+      scope: 'playback',
+      raw: {},
+      code: 'playback:unknown',
+    }
+
+    expect(errorData).to.deep.equal(defaultError)
+  })
+
+  it('creates a code error on the following format: name:code', () => {
+    this.basePlayback.name = 'test'
+    const error = { code: '42' }
+    const errorData = this.basePlayback.createError(error)
+
+    expect(errorData.code).to.deep.equal(`${this.basePlayback.name}:${error.code}`)
+  })
+
+  it('creates a code error on the following format: name:code', () => {
+    this.basePlayback.name = 'test'
+    const error = { code: '42' }
+    const errorData = this.basePlayback.createError(error)
+
+    expect(errorData.code).to.deep.equal(`${this.basePlayback.name}:${error.code}`)
+  })
+
+  it('default error level equals to FATAL', () => {
+    const errorData = this.basePlayback.createError()
+
+    expect(errorData.level).to.deep.equal(PlayerError.Levels.FATAL)
+  })
+
+  it('do not use default level when its setted on error', () => {
+    const error = { level: PlayerError.Levels.WARN }
+    const errorData = this.basePlayback.createError(error)
+
+    expect(errorData.level).to.deep.equal(PlayerError.Levels.WARN)
+  })
+
+  it('always call error to trigger ERROR event', () => {
+    const defaultError = {
+      description: '',
+      level: PlayerError.Levels.FATAL,
+      origin: 'playback',
+      scope: 'playback',
+      raw: {},
+      code: 'playback:unknown',
+    }
+    const spy = sinon.spy(PlayerError, 'error')
+    this.basePlayback.createError()
+
+    expect(spy).to.have.been.calledWith(defaultError)
   })
 })

--- a/test/components/error_spec.js
+++ b/test/components/error_spec.js
@@ -31,7 +31,7 @@ describe('PlayerError', function() {
       }))
     })
 
-    describe('when core is not setted', function() {
+    describe('when core is not set', function() {
       it('does not trigger ERROR event', function() {
         sinon.spy(this.core, 'trigger')
         this.playerError.core = undefined

--- a/test/components/error_spec.js
+++ b/test/components/error_spec.js
@@ -17,7 +17,7 @@ describe('PlayerError', function() {
   })
 
   describe('when error method is called', function() {
-    it('trigger ERROR event with error data', function() {
+    it('trigger ERROR event', function() {
       sinon.spy(this.core, 'trigger')
       PlayerError.error(this.errorData)
 
@@ -32,7 +32,7 @@ describe('PlayerError', function() {
     })
 
     describe('when core is not setted', function() {
-      it('does not trigger ERROR', function() {
+      it('does not trigger ERROR event', function() {
         sinon.spy(this.core, 'trigger')
         PlayerError.core = undefined
         PlayerError.error(this.errorData)

--- a/test/components/error_spec.js
+++ b/test/components/error_spec.js
@@ -16,7 +16,7 @@ describe('PlayerError', function() {
   })
 
   describe('when error method is called', function() {
-    it('trigger ERROR event', function() {
+    it('triggers ERROR event', function() {
       sinon.spy(this.core, 'trigger')
       this.playerError.error(this.errorData)
 

--- a/test/components/error_spec.js
+++ b/test/components/error_spec.js
@@ -1,4 +1,5 @@
 import Core from '../../src/components/core'
+import PlayerError from '../../src/components/error'
 import Events from '../../src/base/events'
 
 describe('PlayerError', function() {
@@ -8,7 +9,7 @@ describe('PlayerError', function() {
     this.errorData = {
       code: 'test_01',
       description: 'test error',
-      level: this.playerError.Levels.FATAL,
+      level: PlayerError.Levels.FATAL,
       origin: 'test',
       scope: 'it',
       raw: {},
@@ -23,7 +24,7 @@ describe('PlayerError', function() {
       assert.ok(this.core.trigger.calledWith(Events.ERROR, {
         code: 'test_01',
         description: 'test error',
-        level: this.playerError.Levels.FATAL,
+        level: PlayerError.Levels.FATAL,
         origin: 'test',
         scope: 'it',
         raw: {},

--- a/test/components/error_spec.js
+++ b/test/components/error_spec.js
@@ -1,15 +1,14 @@
-import PlayerError from '../../src/components/error'
 import Core from '../../src/components/core'
 import Events from '../../src/base/events'
 
 describe('PlayerError', function() {
   beforeEach(function() {
     this.core = new Core({})
-
+    this.playerError = this.core.playerError
     this.errorData = {
       code: 'test_01',
       description: 'test error',
-      level: PlayerError.Levels.FATAL,
+      level: this.playerError.Levels.FATAL,
       origin: 'test',
       scope: 'it',
       raw: {},
@@ -19,12 +18,12 @@ describe('PlayerError', function() {
   describe('when error method is called', function() {
     it('trigger ERROR event', function() {
       sinon.spy(this.core, 'trigger')
-      PlayerError.error(this.errorData)
+      this.playerError.error(this.errorData)
 
       assert.ok(this.core.trigger.calledWith(Events.ERROR, {
         code: 'test_01',
         description: 'test error',
-        level: PlayerError.Levels.FATAL,
+        level: this.playerError.Levels.FATAL,
         origin: 'test',
         scope: 'it',
         raw: {},
@@ -34,8 +33,8 @@ describe('PlayerError', function() {
     describe('when core is not setted', function() {
       it('does not trigger ERROR event', function() {
         sinon.spy(this.core, 'trigger')
-        PlayerError.core = undefined
-        PlayerError.error(this.errorData)
+        this.playerError.core = undefined
+        this.playerError.error(this.errorData)
 
         assert.notOk(this.core.trigger.calledWith(Events.ERROR, this.errorData))
       })

--- a/test/components/error_spec.js
+++ b/test/components/error_spec.js
@@ -16,25 +16,29 @@ describe('PlayerError', function() {
     }
   })
 
-  it('trigger ERROR with error data when error method is called', function() {
-    sinon.spy(this.core, 'trigger')
-    PlayerError.error(this.errorData)
+  describe('when error method is called', function() {
+    it('trigger ERROR event with error data', function() {
+      sinon.spy(this.core, 'trigger')
+      PlayerError.error(this.errorData)
 
-    assert.ok(this.core.trigger.calledWith(Events.ERROR, {
-      code: 'test_01',
-      description: 'test error',
-      level: PlayerError.Levels.FATAL,
-      origin: 'test',
-      scope: 'it',
-      raw: {},
-    }))
-  })
+      assert.ok(this.core.trigger.calledWith(Events.ERROR, {
+        code: 'test_01',
+        description: 'test error',
+        level: PlayerError.Levels.FATAL,
+        origin: 'test',
+        scope: 'it',
+        raw: {},
+      }))
+    })
 
-  it('does not trigger ERROR when core is not setted', function() {
-    sinon.spy(this.core, 'trigger')
-    PlayerError.core = undefined
-    PlayerError.error(this.errorData)
+    describe('when core is not setted', function() {
+      it('does not trigger ERROR', function() {
+        sinon.spy(this.core, 'trigger')
+        PlayerError.core = undefined
+        PlayerError.error(this.errorData)
 
-    assert.notOk(this.core.trigger.calledWith(Events.ERROR, this.errorData))
+        assert.notOk(this.core.trigger.calledWith(Events.ERROR, this.errorData))
+      })
+    })
   })
 })

--- a/test/components/error_spec.js
+++ b/test/components/error_spec.js
@@ -1,0 +1,33 @@
+import PlayerError from '../../src/components/error'
+import Core from '../../src/components/core'
+import Events from '../../src/base/events'
+
+describe('PlayerError', function() {
+  beforeEach(function() {
+    this.core = new Core({})
+
+    this.errorData = {
+      code: 'test_01',
+      description: 'test error',
+      level: PlayerError.Levels.FATAL,
+      origin: 'test',
+      scope: 'it',
+      raw: {},
+    }
+  })
+
+  it('trigger ERROR with error data when error method is called', function() {
+    sinon.spy(this.core, 'trigger')
+    PlayerError.error(this.errorData)
+
+    assert.ok(this.core.trigger.calledWith(Events.ERROR, this.errorData))
+  })
+
+  it('does not trigger ERROR when core is not setted', function() {
+    sinon.spy(this.core, 'trigger')
+    PlayerError.core = undefined
+    PlayerError.error(this.errorData)
+
+    assert.notOk(this.core.trigger.calledWith(Events.ERROR, this.errorData))
+  })
+})

--- a/test/components/error_spec.js
+++ b/test/components/error_spec.js
@@ -20,7 +20,14 @@ describe('PlayerError', function() {
     sinon.spy(this.core, 'trigger')
     PlayerError.error(this.errorData)
 
-    assert.ok(this.core.trigger.calledWith(Events.ERROR, this.errorData))
+    assert.ok(this.core.trigger.calledWith(Events.ERROR, {
+      code: 'test_01',
+      description: 'test error',
+      level: PlayerError.Levels.FATAL,
+      origin: 'test',
+      scope: 'it',
+      raw: {},
+    }))
   })
 
   it('does not trigger ERROR when core is not setted', function() {

--- a/test/playbacks/hls_spec.js
+++ b/test/playbacks/hls_spec.js
@@ -1,4 +1,5 @@
 import Events from 'base/events.js'
+import Core from '../../src/components/core'
 import HLS from 'playbacks/hls'
 import HLSJS from 'hls.js'
 
@@ -87,7 +88,8 @@ describe('HLS playback', () => {
       rejectFn = reject
     })
     let options = { src: 'http://clappr.io/notfound.m3u8' }
-    const playback = new HLS(options)
+    const core = new Core({})
+    const playback = new HLS(options, null, core.playerError)
     playback.on(Events.PLAYBACK_ERROR, (e) => {
       resolveFn(e)
     })

--- a/test/playbacks/hls_spec.js
+++ b/test/playbacks/hls_spec.js
@@ -80,16 +80,23 @@ describe('HLS playback', () => {
     })
   })
 
-  it('should trigger a playback error if source load failed', function(done) {
-    this.timeout(5000)
+  it('should trigger a playback error if source load failed', function() {
+    let resolveFn = undefined, rejectFn = undefined
+    const promise = new Promise((resolve, reject) => {
+      resolveFn = resolve
+      rejectFn = reject
+    })
     let options = { src: 'http://clappr.io/notfound.m3u8' }
     const playback = new HLS(options)
     playback.on(Events.PLAYBACK_ERROR, (e) => {
-      expect(e.raw.type).to.be.equal(HLSJS.ErrorTypes.NETWORK_ERROR)
-      expect(e.raw.details).to.be.equal(HLSJS.ErrorDetails.MANIFEST_LOAD_ERROR)
-      done()
+      resolveFn(e)
     })
     playback.play()
+
+    return promise.then((e) => {
+      expect(e.raw.type).to.be.equal(HLSJS.ErrorTypes.NETWORK_ERROR)
+      expect(e.raw.details).to.be.equal(HLSJS.ErrorDetails.MANIFEST_LOAD_ERROR)
+    })
   })
 
   xit('levels', function() {

--- a/test/playbacks/hls_spec.js
+++ b/test/playbacks/hls_spec.js
@@ -82,10 +82,9 @@ describe('HLS playback', () => {
   })
 
   it('should trigger a playback error if source load failed', function() {
-    let resolveFn = undefined, rejectFn = undefined
-    const promise = new Promise((resolve, reject) => {
+    let resolveFn = undefined
+    const promise = new Promise((resolve) => {
       resolveFn = resolve
-      rejectFn = reject
     })
     let options = { src: 'http://clappr.io/notfound.m3u8' }
     const core = new Core({})

--- a/test/playbacks/hls_spec.js
+++ b/test/playbacks/hls_spec.js
@@ -85,11 +85,11 @@ describe('HLS playback', () => {
     let options = { src: 'http://clappr.io/notfound.m3u8' }
     const playback = new HLS(options)
     playback.on(Events.PLAYBACK_ERROR, (e) => {
-      expect(e.data.type).to.be.equal(HLSJS.ErrorTypes.NETWORK_ERROR)
-      expect(e.data.details).to.be.equal(HLSJS.ErrorDetails.MANIFEST_LOAD_ERROR)
+      expect(e.raw.type).to.be.equal(HLSJS.ErrorTypes.NETWORK_ERROR)
+      expect(e.raw.details).to.be.equal(HLSJS.ErrorDetails.MANIFEST_LOAD_ERROR)
+      done()
     })
     playback.play()
-    done()
   })
 
   xit('levels', function() {


### PR DESCRIPTION
To normalize errors and create a pattern to them a new error component is being created.

Initially only playback errors are being changed to this new format, but errors from other layers can adopt this new format too.

This component will trigger a new error event that contains data that can be useful to, for example, an error screen plugin render information to users.

This new error format contains:

**code**: the error code
**description**: error description
**level**: warn or fatal
**origin**: hls, html5, etc
**scope**: playback, container, etc
**raw error**: the error without modification

This is the first step to create our error screen #1108 