### PR TITLE
docs: Fix simple typo, snipet -> snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ https://medium.com/@bikegriffith/using-clappr-with-reactjs-14a338e3451f#.9a36w0d
 https://github.com/clappr/clappr/issues/933#issuecomment-228540381
 
 ### How can I Log messages with Clappr?
-Add this snipet before you instantiate the player `Clappr.Log.setLevel(0)`
+Add this snippet before you instantiate the player `Clappr.Log.setLevel(0)`
 
 ### Common steps to verify issues
 Very often people open issues related to stream **not working, freezing, glitching, stopping, and so on**. You can try the steps below, taking notes about the results:


### PR DESCRIPTION
There is a small typo in README.md.

Should read `snippet` rather than `snipet`.

