### PR TITLE
fix: mediacontrol autohide timeout

### DIFF
--- a/doc/BUILTIN_PLUGINS.md
+++ b/doc/BUILTIN_PLUGINS.md
@@ -170,6 +170,8 @@ you might consider subclassing the base `MediaControl` and using your own custom
 
 If you want to disable media control auto hide, add `hideMediaControl: false` in your embed parameters.
 
+If you want to change the default media control auto hide timeout value, add `hideMediaControlDelay: 2000` in your embed parameters. (delay in milliseconds)
+
 ##### Hide Volume Bar
 
 When embedded with width less than 320, volume bars are hidden. You can force this behavior for all sizes by adding `hideVolumeBar: true`.

--- a/src/components/media_control/media_control.js
+++ b/src/components/media_control/media_control.js
@@ -659,7 +659,7 @@ export default class MediaControl extends UIObject {
   }
 
   render() {
-    const timeout = 1000
+    const timeout = this.options.hideMediaControlDelay || 2000
     this.$el.html(this.template({ settings: this.settings }))
     this.createCachedElements()
     this.$playPauseToggle.addClass('paused')


### PR DESCRIPTION
It adds `hideMediaControlDelay` embed parameter in documentation.

It also fix and issue in the media control render method which does not take account of `hideMediaControlDelay` value. It currently have an hardcoded 1000 milliseconds default value.

__Note:__ i did not change the default value to 2000 (same value as [hide()](https://github.com/clappr/clappr/blob/master/src/components/media_control/media_control.js#L491) method) to avoid breaking change of the default behaviour. But i think it should be also changed to 2000 [instead of 1000](https://github.com/clappr/clappr/blob/master/src/components/media_control/media_control.js#L662).

So if Clappr core think it should be also changed to 2000, tell me and i modify the PR commit.