### PR TITLE
Fix - Avoid memory leaks

### DIFF
--- a/packages/clappr-core/src/base/events/events.js
+++ b/packages/clappr-core/src/base/events/events.js
@@ -90,6 +90,7 @@ export default class Events {
       off(name, once)
       callback.apply(this, arguments)
     }
+    once._callback = callback
     return this.on(name, once, context)
   }
 

--- a/packages/clappr-core/src/base/events/events.test.js
+++ b/packages/clappr-core/src/base/events/events.test.js
@@ -4,7 +4,7 @@ import Log from '@/components/log'
 describe('Events', function() {
   let events
   let callback
-  
+
   beforeEach(() => {
     events = new Events()
     callback = jest.fn()
@@ -225,6 +225,16 @@ describe('Events', function() {
     events.trigger('clappr.any.event', 42, 'some string')
     expect(callback).toHaveBeenCalledWith(42, 'some string')
     expect(callback).toHaveBeenCalledTimes(3)
+  })
+
+  it('permits to stop listening with callback argument a listen once event', () => {
+    const myEvents = new Events()
+
+    myEvents.listenToOnce(events, 'clappr.any.event', callback)
+    myEvents.stopListening(events, 'clappr.any.event', callback)
+    events.trigger('clappr.any.event')
+
+    expect(callback).not.toHaveBeenCalled()
   })
 
   it('permits to stop listening events in other objects', () => {

--- a/packages/clappr-core/src/components/container/container.js
+++ b/packages/clappr-core/src/components/container/container.js
@@ -284,6 +284,7 @@ export default class Container extends UIObject {
     this.stopListening()
     this.plugins.forEach((plugin) => plugin.destroy())
     this.$el.remove()
+    this.undelegateEvents()
   }
 
   setStyle(style) {

--- a/packages/clappr-core/src/components/core/core.js
+++ b/packages/clappr-core/src/components/core/core.js
@@ -120,10 +120,11 @@ export default class Core extends UIObject {
     this.containers = []
     //FIXME fullscreen api sucks
     this._boundFullscreenHandler = () => this.handleFullscreenChange()
+    this._boundHandleWindowResize = (o) => this.handleWindowResize(o)
     $(document).bind('fullscreenchange', this._boundFullscreenHandler)
     $(document).bind('MSFullscreenChange', this._boundFullscreenHandler)
     $(document).bind('mozfullscreenchange', this._boundFullscreenHandler)
-    Browser.isMobile && $(window).bind('resize', (o) => { this.handleWindowResize(o) })
+    Browser.isMobile && $(window).bind('resize', this._boundHandleWindowResize)
   }
 
   configureDomRecycler() {
@@ -240,6 +241,7 @@ export default class Core extends UIObject {
     $(document).unbind('fullscreenchange', this._boundFullscreenHandler)
     $(document).unbind('MSFullscreenChange', this._boundFullscreenHandler)
     $(document).unbind('mozfullscreenchange', this._boundFullscreenHandler)
+    Browser.isMobile && $(window).unbind('resize', this._boundHandleWindowResize)
     this.stopListening()
   }
 

--- a/packages/clappr-core/src/components/core/core.js
+++ b/packages/clappr-core/src/components/core/core.js
@@ -243,6 +243,7 @@ export default class Core extends UIObject {
     $(document).unbind('mozfullscreenchange', this._boundFullscreenHandler)
     Browser.isMobile && $(window).unbind('resize', this._boundHandleWindowResize)
     this.stopListening()
+    this.undelegateEvents()
   }
 
   handleFullscreenChange() {
@@ -263,6 +264,7 @@ export default class Core extends UIObject {
 
   removeContainer(container) {
     this.stopListening(container)
+    this.containerFactory.stopListening(container)
     this.containers = this.containers.filter((c) => c !== container)
   }
 

--- a/packages/clappr-core/src/playbacks/html5_video/html5_video.js
+++ b/packages/clappr-core/src/playbacks/html5_video/html5_video.js
@@ -527,6 +527,7 @@ export default class HTML5Video extends Playback {
 
   destroy() {
     this._destroyed = true
+    this._stopPlayheadMovingChecks()
     this.handleTextTrackChange && this.el.textTracks.removeEventListener('change', this.handleTextTrackChange)
     this.$el.off('contextmenu')
     super.destroy()


### PR DESCRIPTION
When the player is destroyed, the references and timers should be removed to prevent memory leaks.

Besides that, a fix to `stopListening` was made to allow stopping a `listenToOnce` event handler sending the callback as argument to `stopListening`.