### PR TITLE
refactor html5_video: deleting src attribute using removeAttribute...

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -390,7 +390,7 @@ export default class HTML5Video extends Playback {
     this._destroyed = true
     this.handleTextTrackChange && this.el.textTracks.removeEventListener('change', this.handleTextTrackChange)
     this.$el.remove()
-    delete this.el.src
+    this.el.removeAttribute('src')
     this._src = null
     DomRecycler.garbage(this.$el)
   }


### PR DESCRIPTION
… method instead delete operator

The delete operator is valid only for literal objects, removeAttribute is the appropriate way to remove an attribute of a DOM Element.