### PR TITLE
Fix: stop loading resource after stop() and destroy() methods are called

### DIFF
--- a/src/playbacks/html5_video/html5_video.js
+++ b/src/playbacks/html5_video/html5_video.js
@@ -273,6 +273,7 @@ export default class HTML5Video extends Playback {
     this._stopped = true
     // src will be added again in play()
     this.el.removeAttribute('src')
+    this.el.load() // load with no src to stop loading of the previous source and avoid leaks
     this._stopPlayheadMovingChecks()
     this._handleBufferingEvents()
     this.trigger(Events.PLAYBACK_STOP)
@@ -441,6 +442,7 @@ export default class HTML5Video extends Playback {
     this.handleTextTrackChange && this.el.textTracks.removeEventListener('change', this.handleTextTrackChange)
     super.destroy()
     this.el.removeAttribute('src')
+    this.el.load() // load with no src to stop loading of the previous source and avoid leaks
     this._src = null
     DomRecycler.garbage(this.$el)
   }


### PR DESCRIPTION
When working with icecast audio and call `stop()` or `destroy()` methods, the source continues to load (forever).
Now it's fixed.

[Here you can see an example with icecast](http://clappr.io/demo/#dmFyIHBsYXllckVsZW1lbnQgPSBkb2N1bWVudC5nZXRFbGVtZW50QnlJZCgicGxheWVyLXdyYXBwZXIiKTsKCnZhciBwbGF5ZXIgPSBuZXcgQ2xhcHByLlBsYXllcih7CiAgc291cmNlOiAnaHR0cDovL3JldHJvNzAuaG9zdGluZ3JhZGlvLnJ1OjgwMjUvcmV0cm83MC0xMjgubXAzJywKICBoZWlnaHQ6IDM2MCwKICB3aWR0aDogNjQwCn0pOwoKcGxheWVyLmF0dGFjaFRvKHBsYXllckVsZW1lbnQpOwo=)

Open dev tools -> Network and look: when the player is stopped the resource is still loading. When I have several icecast stations and switch between them, destroying the player each time, I end up with the situation when every resource is loading via several requests and new requests are pending. It's a serious leak. You can press "Run" in the example several times, starting the playback each time, to see the same situation. 

The idea of the fix is discussed here:
https://stackoverflow.com/questions/3258587/how-to-properly-unload-destroy-a-video-element

Also it can be fixed via `this.el.src = ''`, but the variant with load() method is clearer. 

P.S.: I haven't tested the code with this fix directly, since I can't build the player on Windows (yarn install doesn't work and I have Node.js 10 installed). But the same technique I used in my own code to bypass the bug, i.e. the following code

```js
this.player.core.activePlayback.el.removeAttribute('src');
this.player.core.activePlayback.el.load();
```

before `destroy()` and `stop()`. And it works well.