### PR TITLE
Added reference to P2P Media Loader GitHub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Clappr is under heavy development but production-ready. Feel free to open issues
   <img src='https://raw.githubusercontent.com/thiagopnts/clappr-video360/master/360.gif' width="280" height="160"></img>
 </a> <a href="https://github.com/lucasrodcosta/clappr-nerd-stats/">
   <img src='https://raw.githubusercontent.com/lucasrodcosta/clappr-nerd-stats/master/images/clappr-nerd-stats.png' width="280"></img>
+</a> <a href="https://github.com/Novage/p2p-media-loader/">
+  <img src='https://raw.githubusercontent.com/Novage/p2p-media-loader/gh-pages/images/p2pml-logo.png' width="280"></img>
 </a>
 
 ## [Supported Formats](doc/SUPPORTED_FORMATS.md)


### PR DESCRIPTION
FOSS library that adds P2P stream sharing capabilities of live and VOD HLS streams into Clappr