### PR TITLE
feat(hlsjs): add liveSyncPosition getter

### DIFF
--- a/packages/hlsjs-playback/src/hls.js
+++ b/packages/hlsjs-playback/src/hls.js
@@ -44,6 +44,10 @@ export default class HlsjsPlayback extends HTML5Video {
     return this._hls.latency
   }
 
+  get liveSyncPosition() {
+    return this._hls.liveSyncPosition
+  }
+
   get currentProgramDateTime() {
     return this._hls.playingDate
   }


### PR DESCRIPTION
Add liveSyncPosition getter into Hlsjs to get the position of live sync point in low latency streams