### PR TITLE
 fix(core): full screen mode on an iOS browser

### DIFF
--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -304,15 +304,17 @@ export default class Core extends UIObject {
   }
 
   toggleFullscreen() {
-    if (!Fullscreen.isFullscreen()) {
-      Fullscreen.requestFullscreen(this.el)
-      if (!Browser.isiOS)
-        this.$el.addClass('fullscreen')
-
-    } else {
+    if (Fullscreen.isFullscreen()) {
       Fullscreen.cancelFullscreen()
       if (!Browser.isiOS)
         this.$el.removeClass('fullscreen nocursor')
+
+    } else {
+      let element = Browser.isiOS ? this.getCurrentContainer().el : this.el
+      Fullscreen.requestFullscreen(element)
+
+      if (!Browser.isiOS)
+        this.$el.addClass('fullscreen')
 
     }
     this.mediaControl.show()

--- a/test/components/core_spec.js
+++ b/test/components/core_spec.js
@@ -1,5 +1,7 @@
 import Core from '../../src/components/core'
 import Events from '../../src/base/events'
+import { Fullscreen } from '../../src/base/utils'
+import Browser from '../../src/components/browser'
 
 describe('Core', function() {
   describe('When configure', function() {
@@ -39,6 +41,87 @@ describe('Core', function() {
 
       assert.ok(callback.called)
       expect(this.core.options.autoPlay).to.equal(newOptions.autoPlay)
+    })
+  })
+
+  describe('#toggleFullscreen', () => {
+    beforeEach(() => {
+      this.core = new Core({})
+    })
+
+    it('calls this.mediaControl.show()', () => {
+      const spy = sinon.spy(this.core.mediaControl, 'show')
+      this.core.toggleFullscreen()
+      expect(spy).to.have.been.called
+    })
+
+    describe('when is not in fullscreen', () => {
+      let fullScreenSpy
+
+      beforeEach(() => {
+        sinon.stub(Fullscreen, 'isFullscreen').value(() => false)
+        fullScreenSpy = sinon.spy(Fullscreen, 'requestFullscreen')
+      })
+
+      afterEach(() => {
+        fullScreenSpy.restore()
+      })
+
+      describe('and is not an iOS Browser', () => {
+        beforeEach(() => {
+          sinon.stub(Browser, 'isiOS').value(false)
+        })
+
+        it('calls Fullscreen.requestFullscreen with core element', () => {
+          this.core.toggleFullscreen()
+          expect(fullScreenSpy).to.have.been.calledWith(this.core.el)
+        })
+
+        it('adds a class "fullscreen" to core element', () => {
+          const spy = sinon.spy(this.core.$el, 'addClass')
+          expect(spy).not.to.have.been.called
+
+          this.core.toggleFullscreen()
+
+          expect(spy).to.have.been.calledWith('fullscreen')
+        })
+      })
+
+      describe('and is an iOS Browser', () => {
+        it('calls Fullscreen.requestFullscreen with currentContainer element', () => {
+          sinon.stub(Browser, 'isiOS').value(true)
+          const fakeCurrentContainer = '<div id="fakeCurrentContainer"></div>'
+          this.core.getCurrentContainer = sinon.stub().returns({ el: fakeCurrentContainer })
+
+          this.core.toggleFullscreen()
+
+          expect(fullScreenSpy).to.have.been.calledWith(this.core.getCurrentContainer().el)
+        })
+      })
+    })
+
+    describe('when is in fullscreen', () => {
+      beforeEach(() => {
+        sinon.stub(Fullscreen, 'isFullscreen').value(() => true)
+      })
+
+      it('calls Fullscreen.cancelFullscreen', () => {
+        const spy = sinon.spy(Fullscreen, 'cancelFullscreen')
+        this.core.toggleFullscreen()
+        expect(spy).to.have.been.called
+      })
+
+      describe('Browser.isiOS', () => {
+        it('removes "fullscreen nocursor" classes from core element', () => {
+          sinon.stub(Browser, 'isiOS').value(false)
+          const spy = sinon.spy(this.core.$el, 'removeClass')
+          expect(spy).not.to.have.been.called
+
+          this.core.toggleFullscreen()
+
+          expect(spy).to.have.been.calledWith('fullscreen nocursor')
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
This PR fixes that by using the current container element instead of core element as the context on an iOS browser. That prevents to select other Video tags from other plugin like DFP ads.