### PR TITLE
fix(container): handle double touch event

### DIFF
--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -316,22 +316,16 @@ export class DoubleEventHandler {
   constructor(delay = 500) {
     this.delay = delay
     this.lastTime = 0
-    this.timer = null
   }
 
   handle(event, cb, prevented = true) {
     // Based on http://jsfiddle.net/brettwp/J4djY/
     let currentTime = new Date().getTime()
     let diffTime = currentTime - this.lastTime
-    clearTimeout(this.timer)
 
     if (diffTime < this.delay && diffTime > 0) {
       cb()
       prevented && event.preventDefault()
-    } else {
-      this.timer = setTimeout(() => {
-        clearTimeout(this.timer)
-      }, this.delay)
     }
 
     this.lastTime = currentTime

--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -312,22 +312,22 @@ export class DomRecycler {
 
 DomRecycler.options = { recycleVideo: false }
 
-export class DoubleTouchEventHandler {
+export class DoubleEventHandler {
   constructor(delay = 500) {
     this.delay = delay
     this.lastTime = 0
     this.timer = null
   }
 
-  handle(touchendEvent, cb) {
+  handle(event, cb, prevented = true) {
     // Based on http://jsfiddle.net/brettwp/J4djY/
     let currentTime = new Date().getTime()
-    let tapLength = currentTime - this.lastTime
+    let diffTime = currentTime - this.lastTime
     clearTimeout(this.timer)
 
-    if (tapLength < this.delay && tapLength > 0) {
+    if (diffTime < this.delay && diffTime > 0) {
       cb()
-      touchendEvent.preventDefault()
+      prevented && event.preventDefault()
     } else {
       this.timer = setTimeout(() => {
         clearTimeout(this.timer)
@@ -356,5 +356,5 @@ export default {
   removeArrayItem,
   canAutoPlayMedia,
   Media,
-  DoubleTouchEventHandler
+  DoubleEventHandler
 }

--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -312,6 +312,32 @@ export class DomRecycler {
 
 DomRecycler.options = { recycleVideo: false }
 
+export class DoubleTouchEventHandler {
+  constructor(delay = 500) {
+    this.delay = delay
+    this.lastTime = 0
+    this.timer = null
+  }
+
+  handle(touchendEvent, cb) {
+    // Based on http://jsfiddle.net/brettwp/J4djY/
+    let currentTime = new Date().getTime()
+    let tapLength = currentTime - this.lastTime
+    clearTimeout(this.timer)
+
+    if (tapLength < this.delay && tapLength > 0) {
+      cb()
+      touchendEvent.preventDefault()
+    } else {
+      this.timer = setTimeout(() => {
+        clearTimeout(this.timer)
+      }, this.delay)
+    }
+
+    this.lastTime = currentTime
+  }
+}
+
 export default {
   Config,
   Fullscreen,
@@ -329,5 +355,6 @@ export default {
   now,
   removeArrayItem,
   canAutoPlayMedia,
-  Media
+  Media,
+  DoubleTouchEventHandler
 }

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -9,7 +9,7 @@
 import Events from '../../base/events'
 import UIObject from '../../base/ui_object'
 import ErrorMixin from '../../base/error_mixin'
-import { DoubleTouchEventHandler } from '../../base/utils'
+import { DoubleEventHandler } from '../../base/utils'
 
 import './public/style.scss'
 
@@ -125,7 +125,7 @@ export default class Container extends UIObject {
     this.isReady = false
     this.mediaControlDisabled = false
     this.plugins = [this.playback]
-    this.dblTapHandler = new DoubleTouchEventHandler(500)
+    this.dblTapHandler = new DoubleEventHandler(500)
     this.clickTimer = null
     this.clickDelay = 200  // FIXME: could be a player option
     this.bindEvents()

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -9,6 +9,7 @@
 import Events from '../../base/events'
 import UIObject from '../../base/ui_object'
 import ErrorMixin from '../../base/error_mixin'
+import { DoubleTouchEventHandler } from '../../base/utils'
 
 import './public/style.scss'
 
@@ -124,9 +125,7 @@ export default class Container extends UIObject {
     this.isReady = false
     this.mediaControlDisabled = false
     this.plugins = [this.playback]
-    this.dblTapTimer = null
-    this.dblTapLast = 0
-    this.dblTapDelay = 500 // FIXME: could be a player option
+    this.dblTapHandler = new DoubleTouchEventHandler(500)
     this.clickTimer = null
     this.clickDelay = 200  // FIXME: could be a player option
     this.bindEvents()
@@ -358,22 +357,10 @@ export default class Container extends UIObject {
 
   dblTap(evt) {
     if (!this.options.chromeless || this.options.allowUserInteraction) {
-      // Based on http://jsfiddle.net/brettwp/J4djY/
-      let currentTime = new Date().getTime()
-      let tapLength = currentTime - this.dblTapLast
-      clearTimeout(this.dblTapTimer)
-
-      if (tapLength < this.dblTapDelay && tapLength > 0) {
+      this.dblTapHandler.handle(evt, () => {
         this.cancelClicked()
         this.trigger(Events.CONTAINER_DBLCLICK, this, this.name)
-        evt.preventDefault()
-      } else {
-        this.dblTapTimer = setTimeout(() => {
-          clearTimeout(this.dblTapTimer)
-        }, this.dblTapDelay)
-      }
-
-      this.dblTapLast = currentTime
+      })
     }
   }
 

--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -35,7 +35,7 @@ export default class Container extends UIObject {
     return {
       'click': 'clicked',
       'dblclick': 'dblClicked',
-      'doubleTap': 'dblClicked',
+      'touchend': 'dblTap',
       'contextmenu': 'onContextMenu',
       'mouseenter': 'mouseEnter',
       'mouseleave': 'mouseLeave'
@@ -124,6 +124,9 @@ export default class Container extends UIObject {
     this.isReady = false
     this.mediaControlDisabled = false
     this.plugins = [this.playback]
+    this.dblTapTimer = null
+    this.dblTapLast = 0
+    this.dblTapDelay = 500 // FIXME: could be a player option
     this.bindEvents()
   }
 
@@ -339,6 +342,26 @@ export default class Container extends UIObject {
     if (!this.options.chromeless || this.options.allowUserInteraction)
       this.trigger(Events.CONTAINER_DBLCLICK, this, this.name)
 
+  }
+
+  dblTap(evt) {
+    if (!this.options.chromeless || this.options.allowUserInteraction) {
+      // Based on http://jsfiddle.net/brettwp/J4djY/
+      let currentTime = new Date().getTime()
+      let tapLength = currentTime - this.dblTapLast
+      clearTimeout(this.dblTapTimer)
+
+      if (tapLength < this.dblTapDelay && tapLength > 0) {
+        this.trigger(Events.CONTAINER_DBLCLICK, this, this.name)
+        evt.preventDefault()
+      } else {
+        this.dblTapTimer = setTimeout(() => {
+          clearTimeout(this.dblTapTimer)
+        }, this.dblTapDelay)
+      }
+
+      this.dblTapLast = currentTime
+    }
   }
 
   onContextMenu(event) {

--- a/test/base/utils_spec.js
+++ b/test/base/utils_spec.js
@@ -267,10 +267,10 @@ describe('Utils', function() {
     })
   })
 
-  describe('DoubleTouchEventHandler', function() {
+  describe('DoubleEventHandler', function() {
     it('handle double event', function() {
       const delay = 500
-      const handler = new utils.DoubleTouchEventHandler(delay)
+      const handler = new utils.DoubleEventHandler(delay)
       const spy = sinon.spy()
       const evt = new Event('touchend')
 

--- a/test/base/utils_spec.js
+++ b/test/base/utils_spec.js
@@ -266,4 +266,20 @@ describe('Utils', function() {
       expect(video1[0]).to.be.equal(video2[0])
     })
   })
+
+  describe('DoubleTouchEventHandler', function() {
+    it('handle double event', function() {
+      const delay = 500
+      const handler = new utils.DoubleTouchEventHandler(delay)
+      const spy = sinon.spy()
+      const evt = new Event('touchend')
+
+      handler.handle(evt, spy)
+      expect(spy).to.not.have.been.called
+      setTimeout(() => {
+        handler.handle(evt, spy)
+        expect(spy).to.have.been.calledOnce
+      }, delay/2)
+    })
+  })
 })


### PR DESCRIPTION
Since the touch module [has been removed](https://github.com/clappr/clappr-zepto/commit/7dca838af14dab84ebbadef79a27abf45b70553d) from Clappr Zepto custom build, the container double tap/touch event is broken.

I googled about double tab and i make a quick fix based on this [jsFiddle](http://jsfiddle.net/brettwp/J4djY/).

I am not sure if this is the most elegant way to fix the issue, but it seems to work _(i tested on samsung galaxy, galaxy tab, iphone and ipad)_.

Should satisfy #1781.
