### PR TITLE
fix(player): brings back computedSize property

### DIFF
--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -148,11 +148,12 @@ export default class Core extends UIObject {
   triggerResize(newSize) {
     const thereWasChange = this.firstResize || this.oldHeight !== newSize.height || this.oldWidth !== newSize.width
     if (thereWasChange) {
-      Mediator.trigger(`${this.options.playerId}:${Events.PLAYER_RESIZE}`, newSize)
-      this.trigger(Events.CORE_RESIZE, newSize)
       this.oldHeight = newSize.height
       this.oldWidth = newSize.width
+      this.playerInfo.computedSize = newSize
       this.firstResize = false
+      Mediator.trigger(`${this.options.playerId}:${Events.PLAYER_RESIZE}`, newSize)
+      this.trigger(Events.CORE_RESIZE, newSize)
     }
   }
 
@@ -370,7 +371,7 @@ export default class Core extends UIObject {
     this.options.width = this.options.width || this.$el.width()
     this.options.height = this.options.height || this.$el.height()
     const size = { width: this.options.width, height: this.options.height }
-    this.playerInfo.previousSize = this.playerInfo.currentSize = size
+    this.playerInfo.previousSize = this.playerInfo.currentSize = this.playerInfo.computedSize = size
     this.updateSize()
 
     this.previousSize = { width: this.$el.width(), height: this.$el.height() }

--- a/test/components/core_spec.js
+++ b/test/components/core_spec.js
@@ -153,9 +153,34 @@ describe('Core', function() {
   })
 
   describe('#triggerResize', () => {
+    it('sets the properties oldHeight and oldWidth with the new one', () => {
+      const newSize = { width: '50%', height: '50%' }
+      this.core = new Core({})
+
+      expect(this.core.oldHeight).equal(undefined)
+      expect(this.core.oldWidth).equal(undefined)
+
+      sinon.spy(this.core, 'trigger')
+      this.core.triggerResize(newSize)
+
+      expect(this.core.oldHeight).equal('50%')
+      expect(this.core.oldWidth).equal('50%')
+    })
+
+    it('sets the property computedSize with the new one', () => {
+      const newSize = { width: '50%', height: '50%' }
+      this.core = new Core({})
+
+      expect(this.core.computedSize).equal(undefined)
+
+      sinon.spy(this.core, 'trigger')
+      this.core.triggerResize(newSize)
+
+      expect(this.core.playerInfo.computedSize).equal(newSize)
+    })
+
     it('triggers on an event Events.CORE_RESIZE', () => {
       const newSize = { width: '50%', height: '50%' }
-
       this.core = new Core({})
       sinon.spy(this.core, 'trigger')
       this.core.triggerResize(newSize)


### PR DESCRIPTION
This PR brings back the computedSize property because there are third-party applications using it.