### PR TITLE
Bump hlsjs-playback version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/core": "^7.14.2",
     "@babel/preset-env": "^7.14.2",
     "@clappr/core": "^0.4.20",
-    "@clappr/hlsjs-playback": "^0.6.0",
+    "@clappr/hlsjs-playback": "^1.0.0",
     "@clappr/plugins": "^0.4.16",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^19.0.0",


### PR DESCRIPTION
depends on https://github.com/clappr/hlsjs-playback/pull/29 getting merged and released, then build a new dist here I guess