### PR TITLE
feat(utils): add SVG icons module

### DIFF
--- a/src/base/svg_icons.js
+++ b/src/base/svg_icons.js
@@ -1,0 +1,38 @@
+// Copyright 2014 Globo.com Player authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import playIcon from '../icons/01-play.svg'
+import pauseIcon from '../icons/02-pause.svg'
+import stopIcon from '../icons/03-stop.svg'
+import volumeIcon from '../icons/04-volume.svg'
+import volumeMuteIcon from '../icons/05-mute.svg'
+import fullscreenIcon from '../icons/06-expand.svg'
+import exitFullscreenIcon from '../icons/07-shrink.svg'
+import hdIcon from '../icons/08-hd.svg'
+import ccIcon from '../icons/09-cc.svg'
+import reloadIcon from '../icons/10-reload.svg'
+
+export let cc = ccIcon
+export let exitFullscreen = exitFullscreenIcon
+export let fullscreen = fullscreenIcon
+export let hd = hdIcon
+export let pause = pauseIcon
+export let play = playIcon
+export let reload = reloadIcon
+export let stop = stopIcon
+export let volume = volumeIcon
+export let volumeMute = volumeMuteIcon
+
+export default {
+  cc: ccIcon,
+  exitFullscreen: exitFullscreenIcon,
+  fullscreen: fullscreenIcon,
+  hd: hdIcon,
+  pause: pauseIcon,
+  play: playIcon,
+  reload: reloadIcon,
+  stop: stopIcon,
+  volume: volumeIcon,
+  volumeMute: volumeMuteIcon,
+}

--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -7,6 +7,7 @@ import './polyfills'
 import Browser from '../components/browser'
 import $ from 'clappr-zepto'
 import Media from './media'
+import Icons from './svg_icons'
 
 export function assign(obj, source) {
   if (source) {
@@ -330,6 +331,8 @@ export class DoubleEventHandler {
   }
 }
 
+export let SvgIcons = Icons
+
 export default {
   Config,
   Fullscreen,
@@ -348,5 +351,6 @@ export default {
   removeArrayItem,
   canAutoPlayMedia,
   Media,
-  DoubleEventHandler
+  DoubleEventHandler,
+  SvgIcons: Icons,
 }

--- a/src/plugins/closed_captions/closed_captions.js
+++ b/src/plugins/closed_captions/closed_captions.js
@@ -1,7 +1,7 @@
 import UICorePlugin from '../../base/ui_core_plugin'
 import template from '../../base/template'
 import Events from '../../base/events'
-import ccIcon from '../../icons/09-cc.svg'
+import { SvgIcons } from '../../base/utils'
 import ccHTML from './public/closed_captions.html'
 import './public/closed_captions.scss'
 
@@ -114,7 +114,7 @@ export default class ClosedCaptions extends UICorePlugin {
     }))
 
     this.$ccButton = this.$el.find('button.cc-button[data-cc-button]')
-    this.$ccButton.append(ccIcon)
+    this.$ccButton.append(SvgIcons.cc)
     this.$el.append(this.style)
   }
 

--- a/src/plugins/error_screen/error_screen.js
+++ b/src/plugins/error_screen/error_screen.js
@@ -2,8 +2,7 @@ import Events from '../../base/events'
 import UICorePlugin from '../../base/ui_core_plugin'
 import template from '../../base/template'
 import PlayerError from '../../components/error/'
-
-import reloadIcon from '../../icons/10-reload.svg'
+import { SvgIcons } from '../../base/utils'
 import templateHtml from './public/error_screen.html'
 import './public/error_screen.scss'
 
@@ -76,7 +75,7 @@ export default class ErrorScreen extends UICorePlugin {
       message: this.err.UI.message,
       code: this.err.code,
       icon: this.err.UI.icon || '',
-      reloadIcon,
+      reloadIcon: SvgIcons.reload,
     }))
 
     this.core.$el.append(this.el)

