### PR TITLE
Add configure method on playback to allow update options

### DIFF
--- a/src/base/playback.js
+++ b/src/base/playback.js
@@ -2,6 +2,8 @@ import { extend } from './utils'
 import UIObject from './ui_object'
 import ErrorMixin from './error_mixin'
 
+import $ from 'clappr-zepto'
+
 /**
  * An abstraction to represent a generic playback, it's like an interface to be implemented by subclasses.
  * @class Playback
@@ -202,6 +204,15 @@ export default class Playback extends UIObject {
    * @param {Number} value a number between 0 (`muted`) to 100 (`max`)
    */
   volume(value) {} // eslint-disable-line no-unused-vars
+
+  /**
+   * enables to configure the playback after its creation
+   * @method configure
+   * @param {Object} options all the options to change in form of a javascript object
+   */
+  configure(options) {
+    this._options = $.extend(this._options, options)
+  }
 
   /**
    * destroys the playback, removing it from DOM

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -465,6 +465,7 @@ export default class Container extends UIObject {
   configure(options) {
     this._options = $.extend(this._options, options)
     this.updateStyle()
+    this.playback.configure(this.options)
     this.trigger(Events.CONTAINER_OPTIONS_CHANGE)
   }
 

--- a/test/components/container_spec.js
+++ b/test/components/container_spec.js
@@ -47,6 +47,15 @@ describe('Container', function() {
     assert.ok(this.container.$el.remove.calledOnce)
   })
 
+  it('update playback options when configure', function() {
+    sinon.spy(this.playback, 'configure')
+    const fakeOptions = { foo: 'bar' }
+    this.container.configure(fakeOptions)
+
+    assert.ok(this.playback.configure.called)
+    expect(this.playback.options.foo).to.be.equal(fakeOptions.foo)
+  })
+
   it('listens to playback:progress event', function() {
     sinon.spy(this.container, 'progress')
 


### PR DESCRIPTION
When player receive a new set of options, playback can use some of then.
With this PR, when `player.configure` was called the playback will update his internal copy of options, avoiding using old values when play.