### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 sudo: false
-node_js: "8"
+node_js:
+  - "node"
+  - "10"
+  - "8"
+  - "6"
 cache: yarn
 
 before_install:


### PR DESCRIPTION
We should test against all current LTS and stable branches of LTS to catch any issues.