### PR TITLE
Update hls.js to v1.6.2

### DIFF
--- a/packages/hlsjs-playback/package.json
+++ b/packages/hlsjs-playback/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/clappr/hlsjs-playback",
   "peerDependencies": {
     "@clappr/core": "*",
-    "hls.js": "1.5.14"
+    "hls.js": "1.6.2"
   },
   "devDependencies": {
     "@babel/core": "^7.14.2",
@@ -51,7 +51,7 @@
     "coveralls": "^3.1.0",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.26.0",
-    "hls.js": "1.5.14",
+    "hls.js": "1.6.2",
     "jest": "^26.6.3",
     "rollup": "^2.47.0",
     "rollup-plugin-filesize": "^9.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9547,10 +9547,10 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-hls.js@1.5.14:
-  version "1.5.14"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.5.14.tgz#1d52be309a06aab25fee667c4969d8abf9f8fe59"
-  integrity sha512-5wLiQ2kWJMui6oUslaq8PnPOv1vjuee5gTxjJD0DSsccY12OXtDT0h137UuqjczNeHzeEYR0ROZQibKNMr7Mzg==
+hls.js@1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.6.2.tgz#02272bea644b5f61f71741256618d6b629ae7834"
+  integrity sha512-rx+pETSCJEDThm/JCm8CuadcAC410cVjb1XVXFNDKFuylaayHk1+tFxhkjvnMDAfqsJHxZXDAJ3Uc2d5xQyWlQ==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This pull request updates the `hls.js` dependency in the `packages/hlsjs-playback` package to a newer version. Both the `peerDependencies` and `devDependencies` sections of the `package.json` file have been updated to use version `1.6.2`