### PR TITLE
Adjust core resize event

### DIFF
--- a/packages/clappr-core/.eslintrc.json
+++ b/packages/clappr-core/.eslintrc.json
@@ -28,7 +28,7 @@
     "extends": "eslint:recommended",
     "parserOptions": {
         "sourceType": "module",
-        "ecmaVersion": 2018
+        "ecmaVersion": 2020
     },
     "rules": {
         "indent": [

--- a/packages/clappr-core/package.json
+++ b/packages/clappr-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clappr/core",
-  "version": "0.11.5",
+  "version": "0.11.4",
   "description": "Core components of the extensible media player for the web",
   "main": "./dist/clappr-core.js",
   "module": "./dist/clappr-core.esm.js",
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@babel/core": "^7.22.17",
     "@babel/preset-env": "^7.22.15",
+    "@babel/plugin-transform-nullish-coalescing-operator": "^7.22.15",
     "@rollup/plugin-alias": "^5.0.0",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^25.0.4",

--- a/packages/clappr-core/package.json
+++ b/packages/clappr-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clappr/core",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Core components of the extensible media player for the web",
   "main": "./dist/clappr-core.js",
   "module": "./dist/clappr-core.esm.js",

--- a/packages/clappr-core/src/components/core/core.js
+++ b/packages/clappr-core/src/components/core/core.js
@@ -183,7 +183,7 @@ export default class Core extends UIObject {
   enableResizeObserver() {
     this.disableResizeObserver()
     const checkSizeCallback = () => {
-      this.triggerResize({ width: this.el.clientWidth, height: this.el.clientHeight })
+      this.triggerResize({ width: this.el.clientWidth || this.options.width, height: this.el.clientHeight || this.options.height })
     }
     this.resizeObserverInterval = setInterval(checkSizeCallback, 500)
   }
@@ -254,7 +254,7 @@ export default class Core extends UIObject {
     const orientation = (window.innerWidth > window.innerHeight) ? 'landscape' : 'portrait'
     if (this._screenOrientation === orientation) return
     this._screenOrientation = orientation
-    this.triggerResize({ width: this.el.clientWidth, height: this.el.clientHeight })
+    this.triggerResize({ width: this.el.clientWidth || this.options.width, height: this.el.clientHeight || this.options.height })
     this.trigger(Events.CORE_SCREEN_ORIENTATION_CHANGED, {
       event: event,
       orientation: this._screenOrientation

--- a/packages/clappr-core/src/components/core/core.js
+++ b/packages/clappr-core/src/components/core/core.js
@@ -183,7 +183,9 @@ export default class Core extends UIObject {
   enableResizeObserver() {
     this.disableResizeObserver()
     const checkSizeCallback = () => {
-      this.triggerResize({ width: this.el.clientWidth || this.options.width, height: this.el.clientHeight || this.options.height })
+      const width = this.el.clientWidth || this.options.width
+      const height = this.el.clientHeight || this.options.height
+      this.triggerResize({ width: width, height: height })
     }
     this.resizeObserverInterval = setInterval(checkSizeCallback, 500)
   }
@@ -254,7 +256,9 @@ export default class Core extends UIObject {
     const orientation = (window.innerWidth > window.innerHeight) ? 'landscape' : 'portrait'
     if (this._screenOrientation === orientation) return
     this._screenOrientation = orientation
-    this.triggerResize({ width: this.el.clientWidth || this.options.width, height: this.el.clientHeight || this.options.height })
+    const width = this.el.clientWidth || this.options.width;
+    const height = this.el.clientHeight || this.options.height;
+    this.triggerResize({ width: width, height: height })
     this.trigger(Events.CORE_SCREEN_ORIENTATION_CHANGED, {
       event: event,
       orientation: this._screenOrientation

--- a/packages/clappr-core/src/components/core/core.js
+++ b/packages/clappr-core/src/components/core/core.js
@@ -183,8 +183,8 @@ export default class Core extends UIObject {
   enableResizeObserver() {
     this.disableResizeObserver()
     const checkSizeCallback = () => {
-      const width = this.el.clientWidth || this.options.width
-      const height = this.el.clientHeight || this.options.height
+      const width = this.el.clientWidth ?? this.options.width
+      const height = this.el.clientHeight ?? this.options.height
       this.triggerResize({ width: width, height: height })
     }
     this.resizeObserverInterval = setInterval(checkSizeCallback, 500)
@@ -256,8 +256,8 @@ export default class Core extends UIObject {
     const orientation = (window.innerWidth > window.innerHeight) ? 'landscape' : 'portrait'
     if (this._screenOrientation === orientation) return
     this._screenOrientation = orientation
-    const width = this.el.clientWidth || this.options.width;
-    const height = this.el.clientHeight || this.options.height;
+    const width = this.el.clientWidth ?? this.options.width
+    const height = this.el.clientHeight ?? this.options.height
     this.triggerResize({ width: width, height: height })
     this.trigger(Events.CORE_SCREEN_ORIENTATION_CHANGED, {
       event: event,

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,6 +339,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz#9cbdd63a9443a2c92a725cca7ebca12cc8dd9f46"
   integrity sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==
 
+"@babel/helper-plugin-utils@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz#ddb2f876534ff8013e6c2b299bf4d39b3c51d44c"
+  integrity sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==
+
 "@babel/helper-remap-async-to-generator@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz#e53956ab3d5b9fb88be04b3e2f31b523afd34b92"
@@ -844,6 +849,13 @@
   integrity sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
+
+"@babel/plugin-transform-nullish-coalescing-operator@^7.22.15":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz#4f9d3153bf6782d73dd42785a9d22d03197bc91d"
+  integrity sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-transform-nullish-coalescing-operator@^7.25.9":
   version "7.25.9"


### PR DESCRIPTION
Adjust the core resize event to use option.width when el.clientWidth is not available. 

The Clappr core resize event was generating events with an ‘undefined’ size on nodejs enviroment. The issue occurs because two methods rely on el.clientWidth, but el is an empty object on node. I made an adjustment to use option.width when el.clientWidth is null, which ensures no impact on web or HTML-based TVs. It’s worth noting that option.width is already used in this event, so this change makes the behavior more consistent.