### PR TITLE
fix(player): listen "active container changed" event to core

### DIFF
--- a/src/components/player.js
+++ b/src/components/player.js
@@ -295,7 +295,7 @@ export default class Player extends BaseObject {
     else
       this._onReady()
 
-    this.listenTo(this.core.activeContainer, Events.CORE_ACTIVE_CONTAINER_CHANGED, this._containerChanged)
+    this.listenTo(this.core, Events.CORE_ACTIVE_CONTAINER_CHANGED, this._containerChanged)
     this.listenTo(this.core, Events.CORE_FULLSCREEN, this._onFullscreenChange)
     this.listenTo(this.core, Events.CORE_RESIZE, this._onResize)
     return this


### PR DESCRIPTION
Fix a small regression from 0.2.x where player events were not bind after calling `player.load()` or `player.configure()` methods with a new source.

Fixes #1749.
