### PR TITLE
Merge remove/destroy methods

### DIFF
--- a/src/base/ui_container_plugin.js
+++ b/src/base/ui_container_plugin.js
@@ -39,9 +39,6 @@ export default class UIContainerPlugin extends UIObject {
 
   bindEvents() {}
 
-  destroy() {
-    this.remove()
-  }
 }
 
 Object.assign(UIContainerPlugin.prototype, ErrorMixin)

--- a/src/base/ui_core_plugin.js
+++ b/src/base/ui_core_plugin.js
@@ -31,10 +31,6 @@ export default class UICorePlugin extends UIObject {
     this.enabled = false
   }
 
-  destroy() {
-    this.remove()
-  }
-
   render() {
     return this
   }

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -233,7 +233,9 @@ export default class Container extends UIObject {
   destroy() {
     this.trigger(Events.CONTAINER_DESTROYED, this, this.name)
     this.stopListening()
-    this.plugins.forEach((plugin) => plugin.destroy())
+    this.plugins.forEach((plugin) => {
+      plugin.destroy ? plugin.destroy() : plugin.remove()
+    })
     this.$el.remove()
   }
 

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -225,7 +225,9 @@ export default class Core extends UIObject {
   destroy() {
     this.disableResizeObserver()
     this.containers.forEach((container) => container.destroy())
-    this.plugins.forEach((plugin) => plugin.destroy())
+    this.plugins.forEach((plugin) => {
+      plugin.destroy ? plugin.destroy() : plugin.remove()
+    })
     this.$el.remove()
     $(document).unbind('fullscreenchange', this._boundFullscreenHandler)
     $(document).unbind('MSFullscreenChange', this._boundFullscreenHandler)

--- a/src/plugins/media_control/media_control.js
+++ b/src/plugins/media_control/media_control.js
@@ -624,12 +624,12 @@ export default class MediaControl extends UICorePlugin {
     this.buttonsColor && element && $(element).find('svg path').css('fill', this.buttonsColor)
   }
 
-  destroy() {
-    this.remove()
+  remove() {
     $(document).unbind('mouseup', this.stopDragHandler)
     $(document).unbind('mousemove', this.updateDragHandler)
     this.unbindKeyEvents()
     this.stopListening()
+    super.remove()
   }
 
   /**

--- a/test/base/ui_container_plugin_spec.js
+++ b/test/base/ui_container_plugin_spec.js
@@ -53,7 +53,7 @@ describe('UI Container Plugin', function() {
     const plugin = new UIContainerPlugin({})
     const spy = sinon.spy(plugin, 'remove')
 
-    plugin.destroy()
+    plugin.remove()
 
     expect(spy).to.have.been.calledOnce
   })

--- a/test/base/ui_core_spec.js
+++ b/test/base/ui_core_spec.js
@@ -48,7 +48,7 @@ describe('UI Core Plugin', function() {
     const plugin = new MyPlugin({})
     const spy = sinon.spy(plugin, 'remove')
 
-    plugin.destroy()
+    plugin.remove()
 
     expect(spy).to.have.been.calledOnce
   })

--- a/test/playbacks/hls_spec.js
+++ b/test/playbacks/hls_spec.js
@@ -83,18 +83,14 @@ describe('HLS playback', () => {
 
   it('should trigger a playback error if source load failed', function() {
     let resolveFn = undefined
-    const promise = new Promise((resolve) => {
-      resolveFn = resolve
-    })
+    const promise = new Promise((resolve) => { resolveFn = resolve })
     let options = { src: 'http://clappr.io/notfound.m3u8' }
     const core = new Core({})
     const playback = new HLS(options, null, core.playerError)
-    playback.on(Events.PLAYBACK_ERROR, (e) => {
-      resolveFn(e)
-    })
+    playback.on(Events.PLAYBACK_ERROR, (e) => resolveFn(e))
     playback.play()
 
-    return promise.then((e) => {
+    promise.then((e) => {
       expect(e.raw.type).to.be.equal(HLSJS.ErrorTypes.NETWORK_ERROR)
       expect(e.raw.details).to.be.equal(HLSJS.ErrorDetails.MANIFEST_LOAD_ERROR)
     })

--- a/test/plugins/error_screen_spec.js
+++ b/test/plugins/error_screen_spec.js
@@ -39,7 +39,7 @@ describe('ErrorScreen', function() {
         }
         this.playback = new Playback()
         this.container = new Container({ playback: this.playback })
-        this.core.setupContainer(this.container)
+        this.core.setupContainers([this.container])
       })
 
       it('disables media control', () => {


### PR DESCRIPTION
Closes #537 

Changes
======
* Removes method `destroy` from `UIContainerPlugin` and `UICorePlugin`;
* Adapts `container` and `core` to correctly remove UI plugins;
* Refactors `MediaControlPlugin` to use `remove` method;
* Fixes broken tests.