### PR TITLE
Playback fixes/updates and performance improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
         "process": false,
         "ActiveXObject": false,
         "VERSION": false,
+        "CLAPPR_VERSION": false,
         "PLAIN_HTML5_ONLY": false,
         // Build globals
         "__dirname": false,

--- a/packages/clappr-core/src/components/log/log.js
+++ b/packages/clappr-core/src/components/log/log.js
@@ -54,8 +54,8 @@ export default class Log {
   }
 
   log(klass, level, message) {
-    if (this.EXCLUDE_LIST.indexOf(message[0]) >= 0) return
     if (level < this.level) return
+    if (this.EXCLUDE_LIST.indexOf(message[0]) >= 0) return
 
     if (!message) {
       message = klass

--- a/packages/clappr-core/src/components/log/log.js
+++ b/packages/clappr-core/src/components/log/log.js
@@ -30,7 +30,8 @@ export default class Log {
       'playback:progress',
       'container:hover',
       'container:timeupdate',
-      'container:progress'
+      'container:progress',
+      'core:mousemove',
     ]
     this.level = level
     this.previousLevel = this.level

--- a/packages/clappr-core/src/playbacks/html5_video/html5_video.js
+++ b/packages/clappr-core/src/playbacks/html5_video/html5_video.js
@@ -326,7 +326,6 @@ export default class HTML5Video extends Playback {
 
   pause() {
     this.el.pause()
-    this.dvrEnabled && this._updateDvr(true)
   }
 
   stop() {
@@ -443,13 +442,17 @@ export default class HTML5Video extends Playback {
   }
 
   _onPause() {
+    this.dvrEnabled && this._updateDvr(true)
     this._stopPlayheadMovingChecks()
     this._handleBufferingEvents()
     this.trigger(Events.PLAYBACK_PAUSE)
   }
 
   _onSeeking() {
-    this.trigger(Events.PLAYBACK_SEEK, this.getCurrentTime())
+    const currentTime = this.getCurrentTime()
+    // assume live if time within 3 seconds of end of stream
+    this.dvrEnabled && this._updateDvr(currentTime < this.getDuration() - 3)
+    this.trigger(Events.PLAYBACK_SEEK, currentTime)
     this._handleBufferingEvents()
   }
 
@@ -547,8 +550,6 @@ export default class HTML5Video extends Playback {
       Log.warn('Attempt to seek to a negative time. Resetting to live point. Use seekToLivePoint() to seek to the live point.')
       time = this.getDuration()
     }
-    // assume live if time within 3 seconds of end of stream
-    this.dvrEnabled && this._updateDvr(time < this.getDuration()-3)
     time += this.el.seekable.start(0)
 
     this.el.currentTime = time

--- a/packages/clappr-core/src/playbacks/html5_video/html5_video.test.js
+++ b/packages/clappr-core/src/playbacks/html5_video/html5_video.test.js
@@ -516,10 +516,12 @@ describe('HTML5Video playback', function() {
         }
       })
       html5Video.seek(html5Video.el.seekable.end(0))
+      html5Video._onSeeking()
 
       expect(html5Video._updateDvr).toHaveBeenCalledWith(false)
 
       html5Video.seek(96)
+      html5Video._onSeeking()
 
       expect(html5Video._updateDvr).toHaveBeenCalledWith(true)
     })

--- a/packages/dash-shaka-playback/src/clappr-dash-shaka-playback.js
+++ b/packages/dash-shaka-playback/src/clappr-dash-shaka-playback.js
@@ -227,7 +227,7 @@ class DashShakaPlayback extends HTML5Video {
 
   stop () {
     this._stopTimeUpdateTimer()
-    clearInterval(this.sendStatsId)
+    this._stopToSendStats()
     this._stopped = true
 
     if (this._player) {
@@ -364,7 +364,7 @@ class DashShakaPlayback extends HTML5Video {
 
   destroy () {
     this._stopTimeUpdateTimer()
-    clearInterval(this.sendStatsId)
+    this._stopToSendStats()
 
     if (this._player) {
       this._player.destroy()
@@ -383,6 +383,7 @@ class DashShakaPlayback extends HTML5Video {
   _setup() {
     this._isShakaReadyState = false
     this._ccIsSetup = false
+    this._stopToSendStats()
 
     let runAllSteps = () => {
       this._player = this._createPlayer()
@@ -467,8 +468,14 @@ class DashShakaPlayback extends HTML5Video {
   }
 
   _startToSendStats () {
+    this._stopToSendStats()
     const intervalMs = this._options.shakaSendStatsInterval || SEND_STATS_INTERVAL_MS
     this.sendStatsId = setInterval(() => this._sendStats(), intervalMs)
+  }
+
+  _stopToSendStats() {
+    this.sendStatsId && clearInterval(this.sendStatsId)
+    this.sendStatsId = null
   }
 
   _sendStats () {

--- a/packages/dash-shaka-playback/src/clappr-dash-shaka-playback.js
+++ b/packages/dash-shaka-playback/src/clappr-dash-shaka-playback.js
@@ -492,14 +492,20 @@ class DashShakaPlayback extends HTML5Video {
       videoError: this.el.error
     }
 
-    let { category, code, severity } = error.shakaError.detail || error.shakaError
+    let { category, code, severity, data } = error.shakaError.detail || error.shakaError
 
     if (error.videoError || !code && !category) return super._onError()
 
+    let shakaErrorData = ''
+    try {
+      shakaErrorData = JSON.stringify(data)
+    } catch (error) {
+      Log.warn('Fail to parse shaka error data', error)
+    }
     const isCritical = severity === shaka.util.Error.Severity.CRITICAL
     const errorData = {
       code: `${category}_${code}`,
-      description: `Category: ${category}, code: ${code}, severity: ${severity}`,
+      description: `Category: ${category}, code: ${code}, severity: ${severity}, data: ${shakaErrorData}`,
       level: isCritical ? PlayerError.Levels.FATAL : PlayerError.Levels.WARN,
       raw: err
     }

--- a/packages/dash-shaka-playback/src/clappr-dash-shaka-playback.js
+++ b/packages/dash-shaka-playback/src/clappr-dash-shaka-playback.js
@@ -124,25 +124,17 @@ class DashShakaPlayback extends HTML5Video {
     return this.presentationStartTimeAsDate
   }
 
-  _updateDvr(status) {
-    this.trigger(Events.PLAYBACK_DVR, status)
-    this.trigger(Events.PLAYBACK_STATS_ADD, { 'dvr': status })
-  }
-
   seek(time) {
     if (time < 0) {
       Log.warn('Attempt to seek to a negative time. Resetting to live point. Use seekToLivePoint() to seek to the live point.')
       time = this._duration
     }
-    // assume live if time within 3 seconds of end of stream
-    this.dvrEnabled && this._updateDvr(time < this._duration-3)
     time += this._startTime
     this.el.currentTime = time
   }
 
   pause() {
     this.el.pause()
-    this.dvrEnabled && this._updateDvr(true)
   }
 
   play () {

--- a/packages/hlsjs-playback/package.json
+++ b/packages/hlsjs-playback/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/clappr/hlsjs-playback",
   "peerDependencies": {
     "@clappr/core": "*",
-    "hls.js": "^1.2.4"
+    "hls.js": "1.5.14"
   },
   "devDependencies": {
     "@babel/core": "^7.14.2",
@@ -51,7 +51,7 @@
     "coveralls": "^3.1.0",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.26.0",
-    "hls.js": "^1.2.4",
+    "hls.js": "1.5.14",
     "jest": "^26.6.3",
     "rollup": "^2.47.0",
     "rollup-plugin-filesize": "^9.1.1",

--- a/packages/hlsjs-playback/src/hls.js
+++ b/packages/hlsjs-playback/src/hls.js
@@ -265,10 +265,12 @@ export default class HlsjsPlayback extends HTML5Video {
     if (!this._recoveredDecodingError) {
       this._recoveredDecodingError = true
       this._hls.recoverMediaError()
+      this.play()
     } else if (!this._recoveredAudioCodecError) {
       this._recoveredAudioCodecError = true
       this._hls.swapAudioCodec()
       this._hls.recoverMediaError()
+      this.play()
     } else {
       Log.error('hlsjs: failed to recover', { evt, data })
       error.level = PlayerError.Levels.FATAL

--- a/packages/hlsjs-playback/src/hls.js
+++ b/packages/hlsjs-playback/src/hls.js
@@ -143,6 +143,8 @@ export default class HlsjsPlayback extends HTML5Video {
   constructor(...args) {
     super(...args)
     this.options.hlsPlayback = { ...this.defaultOptions, ...this.options.hlsPlayback }
+    this._timeUpdateFiringRate = 0.2
+    this._durationChangeMinOffset = 0.5
     this._setInitialState()
   }
 
@@ -155,7 +157,7 @@ export default class HlsjsPlayback extends HTML5Video {
     this._extrapolatedWindowNumSegments = !this.options.playback || typeof (this.options.playback.extrapolatedWindowNumSegments) === 'undefined' ? 2 :  this.options.playback.extrapolatedWindowNumSegments
 
     this._playbackType = Playback.VOD
-    this._lastTimeUpdate = { current: 0, total: 0 }
+    this._lastTimeUpdate = { current: 0, total: 0, firstFragDateTime: 0 }
     this._lastDuration = null
     // for hls streams which have dvr with a sliding window,
     // the content at the start of the playlist is removed as new
@@ -436,9 +438,10 @@ export default class HlsjsPlayback extends HTML5Video {
 
   _onTimeUpdate() {
     const update = { current: this.getCurrentTime(), total: this.getDuration(), firstFragDateTime: this.getProgramDateTime() }
-    const isSame = this._lastTimeUpdate && (
-      update.current === this._lastTimeUpdate.current &&
-      update.total === this._lastTimeUpdate.total)    
+    const isSameTime = Math.abs(update.current - this._lastTimeUpdate.current) < this._timeUpdateFiringRate
+    const isSameDuration = Math.abs(update.total - this._lastTimeUpdate.total) < this._durationChangeMinOffset
+    const isSameFirstFragDateTime = update.firstFragDateTime === this._lastTimeUpdate.firstFragDateTime
+    const isSame = isSameTime && isSameDuration && isSameFirstFragDateTime
     if (isSame) return
     this._lastTimeUpdate = update
     this.trigger(Events.PLAYBACK_TIMEUPDATE, update, this.name)
@@ -446,7 +449,8 @@ export default class HlsjsPlayback extends HTML5Video {
 
   _onDurationChange() {
     const duration = this.getDuration()
-    if (this._lastDuration === duration) return
+    const isSameDuration = Math.abs(this._lastDuration - duration) < this._durationChangeMinOffset
+    if (isSameDuration) return
     this._lastDuration = duration
     super._onDurationChange()
   }

--- a/packages/hlsjs-playback/src/hls.js
+++ b/packages/hlsjs-playback/src/hls.js
@@ -333,19 +333,12 @@ export default class HlsjsPlayback extends HTML5Video {
       Log.warn('Attempt to seek to a negative time. Resetting to live point. Use seekToLivePoint() to seek to the live point.')
       time = this.getDuration()
     }
-    // assume live if time within 3 seconds of end of stream
-    this.dvrEnabled && this._updateDvr(time < this.getDuration()-3)
     time += this._startTime
     this.el.currentTime = time
   }
 
   seekToLivePoint() {
     this.seek(this.getDuration())
-  }
-
-  _updateDvr(status) {
-    this.trigger(Events.PLAYBACK_DVR, status)
-    this.trigger(Events.PLAYBACK_STATS_ADD, { 'dvr': status })
   }
 
   _updateSettings() {
@@ -494,7 +487,6 @@ export default class HlsjsPlayback extends HTML5Video {
   pause() {
     if (!this._hls) return
     this.el.pause()
-    if (this.dvrEnabled) this._updateDvr(true)
   }
 
   stop() {

--- a/packages/player/rollup.config.js
+++ b/packages/player/rollup.config.js
@@ -25,7 +25,7 @@ const plugins = [
   replace({
     preventAssignment: true,
     values: {
-      VERSION: JSON.stringify(pkg.version),
+      CLAPPR_VERSION: JSON.stringify(pkg.version),
       CLAPPR_CORE_VERSION: JSON.stringify(clapprCoreVersion),
     }
   }),

--- a/packages/player/src/base_bundle.js
+++ b/packages/player/src/base_bundle.js
@@ -5,7 +5,7 @@
 import ClapprCore, { Loader } from '@clappr/core'
 import { Plugins, Vendor } from '@clappr/plugins'
 
-const version = VERSION
+const version = CLAPPR_VERSION
 
 for (let plugin of Object.values(Plugins))
   Loader.registerPlugin(plugin)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,7 +2736,7 @@
     "@docusaurus/theme-search-algolia" "2.0.1"
     "@docusaurus/types" "2.0.1"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -10586,10 +10586,10 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-hls.js@^1.2.4:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.2.9.tgz#2f25e42ec4c2ea8c88ab23c0f854f39062d45ac9"
-  integrity sha512-SPjm8ix0xe6cYzwDvdVGh2QvQPDkCYrGWpZu6bRaKNNVyEGWM9uF0pooh/Lqj/g8QBQgPFEx1vHzW8SyMY9rqg==
+hls.js@1.5.14:
+  version "1.5.14"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.5.14.tgz#1d52be309a06aab25fee667c4969d8abf9f8fe59"
+  integrity sha512-5wLiQ2kWJMui6oUslaq8PnPOv1vjuee5gTxjJD0DSsccY12OXtDT0h137UuqjczNeHzeEYR0ROZQibKNMr7Mzg==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -13100,14 +13100,15 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
-loader-runner@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
-  integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 load-script-promise@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/load-script-promise/-/load-script-promise-1.0.4.tgz#85adbd40e6d940217394400c077f28f577a3f0d1"
   integrity sha512-WCa5M0rkixFb0LRJsE96lpzB638arOWHsafFuJFybhvMzUo/ijQCNK/Cd0njCBn7BCJNYaTzhV4FzofRvRIR7Q==
+
+loader-runner@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
+  integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
 loader-runner@^4.2.0:
   version "4.3.0"
@@ -16181,6 +16182,14 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
+
 react-router-config@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-router-config/-/react-router-config-5.1.1.tgz#0f4263d1a80c6b2dc7b9c1902c9526478194a988"
@@ -17932,7 +17941,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -17949,6 +17958,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
@@ -18019,7 +18037,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18039,6 +18057,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -19742,7 +19767,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -19764,6 +19789,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This MR brings several improvements and fixes listed below:

- `hlsjs-playback`
  - Upgrade hls.js to the latest version (1.5.14) #2146
  - Prevent playback from staying paused when recovering from hlsjs media error
- `dash-shaka-playback`
  - Add more error-related info from the shaka player to the `playback_error` event payload
  - Prevent accumulation of `setIntervals`
- `hlsjs-playback`, `dash-shaka-playback`
  - Reduce the number of calls of `timeupdate` events
- `hlsjs-playback`, `dash-shaka-playback` and `html5_video`
  - Fix the DVR state when pausing/seeking externally from the player and remove duplicated code
 - `Log`
   - Add `core:mousemove` to exclude list
   - Check by level before looking into `exclude_list` array