### PR TITLE
Listen for CORE_ACTIVE_CONTAINER_CHANGED on Core

### DIFF
--- a/src/components/player.js
+++ b/src/components/player.js
@@ -295,7 +295,7 @@ export default class Player extends BaseObject {
     else
       this._onReady()
 
-    this.listenTo(this.core.activeContainer, Events.CORE_ACTIVE_CONTAINER_CHANGED, this._containerChanged)
+    this.listenTo(this.core, Events.CORE_ACTIVE_CONTAINER_CHANGED, this._containerChanged)
     this.listenTo(this.core, Events.CORE_FULLSCREEN, this._onFullscreenChange)
     this.listenTo(this.core, Events.CORE_RESIZE, this._onResize)
     return this


### PR DESCRIPTION
Event `CORE_ACTIVE_CONTAINER_CHANGED` is triggered on the `Core` object. That's why it's needed to listen for this event of the `Core` object also :-)