### PR TITLE
Fix: sync stored volume value with the value passed to the playback and allow floats

### DIFF
--- a/src/components/container/container.js
+++ b/src/components/container/container.js
@@ -388,9 +388,9 @@ export default class Container extends UIObject {
   }
 
   setVolume(value) {
-    this.volume = parseInt(value, 10)
-    this.trigger(Events.CONTAINER_VOLUME, value, this.name)
-    this.playback.volume(value)
+    this.volume = parseFloat(value)
+    this.trigger(Events.CONTAINER_VOLUME, this.volume, this.name)
+    this.playback.volume(this.volume)
   }
 
   fullscreen() {


### PR DESCRIPTION
Current behavior:

```js
player.setVolume(0.9); // the volume will be set, you will hear the sound, but ...
player.getVolume(); // will return 0 
// and after:
player.mute();
player.unmute(); 
// you don't hear the sound anymore, since the stored value 0 is really set as the volume now
 ```

This PR fixes it and allows to use floats normally. To my mind, 1 is much louder than 0.5, so a float volume is a useful feature.