### PR TITLE
Fix (hlsjs-playback) - Prevent calling loadSource multiple times while loadind manifest

### DIFF
--- a/packages/hlsjs-playback/src/hls.js
+++ b/packages/hlsjs-playback/src/hls.js
@@ -196,7 +196,7 @@ export default class HlsjsPlayback extends HTML5Video {
 
   _destroyHLSInstance() {
     if (!this._hls) return
-    this._manifestParsed = false
+    this._manifestLoading = false
     this._ccIsSetup = false
     this._ccTracksUpdated = false
     this._setInitialState()
@@ -217,7 +217,7 @@ export default class HlsjsPlayback extends HTML5Video {
   _listenHLSEvents() {
     if (!this._hls) return
     this._hls.once(HLSJS.Events.MEDIA_ATTACHED, () => { this.options.hlsPlayback.preload && this._hls.loadSource(this.options.src) })
-    this._hls.on(HLSJS.Events.MANIFEST_PARSED, () => this._manifestParsed = true)
+    this._hls.on(HLSJS.Events.MANIFEST_LOADING, () => this._manifestLoading = true)
     this._hls.on(HLSJS.Events.LEVEL_LOADED, (evt, data) => this._updatePlaybackType(evt, data))
     this._hls.on(HLSJS.Events.LEVEL_UPDATED, (evt, data) => this._onLevelUpdated(evt, data))
     this._hls.on(HLSJS.Events.LEVEL_SWITCHING, (evt,data) => this._onLevelSwitch(evt, data))
@@ -486,7 +486,7 @@ export default class HlsjsPlayback extends HTML5Video {
 
   play() {
     !this._hls && this._setup()
-    !this._manifestParsed && !this.options.hlsPlayback.preload && this._hls.loadSource(this.options.src)
+    !this._manifestLoading && !this.options.hlsPlayback.preload && this._hls.loadSource(this.options.src)
     super.play()
     this._startTimeUpdateTimer()
   }


### PR DESCRIPTION
When the `play` method was called more than once while loading the manifest, the playback called `loadSource` again, restarting the loading process.

This happened because the flag `_manifestParsed` was set on `Events.MANIFEST_PARSED` which is async.
By waiting for `MANIFEST_LOADING`, the flag is set on the `loadSource` call, preventing the `loadSource` from being called again on a `play` method call. 