--- a/src/plugins/favicon/favicon.js
+++ b/src/plugins/favicon/favicon.js
@@ -1,9 +1,7 @@
 import CorePlugin from '../../base/core_plugin'
 import Events from '../../base/events'
 import $ from 'clappr-zepto'
-
-import playIcon from '../../icons/01-play.svg'
-import pauseIcon from '../../icons/02-pause.svg'
+import { SvgIcons } from '../../base/utils'
 
 const oldIcon = $('link[rel="shortcut icon"]')
 
@@ -72,14 +70,14 @@ export default class Favicon extends CorePlugin {
 
   setPlayIcon() {
     if (!this.playIcon)
-      this.playIcon = this.createIcon(playIcon)
+      this.playIcon = this.createIcon(SvgIcons.play)
 
     this.changeIcon(this.playIcon)
   }
 
   setPauseIcon() {
     if (!this.pauseIcon)
-      this.pauseIcon = this.createIcon(pauseIcon)
+      this.pauseIcon = this.createIcon(SvgIcons.pause)
 
     this.changeIcon(this.pauseIcon)
   }

--- a/src/plugins/media_control/media_control.js
+++ b/src/plugins/media_control/media_control.js
@@ -8,27 +8,16 @@
 
 import { Config, Fullscreen, formatTime, extend, removeArrayItem } from '../../base/utils'
 import { Kibo } from '../../vendor'
-
 import Events from '../../base/events'
 import UICorePlugin from '../../base/ui_core_plugin'
 import Browser from '../../components/browser'
 import Mediator from '../../components/mediator'
 import template from '../../base/template'
 import Playback from '../../base/playback'
-
 import $ from 'clappr-zepto'
-
 import './public/media-control.scss'
 import mediaControlHTML from './public/media-control.html'
-
-import playIcon from '../../icons/01-play.svg'
-import pauseIcon from '../../icons/02-pause.svg'
-import stopIcon from '../../icons/03-stop.svg'
-import volumeIcon from '../../icons/04-volume.svg'
-import volumeMuteIcon from '../../icons/05-mute.svg'
-import fullscreenIcon from '../../icons/06-expand.svg'
-import exitFullscreenIcon from '../../icons/07-shrink.svg'
-import hdIcon from '../../icons/08-hd.svg'
+import { SvgIcons } from '../../base/utils'
 
 export default class MediaControl extends UICorePlugin {
   get name() { return 'media_control' }
@@ -215,9 +204,9 @@ export default class MediaControl extends UICorePlugin {
     this.$volumeIcon.html('')
     this.$volumeIcon.removeClass('muted')
     if (!this.muted) {
-      this.$volumeIcon.append(volumeIcon)
+      this.$volumeIcon.append(SvgIcons.volume)
     } else {
-      this.$volumeIcon.append(volumeMuteIcon)
+      this.$volumeIcon.append(SvgIcons.volumeMute)
       this.$volumeIcon.addClass('muted')
     }
     this.applyButtonStyle(this.$volumeIcon)
@@ -227,12 +216,12 @@ export default class MediaControl extends UICorePlugin {
     this.$playPauseToggle.html('')
     this.$playStopToggle.html('')
     if (this.container && this.container.isPlaying()) {
-      this.$playPauseToggle.append(pauseIcon)
-      this.$playStopToggle.append(stopIcon)
+      this.$playPauseToggle.append(SvgIcons.pause)
+      this.$playStopToggle.append(SvgIcons.stop)
       this.trigger(Events.MEDIACONTROL_PLAYING)
     } else {
-      this.$playPauseToggle.append(playIcon)
-      this.$playStopToggle.append(playIcon)
+      this.$playPauseToggle.append(SvgIcons.play)
+      this.$playStopToggle.append(SvgIcons.play)
       this.trigger(Events.MEDIACONTROL_NOTPLAYING)
       Browser.isMobile && this.show()
     }
@@ -262,7 +251,7 @@ export default class MediaControl extends UICorePlugin {
 
   playerResize(size) {
     this.$fullscreenToggle.html('')
-    let icon = this.core.isFullscreen() ? exitFullscreenIcon : fullscreenIcon
+    let icon = this.core.isFullscreen() ? SvgIcons.exitFullscreen : SvgIcons.fullscreen
     this.$fullscreenToggle.append(icon)
     this.applyButtonStyle(this.$fullscreenToggle)
     this.$el.find('.media-control').length !== 0 && this.$el.removeClass('w320')
@@ -565,14 +554,14 @@ export default class MediaControl extends UICorePlugin {
 
   initializeIcons() {
     const $layer = this.$el.find('.media-control-layer')
-    $layer.find('button.media-control-button[data-play]').append(playIcon)
-    $layer.find('button.media-control-button[data-pause]').append(pauseIcon)
-    $layer.find('button.media-control-button[data-stop]').append(stopIcon)
-    this.$playPauseToggle.append(playIcon)
-    this.$playStopToggle.append(playIcon)
-    this.$volumeIcon.append(volumeIcon)
-    this.$fullscreenToggle.append(fullscreenIcon)
-    this.$hdIndicator.append(hdIcon)
+    $layer.find('button.media-control-button[data-play]').append(SvgIcons.play)
+    $layer.find('button.media-control-button[data-pause]').append(SvgIcons.pause)
+    $layer.find('button.media-control-button[data-stop]').append(SvgIcons.stop)
+    this.$playPauseToggle.append(SvgIcons.play)
+    this.$playStopToggle.append(SvgIcons.play)
+    this.$volumeIcon.append(SvgIcons.volume)
+    this.$fullscreenToggle.append(SvgIcons.fullscreen)
+    this.$hdIndicator.append(SvgIcons.hd)
   }
 
   setSeekPercentage(value) {

--- a/src/plugins/poster/poster.js
+++ b/src/plugins/poster/poster.js
@@ -8,7 +8,7 @@ import template from '../../base/template'
 import Playback from '../../base/playback'
 import PlayerError from '../../components/error/error'
 import posterHTML from './public/poster.html'
-import playIcon from '../../icons/01-play.svg'
+import { SvgIcons } from '../../base/utils'
 import './public/poster.scss'
 
 export default class PosterPlugin extends UIContainerPlugin {
@@ -151,7 +151,7 @@ export default class PosterPlugin extends UIContainerPlugin {
 
     this.container.$el.append(this.el)
     this.$playWrapper = this.$el.find('.play-wrapper')
-    this.$playWrapper.append(playIcon)
+    this.$playWrapper.append(SvgIcons.play)
     this.$playButton = this.$playWrapper.find('svg')
     this.$playButton.addClass('poster-icon')
     this.$playButton.attr('data-poster', '')


### PR DESCRIPTION
A simple proposition which should satisfy #1846.

It's a simple workaround to allow developper to override player SVG icons. _(in the meantime to implement a proper way)_.

Example usage :

```javascript
var customPlay = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 492.719 492.719" xml:space="preserve"><path d="M492.719,166.008c0-73.486-59.573-133.056-133.059-133.056c-47.985,0-89.891,25.484-113.302,63.569 c-23.408-38.085-65.332-63.569-113.316-63.569C59.556,32.952,0,92.522,0,166.008c0,40.009,17.729,75.803,45.671,100.178 l188.545,188.553c3.22,3.22,7.587,5.029,12.142,5.029c4.555,0,8.922-1.809,12.142-5.029l188.545-188.553 C474.988,241.811,492.719,206.017,492.719,166.008z"/></svg>';

// Override before create Clappr instance
Clappr.Utils.SvgIcons.play = customPlay;

// A small heart will replace the default play icon
var player = new Clappr.Player({
  // [...]
});
```