### PR TITLE
Remove unused animate method from container

### DIFF
--- a/packages/clappr-core/src/components/container/container.js
+++ b/packages/clappr-core/src/components/container/container.js
@@ -291,10 +291,6 @@ export default class Container extends UIObject {
     this.$el.css(style)
   }
 
-  animate(style, duration) {
-    return this.$el.animate(style, duration).promise()
-  }
-
   ready() {
     this.isReady = true
     this.trigger(Events.CONTAINER_READY, this.name)


### PR DESCRIPTION
This PR removes `animate()` method from `container.js`.

The method is an old implementation from Zepto that was replaced by clappr-zepto. In clappr-zepto, the animate() method does not exist, so it appears that it is no longer used.
