### PR TITLE
fix: mobile device autoplay

### DIFF
--- a/doc/BUILTIN_PLUGINS.md
+++ b/doc/BUILTIN_PLUGINS.md
@@ -18,6 +18,8 @@ You can specify where the player should be attached to using either the `parentI
 ##### Auto Play
 Add `autoPlay: true` if you want the video to automatically play after page load.
 
+By default, Clappr player will do its best to detect if the browser can play video automatically. If you want to disable this behaviour, add `disableCanAutoPlay: true` parameter.
+
 ##### Loop
 Add `loop: true` if you want the video to automatically replay after it ends.
 

--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -246,10 +246,11 @@ export function canAutoPlayMedia(cb, options) {
     muted: false,
     timeout: 250,
     type: 'video',
-    source: Media.mp4
+    source: Media.mp4,
+    element: null
   }, options)
 
-  let element = document.createElement(options.type)
+  let element = options.element ? options.element : document.createElement(options.type)
 
   element.muted = options.muted
   if (options.muted === true)

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -156,16 +156,24 @@ export default class HTML5Video extends Playback {
 
   // See Playback.canAutoPlay()
   canAutoPlay(cb) {
+    let opts = {
+      timeout: this.options.autoPlayTimeout || 500,
+      inline: this.options.playback.playInline || false,
+      muted: this.options.mute || false, // Known issue: mediacontrols may asynchronously mute video
+    }
+
     if (Browser.isMobile) {
+      if (DomRecycler.options.recycleVideo) {
+        // Use current video element if recycling feature enabled
+        opts.element = this.el
+      }
+
       // Mobile browser autoplay require user consent and video recycling feature enabled
-      cb(this.consented && DomRecycler.options.recycleVideo, null)
+      // It may returns a false positive with source-less player consent
+      canAutoPlayMedia(cb, opts)
     } else {
       // Desktop browser autoplay policy may require user action
-      canAutoPlayMedia(cb, {
-        timeout: this.options.autoPlayTimeout || 500,
-        inline: this.options.playback.playInline || false,
-        muted: this.options.mute || false, // Known issue: mediacontrols may asynchronously mute video
-      })
+      canAutoPlayMedia(cb, opts)
     }
   }
 

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -162,19 +162,14 @@ export default class HTML5Video extends Playback {
       muted: this.options.mute || false, // Known issue: mediacontrols may asynchronously mute video
     }
 
-    if (Browser.isMobile) {
-      if (DomRecycler.options.recycleVideo) {
-        // Use current video element if recycling feature enabled
-        opts.element = this.el
-      }
+    // Use current video element if recycling feature enabled with mobile devices
+    if (Browser.isMobile && DomRecycler.options.recycleVideo)
+      opts.element = this.el
 
-      // Mobile browser autoplay require user consent and video recycling feature enabled
-      // It may returns a false positive with source-less player consent
-      canAutoPlayMedia(cb, opts)
-    } else {
-      // Desktop browser autoplay policy may require user action
-      canAutoPlayMedia(cb, opts)
-    }
+    // Desktop browser autoplay policy may require user action
+    // Mobile browser autoplay require user consent and video recycling feature enabled
+    // It may returns a false positive with source-less player consent
+    canAutoPlayMedia(cb, opts)
   }
 
   _setupExternalTracks(tracks) {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -156,6 +156,9 @@ export default class HTML5Video extends Playback {
 
   // See Playback.canAutoPlay()
   canAutoPlay(cb) {
+    if (this.options.disableCanAutoPlay)
+      cb(true, null)
+
     let opts = {
       timeout: this.options.autoPlayTimeout || 500,
       inline: this.options.playback.playInline || false,

--- a/test/playbacks/html5_video_spec.js
+++ b/test/playbacks/html5_video_spec.js
@@ -78,7 +78,8 @@ describe('HTML5Video playback', function() {
 
   it('can check autoplay availability', function(done) {
     this.timeout(5000)
-    const playback = new HTML5Video({ src: 'http://example.com/dash.ogg', mute: true })
+    // FIXME: find a way to set disableCanAutoPlay to true only if Travis run
+    const playback = new HTML5Video({ src: 'http://example.com/dash.ogg', mute: true, disableCanAutoPlay: true })
 
     playback.canAutoPlay(function(result, error) {
       expect(result).to.be.true
@@ -97,7 +98,7 @@ describe('HTML5Video playback', function() {
 
   it('isPlaying() is true after constructor when autoPlay is true', function(done) {
     this.timeout(5000)
-    const playback = new HTML5Video({ src: 'http://example.com/dash.ogg', autoPlay: true, mute: true })
+    const playback = new HTML5Video({ src: 'http://example.com/dash.ogg', autoPlay: true, mute: true, disableCanAutoPlay: true })
 
     playback.on(Events.PLAYBACK_PLAY_INTENT, function() {
       process.nextTick(function() {


### PR DESCRIPTION
It fixes an issue for mobile devices in the canAutoPlay method in html5 video playback : it does not rely anymore on the playback consented value because it may be reseted to false if source has changed (ie: playback re-created).

Fixes #1680.
