### PR TITLE
Fix player event onResize

### DIFF
--- a/src/base/events.js
+++ b/src/base/events.js
@@ -579,6 +579,13 @@ Events.CORE_READY = 'core:ready'
  */
 Events.CORE_FULLSCREEN = 'core:fullscreen'
 /**
+ * Fired when core updates size
+ *
+ * @event CORE_RESIZE
+ * @param {Object} currentSize an object with the current size
+ */
+Events.CORE_RESIZE = 'core:resize'
+/**
  * Fired when the screen orientation has changed.
  * This event is trigger only for mobile devices.
  *

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -153,6 +153,7 @@ export default class Core extends UIObject {
     const thereWasChange = this.firstResize || this.oldHeight !== newSize.height || this.oldWidth !== newSize.width
     if (thereWasChange) {
       Mediator.trigger(`${this.options.playerId}:${Events.PLAYER_RESIZE}`, newSize)
+      this.trigger(Events.CORE_RESIZE, newSize)
       this.oldHeight = newSize.height
       this.oldWidth = newSize.width
       this.firstResize = false

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -140,11 +140,7 @@ export default class Core extends UIObject {
 
   enableResizeObserver() {
     const checkSizeCallback = () => {
-      if (this.playerInfo.computedSize.width !== this.el.clientWidth ||
-          this.playerInfo.computedSize.height !== this.el.clientHeight) {
-        this.playerInfo.computedSize = { width: this.el.clientWidth, height: this.el.clientHeight }
-        this.triggerResize(this.playerInfo.computedSize)
-      }
+      this.triggerResize({ width: this.el.clientWidth, height: this.el.clientHeight })
     }
     this.resizeObserverInterval = setInterval(checkSizeCallback, 500)
   }
@@ -219,6 +215,7 @@ export default class Core extends UIObject {
     if (this._screenOrientation === orientation) return
     this._screenOrientation = orientation
 
+    this.triggerResize({ width: this.el.clientWidth, height: this.el.clientHeight })
     this.trigger(Events.CORE_SCREEN_ORIENTATION_CHANGED, {
       event: event,
       orientation: this._screenOrientation
@@ -373,7 +370,7 @@ export default class Core extends UIObject {
     this.options.width = this.options.width || this.$el.width()
     this.options.height = this.options.height || this.$el.height()
     const size = { width: this.options.width, height: this.options.height }
-    this.playerInfo.previousSize = this.playerInfo.currentSize = this.playerInfo.computedSize = size
+    this.playerInfo.previousSize = this.playerInfo.currentSize = size
     this.updateSize()
 
     this.previousSize = { width: this.$el.width(), height: this.$el.height() }

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -288,6 +288,7 @@ export default class Player extends BaseObject {
 
     this.listenTo(this.core.mediaControl, Events.MEDIACONTROL_CONTAINERCHANGED, this._containerChanged)
     this.listenTo(this.core, Events.CORE_FULLSCREEN, this._onFullscreenChange)
+    this.listenTo(this.core, Events.CORE_RESIZE, this._onResize)
     return this
   }
 
@@ -346,6 +347,10 @@ export default class Player extends BaseObject {
 
   _onSubtitleAvailable() {
     this.trigger(Events.PLAYER_SUBTITLE_AVAILABLE)
+  }
+
+  _onResize(size) {
+    this.trigger(Events.PLAYER_RESIZE, size)
   }
 
   _onPlay() {

--- a/test/components/core_spec.js
+++ b/test/components/core_spec.js
@@ -174,14 +174,14 @@ describe('Core', function() {
     describe('when change the screen orientation', () => {
       it('calls #triggerResize with core element width and height', () => {
         this.core._screenOrientation = 'portrait'
-        this.core.handleWindowResize("event")
+        this.core.handleWindowResize('event')
         expect(this.core.triggerResize).to.have.been.calledWith({ height: 0, width: 0 })
       })
     })
 
     describe('when screen orientation doesn\'t change', () => {
       it('doesn\'t calls #triggerResize', () => {
-        this.core.handleWindowResize("event")
+        this.core.handleWindowResize('event')
         expect(this.core.triggerResize).not.to.have.been.called
       })
     })

--- a/test/components/core_spec.js
+++ b/test/components/core_spec.js
@@ -125,7 +125,7 @@ describe('Core', function() {
     })
   })
 
-  describe.only('#enableResizeObserver', () => {
+  describe('#enableResizeObserver', () => {
     beforeEach(() => {
       this.clock = sinon.useFakeTimers()
       this.core = new Core({})

--- a/test/components/core_spec.js
+++ b/test/components/core_spec.js
@@ -125,6 +125,33 @@ describe('Core', function() {
     })
   })
 
+  describe.only('#enableResizeObserver', () => {
+    beforeEach(() => {
+      this.clock = sinon.useFakeTimers()
+      this.core = new Core({})
+      sinon.spy(this.core, 'triggerResize')
+    })
+
+    afterEach(() => {
+      this.clock.restore()
+    })
+
+    it('calls #triggerResize every 500 milliseconds', () => {
+      this.core.enableResizeObserver()
+      expect(this.core.triggerResize).not.to.have.been.called
+      this.clock.tick(500)
+      expect(this.core.triggerResize).to.have.been.called
+      this.clock.tick(500)
+      expect(this.core.triggerResize).to.have.been.calledTwice
+    })
+
+    it('calls #triggerResize with core element width and height', () => {
+      this.core.enableResizeObserver()
+      this.clock.tick(500)
+      expect(this.core.triggerResize).to.have.been.calledWith({ height: 0, width: 0 })
+    })
+  })
+
   describe('#triggerResize', () => {
     it('triggers on an event Events.CORE_RESIZE', () => {
       const newSize = { width: '50%', height: '50%' }
@@ -134,6 +161,29 @@ describe('Core', function() {
       this.core.triggerResize(newSize)
 
       expect(this.core.trigger).to.have.been.calledWith(Events.CORE_RESIZE, newSize)
+    })
+  })
+
+  describe('#handleWindowResize', () => {
+    beforeEach(() => {
+      this.core = new Core({})
+      this.core._screenOrientation = 'landscape'
+      sinon.spy(this.core, 'triggerResize')
+    })
+
+    describe('when change the screen orientation', () => {
+      it('calls #triggerResize with core element width and height', () => {
+        this.core._screenOrientation = 'portrait'
+        this.core.handleWindowResize("event")
+        expect(this.core.triggerResize).to.have.been.calledWith({ height: 0, width: 0 })
+      })
+    })
+
+    describe('when screen orientation doesn\'t change', () => {
+      it('doesn\'t calls #triggerResize', () => {
+        this.core.handleWindowResize("event")
+        expect(this.core.triggerResize).not.to.have.been.called
+      })
     })
   })
 })

--- a/test/components/core_spec.js
+++ b/test/components/core_spec.js
@@ -124,4 +124,16 @@ describe('Core', function() {
       })
     })
   })
+
+  describe('#triggerResize', () => {
+    it('triggers on an event Events.CORE_RESIZE', () => {
+      const newSize = { width: '50%', height: '50%' }
+
+      this.core = new Core({})
+      sinon.spy(this.core, 'trigger')
+      this.core.triggerResize(newSize)
+
+      expect(this.core.trigger).to.have.been.calledWith(Events.CORE_RESIZE, newSize)
+    })
+  })
 })

--- a/test/player_spec.js
+++ b/test/player_spec.js
@@ -191,4 +191,30 @@ describe('Player', function() {
       expect(callbacks.callbackB).to.have.been.calledOnce
     })
   })
+
+  describe('when a core event is fired', () => {
+    let onResizeSpy
+
+    beforeEach(() => {
+      onResizeSpy = sinon.spy()
+
+      this.player = new Player({
+        source: '/video.mp4',
+        events: {
+          onResize: onResizeSpy
+        }
+      })
+
+      const element = document.createElement('div')
+      this.player.attachTo(element)
+    })
+
+    describe('on Events.CORE_RESIZE', () => {
+      it('calls onResize callback with width and height', () => {
+        const newSize = { width: '50%', height: '50%' }
+        this.player.core.trigger(Events.CORE_RESIZE, newSize)
+        expect(onResizeSpy).to.have.been.calledWith(newSize)
+      })
+    })
+  })
 })


### PR DESCRIPTION
This PR creates a new event in core component and triggers that on resize, so we can effectively fire the event PLAYER_RESIZE.
