### PR TITLE
fix(playback) HTML5 playback isMuted function logic is inverted

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -306,7 +306,7 @@ export default class HTML5Video extends Playback {
   }
 
   isMuted() {
-    return !this.el.volume
+    return this.el.muted === true || this.el.volume === 0
   }
 
   isPlaying() {

--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -306,7 +306,7 @@ export default class HTML5Video extends Playback {
   }
 
   isMuted() {
-    return !!this.el.volume
+    return !this.el.volume
   }
 
   isPlaying() {


### PR DESCRIPTION
It looks like it's been (broken) this way for a long time.

In addition, I observed that the `video.muted` property could be set to true while the `video.volume` > 0, and it still behaves muted.  We should check both of the properties.