### PR TITLE
Setup i18n for documentation

### DIFF
--- a/apps/clappr.io/docs/guides/plugins/metrics.md
+++ b/apps/clappr.io/docs/guides/plugins/metrics.md
@@ -92,11 +92,7 @@ class GA4 extends ContainerPlugin {
 
 `this.options` can be accessed from any plugin
 
-...
-
 ## 5. Using the plugin
-
-...
 
 ```js
 new Player({
@@ -115,9 +111,3 @@ new Player({
   // highlight-end
 });
 ```
-
-<!-- Custom component -->
-
-import GA4 from '@site/src/components/GA4PluginSample';
-
-<GA4 />

--- a/apps/clappr.io/docs/guides/plugins/metrics.md
+++ b/apps/clappr.io/docs/guides/plugins/metrics.md
@@ -1,0 +1,123 @@
+# Creating a metrics plugin
+
+Creating a plugin integrated with GA4
+
+:::info You will learn
+
+- Understand what a Container plugin is
+- Integrating with third-party scripts
+- Tracking playback events
+
+:::
+
+Before anything else, it's important to have a property created in GA4.
+[Como criar uma propriedade no GA4](https://support.google.com/analytics/answer/9744165?hl=pt-BR#zippy=%2Cneste-artigo)
+
+## 1. Creating the plugin
+
+```js
+import { ContainerPlugin } from '@clappr/core'
+
+class GA4 extends ContainerPlugin {
+    get name() {
+        return 'ga4_metrics'
+    }
+}
+```
+
+## 2. Loading the GTAG script
+
+You need to load the Google Analytics script (gtag) and assign the global object to your plugin.
+
+There are several ways to load a script, in this tutorial we will use the lib `load-script-promise`. To install it in your project, run the command:
+
+
+```bash
+npm install load-script-promise
+```
+
+Load the script from `constructor`
+The `gtagScript` function is from [Google documentation](https://developers.google.com/tag-platform/gtagjs/install)
+
+```js
+import { ContainerPlugin } from '@clappr/core'
+import { loadScript } from 'load-script-promise'
+
+function gtagScript(measurementId) {
+    window.dataLayer = window.dataLayer || []
+    function gtag() {
+        window.dataLayer.push(arguments)
+    }
+    gtag('js', new Date())
+    gtag('config', measurementId)
+    return gtag
+}
+
+const MEASUREMENT_ID = 'G-123456'
+
+class GA4 extends ContainerPlugin {
+    // highlight-start
+    constructor(container) {
+        super(container)
+        loadScript('https://www.googletagmanager.com/gtag/js?id=${MEASUREMENT_ID}')
+            .then(() => {
+                this.gtag = gtagScript(MEASUREMENT_ID)
+            })
+    }
+    // highlight-end
+
+    // ...
+}
+```
+
+## 3. Event tracking
+
+```js
+  bindEvents() {
+    this.listenTo(this.playback, Events.PLAYBACK_PLAY, this.onPlay)
+    this.listenTo(this.playback, Events.PLAYBACK_PAUSE, this.onPause)
+  }
+
+  onPlay() {
+    this.gtag('event', 'PLAY', { ...options.ga.dimensions })
+  }
+
+  onPause() {
+    this.gtag('event', 'PAUSE', { ...options.ga.dimensions })
+  }
+
+```
+
+## 4. Options
+
+`this.options` can be accessed from any plugin
+
+...
+
+## 5. Using the plugin
+
+...
+
+```js
+new Player({
+  source: "http://clappr.io/media/video.mp4",
+  parentId: "#player",
+  // highlight-start
+  plugins: {
+    container: [GA4],
+  },
+  ga: {
+    dimension: {
+        video_title: 'Jornal Nacional',
+        duration: 20302
+    }
+  }
+  // highlight-end
+});
+```
+
+<!-- Custom component -->
+
+import GA4 from '@site/src/components/GA4PluginSample';
+
+<GA4 />

--- a/apps/clappr.io/docusaurus.config.js
+++ b/apps/clappr.io/docusaurus.config.js
@@ -23,7 +23,7 @@ const config = {
   // to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: 'en',
-    locales: ['en'],
+    locales: ['en', 'pt-BR'],
   },
 
   presets: [
@@ -55,20 +55,24 @@ const config = {
         },
         items: [
           {
-            to: '/docs/intro', 
-            label: 'Docs', 
-            position: 
+            to: '/docs/intro',
+            label: 'Docs',
+            position:
             'left'
           },
           {
-            to: 'http://clappr.github.io/', 
-            label: 'API', 
-            position: 
+            to: 'http://clappr.github.io/',
+            label: 'API',
+            position:
             'left'
           },
           {
             href: 'https://github.com/clappr/clappr',
             label: 'GitHub',
+            position: 'right',
+          },
+          {
+            type: 'localeDropdown',
             position: 'right',
           },
         ],

--- a/apps/clappr.io/i18n/pt-BR/code.json
+++ b/apps/clappr.io/i18n/pt-BR/code.json
@@ -1,0 +1,280 @@
+{
+  "Get Started": {
+    "message": "Começar"
+  },
+  "Try a Demo": {
+    "message": "Demonstração"
+  },
+  "Easy to Use": {
+    "message": "Fácil de usar"
+  },
+  "Clappr was designed from the ground up to be easily installed and used. Just import it, plug it in your page and it's ready to play.": {
+    "message": "O Clappr foi projetado desde o início para ser facilmente instalado e usado. Basta importá-lo, conectá-lo à sua página e ele estará pronto para ser usado."
+  },
+  "Build It Your Way": {
+    "message": "Monte do seu jeito"
+  },
+  "Clappr is 100% open-source. It's architecture was projected with extensibility and low coupling by design. You can build new features and customize anything you want in Clappr with the use of plugins.": {
+    "message": "O Clappr é 100% de código aberto. Sua arquitetura foi projetada com extensibilidade e baixo acoplamento por design. Você pode criar novos recursos e personalizar o que quiser no Clappr com o uso de plug-ins."
+  },
+  "Play Anywhere": {
+    "message": "Execute em qualquer lugar"
+  },
+  "Clappr is HTML5 first and is able to deliver your content across multiple modern media devices. You can also extend the default HTML5 playback or create your own playback interface to create a new media support!": {
+    "message": "O Clappr é o primeiro em HTML5 e é capaz de fornecer seu conteúdo em vários dispositivos de mídia modernos. Você também pode estender a reprodução padrão do HTML5 ou criar sua própria interface de reprodução para criar um novo suporte de mídia!"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "This page crashed.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Try again",
+    "description": "The label of the button to try again when the page crashed"
+  },
+  "theme.NotFound.title": {
+    "message": "Página não encontrada",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "Não foi possível encontrar o que você está procurando.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Entre em contato com o proprietário do site que lhe trouxe para cá e lhe informe que o link está quebrado.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.admonition.note": {
+    "message": "note",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "tip",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.danger": {
+    "message": "danger",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "info",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.caution": {
+    "message": "caution",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Volte para o topo",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Arquivo",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Arquivo",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Fechar",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Navegação da página de listagem do blog",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Conteúdo mais novo",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Conteúdo mais antigo",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Navegação da página de postagem do blog",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Postagem mais nova",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Postagem mais antiga",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.post.plurals": {
+    "message": "Uma postagem|{count} postagens",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} marcadas com \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "Ver todas os Marcadores",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Switch between dark and light mode (currently {mode})",
+    "description": "The ARIA label for the navbar color mode toggle"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "dark mode",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "light mode",
+    "description": "The name for the light color mode"
+  },
+  "theme.docs.DocCard.categoryDescription": {
+    "message": "{count} items",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Home page",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Breadcrumbs",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Navigação das páginas de documentação",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Anterior",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Próxima",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "Um documento selecionado|{count} documentos selecionados",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} com \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Version: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "Esta é uma documentação não lançada para {siteTitle} {versionLabel}.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "Esta é a documentação para {siteTitle} {versionLabel}, que não é mais mantida ativamente.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "Para a documentação atualizada, veja: {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "última versão",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Editar essa página",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Link direto para o título",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " em {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " por {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Última atualização {atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versions",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Pular para o conteúdo principal",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Marcadores:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copiado",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copiar código para a área de transferência",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copiar",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Toggle word wrap",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Blog recent posts navigation",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
+    "message": "Toggle the collapsible sidebar category '{label}'",
+    "description": "The ARIA label to toggle the collapsible sidebar category"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Languages",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "Nessa página",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Leia Mais",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Read more about {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "Leitura de um minuto|Leitura de {readingTime} minutos",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Fechar painel lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Fechar painel lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Voltar para o menu principal",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expandir painel lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expandir painel lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "An extensible media player for web applications": {
+    "message": "Um player de vídeo extensível para aplicações web"
+  }
+}

--- a/apps/clappr.io/i18n/pt-BR/docusaurus-plugin-content-blog/options.json
+++ b/apps/clappr.io/i18n/pt-BR/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Blog",
+    "description": "The title for the blog used in SEO"
+  },
+  "description": {
+    "message": "Blog",
+    "description": "The description for the blog used in SEO"
+  },
+  "sidebar.title": {
+    "message": "Recent posts",
+    "description": "The label for the left sidebar"
+  }
+}

--- a/apps/clappr.io/i18n/pt-BR/docusaurus-plugin-content-docs/current.json
+++ b/apps/clappr.io/i18n/pt-BR/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,18 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.docs.category.Getting Started": {
+    "message": "Getting Started",
+    "description": "The label for category Getting Started in sidebar docs"
+  },
+  "sidebar.docs.category.Guides": {
+    "message": "Guides",
+    "description": "The label for category Guides in sidebar docs"
+  },
+  "sidebar.docs.category.Plugins": {
+    "message": "Plugins",
+    "description": "The label for category Plugins in sidebar docs"
+  }
+}

--- a/apps/clappr.io/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/plugins/metrics.md
+++ b/apps/clappr.io/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/plugins/metrics.md
@@ -92,11 +92,7 @@ class GA4 extends ContainerPlugin {
 
 `this.options` pode ser acessado em qualquer plugin
 
-...
-
 ## Usando um plugin
-
-...
 
 ```js
 new Player({
@@ -115,9 +111,3 @@ new Player({
   // highlight-end
 });
 ```
-
-<!-- Custom component -->
-
-import GA4 from '@site/src/components/GA4PluginSample';
-
-<GA4 />

--- a/apps/clappr.io/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/plugins/metrics.md
+++ b/apps/clappr.io/i18n/pt-BR/docusaurus-plugin-content-docs/current/guides/plugins/metrics.md
@@ -1,0 +1,123 @@
+# Criando um plugin de métricas
+
+Criando um plugin integrado ao GA4
+
+:::info Você vai aprender
+
+- Entender o que é um plugin de Container
+- Integrar com scripts de terceiros
+- Tracking de eventos do playback
+
+:::
+
+Antes de qualquer coisa é importante ter uma propriedade criada no GA4.
+[Como criar uma propriedade no GA4](https://support.google.com/analytics/answer/9744165?hl=pt-BR#zippy=%2Cneste-artigo)
+
+## 1 Criando o plugin
+
+```js
+import { ContainerPlugin } from '@clappr/core'
+
+class GA4 extends ContainerPlugin {
+    get name() {
+        return 'ga4_metrics'
+    }
+}
+```
+
+## 2 Carregando o script GTAG
+
+Você precisa carregar o script do Google Analytics (gtag) e atribuir o objeto global no seu plugin.
+
+Existem várias formas de carregar um script, neste tutorial vamos usar a lib `load-script-promise`. Para instalar no projeto execute o comando:
+
+
+```bash
+npm install load-script-promise
+```
+
+Carregue o script a partir do `constructor`
+A função `gtagScript` é da [documentação do Google](https://developers.google.com/tag-platform/gtagjs/install)
+
+```js
+import { ContainerPlugin } from '@clappr/core'
+import { loadScript } from 'load-script-promise'
+
+function gtagScript(measurementId) {
+    window.dataLayer = window.dataLayer || []
+    function gtag() {
+        window.dataLayer.push(arguments)
+    }
+    gtag('js', new Date())
+    gtag('config', measurementId)
+    return gtag
+}
+
+const MEASUREMENT_ID = 'G-123456'
+
+class GA4 extends ContainerPlugin {
+    // highlight-start
+    constructor(container) {
+        super(container)
+        loadScript('https://www.googletagmanager.com/gtag/js?id=${MEASUREMENT_ID}')
+            .then(() => {
+                this.gtag = gtagScript(MEASUREMENT_ID)
+            })
+    }
+    // highlight-end
+
+    // ...
+}
+```
+
+## 3. Tracking de eventos
+
+```js
+  bindEvents() {
+    this.listenTo(this.playback, Events.PLAYBACK_PLAY, this.onPlay)
+    this.listenTo(this.playback, Events.PLAYBACK_PAUSE, this.onPause)
+  }
+
+  onPlay() {
+    this.gtag('event', 'PLAY', { ...options.ga.dimensions })
+  }
+
+  onPause() {
+    this.gtag('event', 'PAUSE', { ...options.ga.dimensions })
+  }
+
+```
+
+## 4 Options
+
+`this.options` pode ser acessado em qualquer plugin
+
+...
+
+## Usando um plugin
+
+...
+
+```js
+new Player({
+  source: "http://clappr.io/media/video.mp4",
+  parentId: "#player",
+  // highlight-start
+  plugins: {
+    container: [GA4],
+  },
+  ga: {
+    dimension: {
+        video_title: 'Jornal Nacional',
+        duration: 20302
+    }
+  }
+  // highlight-end
+});
+```
+
+<!-- Custom component -->
+
+import GA4 from '@site/src/components/GA4PluginSample';
+
+<GA4 />

--- a/apps/clappr.io/i18n/pt-BR/docusaurus-theme-classic/footer.json
+++ b/apps/clappr.io/i18n/pt-BR/docusaurus-theme-classic/footer.json
@@ -1,0 +1,34 @@
+{
+  "link.title.Learn": {
+    "message": "Aprender",
+    "description": "The title of the footer links column with title=Learn in the footer"
+  },
+  "link.title.Community": {
+    "message": "Comunidade",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.item.label.Getting Started": {
+    "message": "Iniciar",
+    "description": "The label of footer link with label=Getting Started linking to /getting-started/intro"
+  },
+  "link.item.label.Docs": {
+    "message": "Docs",
+    "description": "The label of footer link with label=Docs linking to /docs/intro"
+  },
+  "link.item.label.API": {
+    "message": "API",
+    "description": "The label of footer link with label=API linking to http://clappr.github.io/"
+  },
+  "link.item.label.Stack Overflow": {
+    "message": "Stack Overflow",
+    "description": "The label of footer link with label=Stack Overflow linking to https://stackoverflow.com/questions/tagged/clappr"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/clappr/clappr"
+  },
+  "copyright": {
+    "message": "Copyright © 2023 Clappr, Inc. Feito com Docusaurus.",
+    "description": "The footer copyright"
+  }
+}

--- a/apps/clappr.io/i18n/pt-BR/docusaurus-theme-classic/navbar.json
+++ b/apps/clappr.io/i18n/pt-BR/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,18 @@
+{
+  "title": {
+    "message": "Clappr",
+    "description": "The title in the navbar"
+  },
+  "item.label.Docs": {
+    "message": "Docs",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.API": {
+    "message": "API",
+    "description": "Navbar item with label API"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  }
+}

--- a/apps/clappr.io/package.json
+++ b/apps/clappr.io/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/preset-classic": "2.0.1",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
+    "load-script-promise": "^1.0.4",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/apps/clappr.io/sidebars.js
+++ b/apps/clappr.io/sidebars.js
@@ -37,6 +37,7 @@ const sidebars = {
           collapsed: false,
           items: [
             'guides/plugins/intro',
+            'guides/plugins/metrics',
             'guides/plugins/built-in',
             'guides/plugins/external',
             'guides/plugins/building',

--- a/apps/clappr.io/src/components/GA4PluginSample/index.js
+++ b/apps/clappr.io/src/components/GA4PluginSample/index.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import { Player, ContainerPlugin, Events } from '@clappr/core'
+import { loadScript } from 'load-script-promise'
+
+const GA4 = ({ children }) => {
+  function gtagScript(measurementId) {
+    window.dataLayer = window.dataLayer || []
+    function gtag() {
+      window.dataLayer.push(arguments)
+    }
+    gtag('js', new Date())
+    gtag('config', measurementId)
+    return gtag
+  }
+  class GA4Plugin extends ContainerPlugin {
+    constructor(container) {
+      super(container)
+      loadScript(
+        `https://www.googletagmanager.com/gtag/js?id=${this.options.ga.measurementId}`
+      ).then(() => {
+        this.gtag = gtagScript(this.options.ga.measurementId)
+      })
+    }
+
+    get name() {
+      return 'ga4_metrics'
+    }
+
+    bindEvents() {
+      this.listenTo(this.container.playback, Events.PLAYBACK_PLAY, this.onPlay)
+      this.listenTo(
+        this.container.playback,
+        Events.PLAYBACK_PAUSE,
+        this.onPause
+      )
+    }
+
+    onPlay() {
+      this.gtag('event', 'PLAY', { ...this.options.ga.dimensions })
+    }
+
+    onPause() {
+      this.gtag('event', 'PAUSE', { ...this.options.ga.dimensions })
+    }
+  }
+
+  window.player = new Player({
+    source: 'http://clappr.io/media/video.mp4',
+    parentId: '#player',
+    plugins: {
+      container: [GA4Plugin],
+    },
+    ga: {
+      measurementId: 'G-123456',
+      dimensions: {
+        video_title: 'Jornal Nacional',
+        duration: 20302,
+      },
+    },
+  })
+
+  return (
+    <div>
+      <div id="player">{children}</div>
+    </div>
+  )
+}
+
+export default GA4

--- a/apps/clappr.io/src/components/HomepageFeatures/index.js
+++ b/apps/clappr.io/src/components/HomepageFeatures/index.js
@@ -1,43 +1,45 @@
-import React from 'react';
-import clsx from 'clsx';
-import styles from './styles.module.css';
+import React from 'react'
+import Translate from '@docusaurus/Translate'
+import clsx from 'clsx'
+import styles from './styles.module.css'
 
 const FeatureList = [
   {
-    title: 'Easy to Use',
+    title: <Translate>Easy to Use</Translate>,
     Svg: require('@site/static/img/undraw_website_setup_re_d4y9.svg').default,
     description: (
-      <>
-        Clappr was designed from the ground up to be easily installed and
-        used. Just import it, plug it in your page and it&apos;s ready to play.
-      </>
+      <Translate>
+        Clappr was designed from the ground up to be easily installed and used.
+        Just import it, plug it in your page and it&apos;s ready to play.
+      </Translate>
     ),
   },
   {
-    title: 'Build It Your Way',
+    title: <Translate>Build It Your Way</Translate>,
     Svg: require('@site/static/img/undraw_programming_re_kg9v.svg').default,
     description: (
-      <>
-        Clappr is 100% open-source. It&apos;s architecture was projected with extensibility 
-        and low coupling by design. You can build new features and customize anything you
-        want in Clappr with the use of plugins.
-      </>
+      <Translate>
+        Clappr is 100% open-source. It&apos;s architecture was projected with
+        extensibility and low coupling by design. You can build new features and
+        customize anything you want in Clappr with the use of plugins.
+      </Translate>
     ),
   },
   {
-    title: 'Play Anywhere',
+    title: <Translate>Play Anywhere</Translate>,
     Svg: require('@site/static/img/undraw_video_streaming_re_v3qg.svg').default,
     description: (
-      <>
-        Clappr is HTML5 first and is able to deliver your content across multiple modern media 
-        devices. You can also extend the default HTML5 playback or create your own playback 
-        interface to create a new media support!
-      </>
+      <Translate>
+        Clappr is HTML5 first and is able to deliver your content across
+        multiple modern media devices. You can also extend the default HTML5
+        playback or create your own playback interface to create a new media
+        support!
+      </Translate>
     ),
   },
-];
+]
 
-function Feature({Svg, title, description}) {
+function Feature({ Svg, title, description }) {
   return (
     <div className={clsx('col col--4')}>
       <div className="text--center">
@@ -48,7 +50,7 @@ function Feature({Svg, title, description}) {
         <p>{description}</p>
       </div>
     </div>
-  );
+  )
 }
 
 export default function HomepageFeatures() {
@@ -62,5 +64,5 @@ export default function HomepageFeatures() {
         </div>
       </div>
     </section>
-  );
+  )
 }

--- a/apps/clappr.io/src/pages/index.js
+++ b/apps/clappr.io/src/pages/index.js
@@ -1,29 +1,26 @@
-import React from 'react';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
+import React from 'react'
+import Translate from '@docusaurus/Translate'
+import clsx from 'clsx'
+import Link from '@docusaurus/Link'
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import Layout from '@theme/Layout'
+import HomepageFeatures from '@site/src/components/HomepageFeatures'
 
-import styles from './index.module.css';
+import styles from './index.module.css'
 
 function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext()
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
         <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
+        <p className="hero__subtitle"><Translate>An extensible media player for web applications</Translate></p>
         <div className={styles.buttons}>
-          <Link
-            className="button button--secondary"
-            to="/docs/intro">
-            Get Started
+          <Link className="button button--secondary" to="/docs/intro">
+            <Translate>Get Started</Translate>
           </Link>
-          <Link
-            className="button button--info"
-            href="http://clappr.io/demo">
-            Try a Demo
+          <Link className="button button--info" href="http://clappr.io/demo">
+            <Translate>Try a Demo</Translate>
           </Link>
           <span className={styles.indexCtasGitHubButtonWrapper}>
             <iframe
@@ -37,17 +34,16 @@ function HomepageHeader() {
         </div>
       </div>
     </header>
-  );
+  )
 }
 
 export default function Home() {
   return (
-    <Layout
-      description="Description will go into a meta tag in <head />">
+    <Layout description="Description will go into a meta tag in <head />">
       <HomepageHeader />
       <main>
         <HomepageFeatures />
       </main>
     </Layout>
-  );
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13104,6 +13104,10 @@ loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
+load-script-promise@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/load-script-promise/-/load-script-promise-1.0.4.tgz#85adbd40e6d940217394400c077f28f577a3f0d1"
+  integrity sha512-WCa5M0rkixFb0LRJsE96lpzB638arOWHsafFuJFybhvMzUo/ijQCNK/Cd0njCBn7BCJNYaTzhV4FzofRvRIR7Q==
 
 loader-runner@^4.2.0:
   version "4.3.0"


### PR DESCRIPTION
This PR configures the internationalization of Clappr's documentation into the pt-br language. The main features are:
- i18n setup for pt-br language
- Translation of the main doc components
- Addition of a tutorial on building metrics plugins and their translation (example, can be modified)

To run the documentation in the pt-br version use: `yarn start --locale=pt-BR `