### PR TITLE
feat: add CORE_OPTIONS_WILL_CHANGE event to track configuration changes

### DIFF
--- a/packages/clappr-core/src/base/events/events.js
+++ b/packages/clappr-core/src/base/events/events.js
@@ -610,6 +610,15 @@ Events.CORE_CONTAINERS_CREATED = 'core:containers:created'
  * @event CORE_ACTIVE_CONTAINER_CHANGED
  */
 Events.CORE_ACTIVE_CONTAINER_CHANGED = 'core:active:container:changed'
+
+/**
+   * Fired before options are changed in core
+   *
+   * @event CORE_OPTIONS_WILL_CHANGE
+   * @param {Object} current options before change
+   */
+Events.CORE_OPTIONS_WILL_CHANGE = 'core:options:will:change'
+
 /**
  * Fired when the options were changed for the core
  *

--- a/packages/clappr-core/src/components/core/core.js
+++ b/packages/clappr-core/src/components/core/core.js
@@ -364,6 +364,9 @@ export default class Core extends UIObject {
    * @param {Object} options all the options to change in form of a javascript object
    */
   configure(options) {
+    const oldOptions = $.extend(true, {}, this._options)
+    this.trigger(Events.CORE_OPTIONS_WILL_CHANGE, oldOptions) // Trigger with oldOptions
+
     this._options = $.extend(true, this._options, options)
     this.configureDomRecycler()
 

--- a/packages/clappr-core/src/components/core/core.test.js
+++ b/packages/clappr-core/src/components/core/core.test.js
@@ -43,6 +43,34 @@ describe('Core', function() {
       expect(callback).toHaveBeenCalled()
       expect(core.options.autoPlay).toEqual(newOptions.autoPlay)
     })
+
+    test('should trigger options will change event', () => {
+      let callback = jest.fn()
+      core.on(Events.CORE_OPTIONS_WILL_CHANGE, callback)
+
+      const newOptions = {
+        autoPlay: false
+      }
+      core.configure(newOptions)
+
+      expect(callback).toHaveBeenCalled()
+    })
+
+    test('should trigger both events in correct order', () => {
+      const eventOrder = []
+      
+      core.on(Events.CORE_OPTIONS_WILL_CHANGE, () => {
+        eventOrder.push('will_change')
+      })
+      
+      core.on(Events.CORE_OPTIONS_CHANGE, () => {
+        eventOrder.push('change')
+      })
+
+      core.configure({ autoPlay: false })
+
+      expect(eventOrder).toEqual(['will_change', 'change'])
+    })
   })
 
   describe('#isFullscreen', () => {


### PR DESCRIPTION
## Summary

Adds a new `CORE_OPTIONS_WILL_CHANGE` event that fires before options are modified in the Core.configure() method, access to the previous options state.

## Changes 
- **New Event**: `Events.CORE_OPTIONS_WILL_CHANGE` in `events.js` 
- **Core Enhancement**: Modified `Core.configure()` to trigger the new event with a deep copy of old options