### PR TITLE
chore: include types dir to npm files

### DIFF
--- a/packages/clappr-core/package.json
+++ b/packages/clappr-core/package.json
@@ -22,7 +22,8 @@
   },
   "files": [
     "/dist",
-    "/src"
+    "/src",
+    "/types"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This pull request includes a small change to the `packages/clappr-core/package.json` file. The change adds the `/types` directory to the list of files that are included when the package is published.