### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -99,7 +99,7 @@ player.attachTo(playerElement);
     window.onload = function () {
 
       if (window.location.hash) {
-        var editorContent = atob(window.location.hash.substr(1))
+        var editorContent = atob(window.location.hash.slice(1))
         document.getElementById("editor").innerHTML = editorContent
         setTimeout(run, 0)
       } else {

--- a/public/index.plainhtml5.html
+++ b/public/index.plainhtml5.html
@@ -99,7 +99,7 @@ player.attachTo(playerElement);
     window.onload = function () {
 
       if (window.location.hash) {
-        var editorContent = atob(window.location.hash.substr(1))
+        var editorContent = atob(window.location.hash.slice(1))
         document.getElementById("editor").innerHTML = editorContent
         setTimeout(run, 0)
       } else {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
