### PR TITLE
feat: HLS level switch

### DIFF
--- a/doc/BUILTIN_PLUGINS.md
+++ b/doc/BUILTIN_PLUGINS.md
@@ -72,6 +72,9 @@ In case you're loading a on demand video (mp4), it's possible to define the way 
 ##### HLS Buffer Length
 The default behavior for the HLS playback is to keep buffering indefinitely, even on VoD. This replicates the behavior for progressive download, which continues buffering when pausing the video, thus making the video available for playback even on slow networks. To change this behavior, add `maxBufferLength: <value>` to embed parameters, where `value` is in seconds.
 
+##### HLS level switch
+The default behavior for the HLS playback is to use [hls.currentLevel](https://github.com/video-dev/hls.js/blob/master/docs/API.md#hlscurrentlevel) to switch current level. To change this behaviour and force HLS playback to use [hls.nextLevel](https://github.com/video-dev/hls.js/blob/master/docs/API.md#hlsnextlevel), add `hlsUseNextLevel: true` to embed parameters. (default value is false)
+
 ##### Playback configuration
 The configuration for the playback, it's still only compatible with `html5_video` playback.
 

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -32,7 +32,10 @@ export default class HLS extends HTML5VideoPlayback {
   set currentLevel(id) {
     this._currentLevel = id
     this.trigger(Events.PLAYBACK_LEVEL_SWITCH_START)
-    this._hls.currentLevel = this._currentLevel
+    if (this.options.hlsUseNextLevel)
+      this._hls.nextLevel = this._currentLevel
+    else
+      this._hls.currentLevel = this._currentLevel
   }
 
   get _startTime() {


### PR DESCRIPTION
It adds `hlsUseNextLevel` player option to change default HLS playback behaviour for level switch.
(for more details, see documentation changes)

Should satisfy #1670.

@core : i can rename option if required.