### PR TITLE
Error mixin expansion

### DIFF
--- a/src/base/error_mixin.js
+++ b/src/base/error_mixin.js
@@ -35,7 +35,7 @@ const ErrorMixin = {
     }
 
     if (this.playerError)
-      this.playerError.error(errorData)
+      this.playerError.createError(errorData)
     else
       Log.warn(origin, 'PlayerError is not defined. Error: ', errorData)
 

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -8,6 +8,7 @@
 
 import Events from '../../base/events'
 import UIObject from '../../base/ui_object'
+import ErrorMixin from '../../base/error_mixin'
 
 import './public/style.scss'
 
@@ -473,3 +474,5 @@ export default class Container extends UIObject {
     return this
   }
 }
+
+Object.assign(Container.prototype, ErrorMixin)

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -12,6 +12,7 @@ import MediaControl from '../../components/media_control'
 import Mediator from '../../components/mediator'
 import PlayerInfo from '../../components/player_info'
 import PlayerError from '../../components/error'
+import ErrorMixin from '../../base/error_mixin'
 
 import Styler from '../../base/styler'
 
@@ -379,3 +380,5 @@ export default class Core extends UIObject {
     return this
   }
 }
+
+Object.assign(Core.prototype, ErrorMixin)

--- a/src/components/error/error.js
+++ b/src/components/error/error.js
@@ -31,10 +31,10 @@ class PlayerError extends BaseObject {
 
   /**
    * creates and trigger an error.
-   * @method error
+   * @method createError
    * @param {Object} err should be an object with code, description, level, origin, scope and raw error.
    */
-  error(err) {
+  createError(err) {
     if (!this.core) {
       Log.warn(this.name, 'Core is not set. Error: ', err)
       return

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -10,6 +10,7 @@ import Browser from './browser'
 import CoreFactory from './core_factory'
 import Loader from './loader'
 import PlayerInfo from './player_info'
+import ErrorMixin from '../base/error_mixin'
 import $ from 'clappr-zepto'
 
 const baseUrl = currentScriptUrl().replace(/\/[^/]+$/, '')
@@ -609,3 +610,5 @@ export default class Player extends BaseObject {
     return this.core.mediaControl.container.getDuration()
   }
 }
+
+Object.assign(Player.prototype, ErrorMixin)

--- a/test/base/playback_spec.js
+++ b/test/base/playback_spec.js
@@ -150,7 +150,7 @@ describe('Playback', function() {
         raw: {},
         code: 'playback:unknown',
       }
-      const spy = sinon.spy(this.playerError, 'error')
+      const spy = sinon.spy(this.playerError, 'createError')
       this.basePlayback.createError()
 
       expect(spy).to.have.been.calledWith(defaultError)

--- a/test/components/error_spec.js
+++ b/test/components/error_spec.js
@@ -19,7 +19,7 @@ describe('PlayerError', function() {
   describe('when error method is called', function() {
     it('triggers ERROR event', function() {
       sinon.spy(this.core, 'trigger')
-      this.playerError.error(this.errorData)
+      this.playerError.createError(this.errorData)
 
       assert.ok(this.core.trigger.calledWith(Events.ERROR, {
         code: 'test_01',
@@ -35,7 +35,7 @@ describe('PlayerError', function() {
       it('does not trigger ERROR event', function() {
         sinon.spy(this.core, 'trigger')
         this.playerError.core = undefined
-        this.playerError.error(this.errorData)
+        this.playerError.createError(this.errorData)
 
         assert.notOk(this.core.trigger.calledWith(Events.ERROR, this.errorData))
       })


### PR DESCRIPTION
The main change here is the addition of the method `createError`. The method was added to the `player`, `core` and `container` and now it's possible to create an error in these scopes.