### PR TITLE
fix(media_control): prevent mediacontrol to show calling configure with source

### DIFF
--- a/src/base/events.js
+++ b/src/base/events.js
@@ -569,6 +569,7 @@ Events.CORE_ACTIVE_CONTAINER_CHANGED = 'core:active:container:changed'
  * Fired when the options were changed for the core
  *
  * @event CORE_OPTIONS_CHANGE
+ * @param {Object} new options provided to configure() method
  */
 Events.CORE_OPTIONS_CHANGE = 'core:options:change'
 /**

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -342,7 +342,7 @@ export default class Core extends UIObject {
     const sources = options.source || options.sources
     sources && this.load(sources, options.mimeType || this.options.mimeType)
 
-    this.trigger(Events.CORE_OPTIONS_CHANGE)
+    this.trigger(Events.CORE_OPTIONS_CHANGE, options) // Trigger with newly provided options
     this.containers.forEach((container) => container.configure(this.options))
   }
 

--- a/src/plugins/media_control/media_control.js
+++ b/src/plugins/media_control/media_control.js
@@ -664,8 +664,13 @@ export default class MediaControl extends UICorePlugin {
    * @method configure
    * @param {Object} options all the options to change in form of a javascript object
    */
-  configure() {
-    this.options.chromeless ? this.disable() : this.enable()
+  configure(options) {
+    // Check if chromeless mode or if configure is called with new source(s)
+    if (this.options.chromeless || options.source || options.sources)
+      this.disable()
+    else
+      this.enable()
+
     this.trigger(Events.MEDIACONTROL_OPTIONS_CHANGE)
   }
 


### PR DESCRIPTION
This is a proposition to fix #1868 

It  adds the options object passed as argument to configure() method to the CORE_OPTIONS_CHANGE event.

This change allow media_control plugin to check if configure has been called with new source(s) and decide if it enable or not.
