### PR TITLE
fix(html5_video):  Locked mute/unmute when setting any volume value

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -279,8 +279,8 @@ export default class HTML5Video extends Playback {
     } else {
       this.$el.attr({ muted: null })
       this.el.muted = false
+      this.el.volume = value / 100
     }
-    this.el.volume = value / 100
   }
 
   /**


### PR DESCRIPTION
Setting volume property on tag video only if value !== 0
This can lock the mute/unmute action in some browsers/devices (e.g. Chrome + OnePlus)