### PR TITLE
HLS - Fix interval timer leak

### DIFF
--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -199,6 +199,8 @@ export default class HLS extends HTML5VideoPlayback {
   }
 
   _startTimeUpdateTimer() {
+    if (this._timeUpdateTimer) return
+
     this._timeUpdateTimer = setInterval(() => {
       this._onDurationChange()
       this._onTimeUpdate()
@@ -206,7 +208,10 @@ export default class HLS extends HTML5VideoPlayback {
   }
 
   _stopTimeUpdateTimer() {
+    if (!this._timeUpdateTimer) return
+
     clearInterval(this._timeUpdateTimer)
+    this._timeUpdateTimer = null
   }
 
   getProgramDateTime() {

--- a/src/playbacks/hls/hls.js
+++ b/src/playbacks/hls/hls.js
@@ -405,6 +405,7 @@ export default class HLS extends HTML5VideoPlayback {
   }
 
   stop() {
+    this._stopTimeUpdateTimer()
     if (this._hls) {
       super.stop()
       this._hls.destroy()


### PR DESCRIPTION
This PR fixes a leak of the timer from the HLS plugin. 

The problem happens when the method 'play` is called multiple times. This scenario can happen when the user pauses/play the video, for example.

For each time the `play` was being called, a new timer was being created and not being cleared when the playback was being destroyed.

This PR ensures that only one timer is running and, also, stop the timer when the playback is stopped.