### PR TITLE
Add option to disable error screen plugin

### DIFF
--- a/src/components/player.js
+++ b/src/components/player.js
@@ -221,6 +221,8 @@ export default class Player extends BaseObject {
    * E.g. onReady -> "PLAYER_READY", onTimeUpdate -> "PLAYER_TIMEUPDATE"
    * @param {PlaybackConfig} [options.playback]
    * Generic `Playback` component related configuration
+   * @param {Boolean} [options.disableErrorScreen]
+   * disables the error screen plugin.
    */
 
   constructor(options) {

--- a/src/plugins/error_screen/error_screen.js
+++ b/src/plugins/error_screen/error_screen.js
@@ -18,6 +18,12 @@ export default class ErrorScreen extends UICorePlugin {
     }
   }
 
+  constructor(core) {
+    super(core)
+
+    if (this.options.disableErrorScreen) return this.disable()
+  }
+
   bindEvents() {
     this.listenTo(this.core, Events.ERROR, this.onError)
     this.listenTo(this.core.mediaControl, Events.MEDIACONTROL_CONTAINERCHANGED, this.onContainerChanged)

--- a/src/plugins/poster/poster.js
+++ b/src/plugins/poster/poster.js
@@ -55,6 +55,8 @@ export default class PosterPlugin extends UIContainerPlugin {
   }
 
   onError(error) {
+    if (this.options.disableErrorScreen) return
+
     if (error.level == PlayerError.Levels.FATAL) {
       this.hasFatalError = true
       this.hidePlayButton()


### PR DESCRIPTION
Add an option to disable error screen plugin. This option also prevents the poster hides its play button when there is a fatal error.