### PR TITLE
Fixed not fullscreen with Bootstrap

### DIFF
--- a/src/components/container/public/style.scss
+++ b/src/components/container/public/style.scss
@@ -3,7 +3,8 @@
   background-color: black;
   height: 100%;
   width: 100%;
-
+  max-width: 100%;
+  
   .chromeless {
     cursor: default;
   }


### PR DESCRIPTION
Because of the bootstrap container class the player doesn't go full screen, only half. After adding max-width, the bootstrap max-width is ignored and the player goes to proper full screen again.