### PR TITLE
Use remove from ui object instead of zepto on playback

### DIFF
--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -208,7 +208,7 @@ export default class Playback extends UIObject {
    * @method destroy
    */
   destroy() {
-    this.$el.remove()
+    this.remove()
   }
 }
 

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -401,7 +401,7 @@ export default class HTML5Video extends Playback {
   destroy() {
     this._destroyed = true
     this.handleTextTrackChange && this.el.textTracks.removeEventListener('change', this.handleTextTrackChange)
-    this.$el.remove()
+    super.destroy()
     this.el.removeAttribute('src')
     this._src = null
     DomRecycler.garbage(this.$el)

--- a/test/base/playback_spec.js
+++ b/test/base/playback_spec.js
@@ -29,7 +29,7 @@ describe('Playback', function() {
 
   it('destroys by removing element from DOM', () => {
     const spy = sinon.spy()
-    this.basePlayback.$el = { remove: spy }
+    this.basePlayback.$el = { remove: spy, off: () => {} }
 
     this.basePlayback.destroy()
 


### PR DESCRIPTION
In addition to removing element this change removes listeners and undelegate events from playback.
This will stop triggering errors from destroyed video element that was still delegated.