### PR TITLE
Fix: Add types to release

### DIFF
--- a/packages/clappr-core/package.json
+++ b/packages/clappr-core/package.json
@@ -7,7 +7,7 @@
   "types": "./types/main.d.ts",
   "scripts": {
     "bundle-check": "ANALYZE_BUNDLE=true rollup --config --bundleConfigAsCjs",
-    "release": "MINIMIZE=true rollup --config --bundleConfigAsCjs",
+    "release": "MINIMIZE=true rollup --config --bundleConfigAsCjs && tsc",
     "build": "rollup --config --bundleConfigAsCjs && tsc",
     "watch": "rollup --config --watch --bundleConfigAsCjs",
     "test": "jest /src --coverage --silent",


### PR DESCRIPTION
This pull request includes a small change to the `packages/clappr-core/package.json` file. The change modifies the `bundle-check` script to include a TypeScript compilation step.

* [`packages/clappr-core/package.json`](diffhunk://#diff-7ed5fc5d22083b11fa490f432292bd05f88d9ca962c19a877f82538635b916faL9-R9): Updated the `bundle-check` script to run `tsc` after the rollup command.