### PR TITLE
fix: repair fullscreen element detection with Firefox

### DIFF
--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -56,10 +56,10 @@ export function formatTime(time, paddedHours) {
 }
 
 export const Fullscreen = {
-  getFullscreenElement: function() {
-    return document.webkitFullscreenElement ||
-      document.webkitIsFullScreen ||
-      document.mozFullScreen ||
+  fullscreenElement: function() {
+    return document.fullscreenElement ||
+      document.webkitFullscreenElement ||
+      document.mozFullScreenElement ||
       document.msFullscreenElement
   },
   requestFullscreen: function(el) {

--- a/src/components/core/core.js
+++ b/src/components/core/core.js
@@ -309,7 +309,8 @@ export default class Core extends UIObject {
   }
 
   isFullscreen() {
-    return Fullscreen.getFullscreenElement() === (Browser.isiOS ? this.activeContainer.el : this.el)
+    // Ensure current instance is in fullscreen mode by checking fullscreen element
+    return Fullscreen.fullscreenElement() === (Browser.isiOS ? this.activeContainer.el : this.el)
   }
 
   toggleFullscreen() {

--- a/test/components/core_spec.js
+++ b/test/components/core_spec.js
@@ -131,7 +131,7 @@ describe('Core', function() {
         expect(this.core.isFullscreen()).to.equal(false)
         expect(newInstance.isFullscreen()).to.equal(false)
 
-        sinon.stub(Fullscreen, 'getFullscreenElement').returns(fakeContainer1)
+        sinon.stub(Fullscreen, 'fullscreenElement').returns(fakeContainer1)
         expect(this.core.isFullscreen()).to.equal(false)
         expect(newInstance.isFullscreen()).to.equal(true)
       })


### PR DESCRIPTION
If fix fullscreen detection with Firefox browser. _(based on current fullscreen element)_

It also rename the Utils.Fullscreen `getFullscreenElement` method to `fullscreenElement` to be more consistent with [fullscreen api](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/fullscreenElement).