### PR TITLE
Container - Avoid the override of the method progress

### DIFF
--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -160,7 +160,7 @@ export default class Container extends UIObject {
    * @method bindEvents
    */
   bindEvents() {
-    this.listenTo(this.playback, Events.PLAYBACK_PROGRESS, this.progress)
+    this.listenTo(this.playback, Events.PLAYBACK_PROGRESS, this.onProgress)
     this.listenTo(this.playback, Events.PLAYBACK_TIMEUPDATE, this.timeUpdated)
     this.listenTo(this.playback, Events.PLAYBACK_READY, this.ready)
     this.listenTo(this.playback, Events.PLAYBACK_BUFFERING, this.onBuffering)
@@ -287,7 +287,7 @@ export default class Container extends UIObject {
     this.trigger(Events.CONTAINER_TIMEUPDATE, timeProgress, this.name)
   }
 
-  progress(...args) {
+  onProgress(...args) {
     this.trigger(Events.CONTAINER_PROGRESS, ...args, this.name)
   }
 

--- a/test/components/container_spec.js
+++ b/test/components/container_spec.js
@@ -57,12 +57,12 @@ describe('Container', function() {
   })
 
   it('listens to playback:progress event', function() {
-    sinon.spy(this.container, 'progress')
+    sinon.spy(this.container, 'onProgress')
 
     this.container.bindEvents()
     this.playback.trigger(Events.PLAYBACK_PROGRESS, { start: 0, current: 3000, total: 6000 })
 
-    assert.ok(this.container.progress.calledWith({ start: 0, current: 3000, total: 6000 }))
+    assert.ok(this.container.onProgress.calledWith({ start: 0, current: 3000, total: 6000 }))
   })
 
   it('listens to playback:timeupdate event', function() {


### PR DESCRIPTION
This PR renames the handler of PLAYBACK_PROGRESS event on the container.

This is necessary because the method `progress` was being overwritten when the container is transformed into a promise. 
When this happens, some methods are included in its prototype: `[state, always, then, promise, done, fail, progress]`

The method `progress` is one of them, so if a new call to the `bindEvents` method happens when the method `progress` is overwritten, the reference is no longer the original `progress` method.