### PR TITLE
feat(telemetry): buffer and decoding metrics sampling

### DIFF
--- a/packages/clappr-telemetry/README.md
+++ b/packages/clappr-telemetry/README.md
@@ -2,13 +2,16 @@
 
 [![npm version](https://img.shields.io/badge/npm-v0.1.0-cb3837)](https://www.npmjs.com/package/@clappr/telemetry)
 
-A telemetry plugin for [Clappr](https://github.com/clappr/clappr). Collects network, engine, and MSE metrics from the player and exposes them through a single unified event on the container bus.
+A telemetry plugin for [Clappr](https://github.com/clappr/clappr). Collects network, buffer, and decoding metrics from the player and exposes them through a single unified event on the container bus.
 
 ## Overview
 
 `@clappr/telemetry` is a `ContainerPlugin` that automatically detects the active playback engine and activates the appropriate adapter for metrics collection. All telemetry data — regardless of source or event type — flows through the same registered event channel using a versioned envelope format, keeping consumers decoupled from internal implementation details.
 
-The adapter architecture is extensible: new playback engines (HLS.js, Shaka, native playback, etc.) can be supported by adding an adapter without changing the plugin or consumer code.
+The plugin is built around two extensible subsystems:
+
+- **Network adapters** — hook into the streaming engine (Shaka, HLS.js) to capture request timings, bitrate changes, and DRM events
+- **Sampler registry** — drives a set of periodic samplers from a single timer, emitting one `mse.sample` event per tick with buffer and decoding data grouped under their respective keys
 
 ## Installation
 
@@ -36,7 +39,9 @@ Via CDN (jsDelivr):
     source: 'https://example.com/stream.mpd',
     plugins: [DashShakaPlayback, ClapprTelemetry],
     telemetry: {
-      network: { enabled: true }
+      network:        { enabled: true },
+      bufferSample:   { enabled: true },
+      decodingSample: { enabled: true }
     }
   })
 </script>
@@ -54,48 +59,59 @@ const player = new Clappr.Player({
   source: 'https://example.com/stream.mpd',
   plugins: [DashShakaPlayback, ClapprTelemetry],
   telemetry: {
-    network: { enabled: true }
+    network:        { enabled: true },
+    bufferSample:   { enabled: true },
+    decodingSample: { enabled: true }
   }
 })
 ```
 
-### Public API (ES modules)
+### Named exports (ES modules)
 
-The `module` field points to `dist/clappr-telemetry.esm.js`, which exposes the plugin as the **default** export and these **named** exports (for tests, tooling, or custom adapters):
+Available from `dist/clappr-telemetry.esm.js`:
 
-| Export                       | Description                                                               |
-| ---------------------------- | ------------------------------------------------------------------------- |
-| `ShakaNetworkAdapter`        | Shaka network metrics adapter class                                       |
-| `HlsNetworkAdapter`          | HLS.js network metrics adapter class                                      |
-| `findNetworkAdapter`         | Resolves the adapter class for a playback instance (used by the plugin)   |
-| `TELEMETRY_CONTRACT_VERSION` | Semver string on each envelope (`v` field)                                |
-| `EVENT_TYPES`                | Canonical `type` strings (`request:start`, `request:end`, etc.)           |
-| `TELEMETRY_SOURCES`          | Canonical `source` values (e.g. `network`)                                |
-| `createEnvelope`             | Builds the versioned envelope object                                      |
-| `emitTelemetry`              | Triggers `Events.Custom.CONTAINER_TELEMETRY_TRACE` on an emitter          |
-| `calculateThroughput`        | Mbps helper used by network adapters                                      |
+**Adapters**
 
-Example:
+| Export                | Description                                                             |
+| --------------------- | ----------------------------------------------------------------------- |
+| `ShakaNetworkAdapter` | Shaka network metrics adapter class                                     |
+| `HlsNetworkAdapter`   | HLS.js network metrics adapter class                                    |
+| `findNetworkAdapter`  | Resolves the adapter class for a playback instance (used by the plugin) |
 
-```javascript
-import ClapprTelemetry, {
-  ShakaNetworkAdapter,
-  HlsNetworkAdapter,
-  findNetworkAdapter
-} from '@clappr/telemetry'
+**Samplers**
 
-const Adapter = findNetworkAdapter(playback)
-if (Adapter === ShakaNetworkAdapter) { /* ... */ }
-if (Adapter === HlsNetworkAdapter) { /* ... */ }
-```
+| Export              | Description                                              |
+| ------------------- | -------------------------------------------------------- |
+| `SamplerRegistry`  | Registry class — use to register custom samplers         |
+| `BufferSampler`     | Built-in buffer state sampler                            |
+| `DecodingSampler`   | Built-in decoding quality sampler                        |
+
+**Utils**
+
+| Export                       | Description                                                      |
+| ---------------------------- | ---------------------------------------------------------------- |
+| `TELEMETRY_CONTRACT_VERSION` | Semver string on each envelope (`v` field)                       |
+| `EVENT_TYPES`                | Canonical `type` strings (`request:start`, `mse.sample`, etc.)  |
+| `TELEMETRY_SOURCES`          | Canonical `source` values (e.g. `network`)                       |
+| `createEnvelope`             | Builds the versioned envelope object                             |
+| `emitTelemetry`              | Triggers `CONTAINER_TELEMETRY_TRACE` on an emitter               |
+| `calculateThroughput`        | Mbps helper used by network adapters                             |
+| `getBufferAhead`             | Returns seconds buffered ahead of the current position           |
+| `getBufferedRanges`          | Converts `TimeRanges` to a compact `[[start, end], ...]` array   |
 
 The UMD build (`dist/clappr-telemetry.js` / CDN) exposes **only** the plugin as the global `ClapprTelemetry`. Use the ESM file if you need named exports.
 
 ## Configuration
 
-| Option                      | Type    | Default | Description                       |
-| --------------------------- | ------- | ------- | --------------------------------- |
-| `telemetry.network.enabled` | Boolean | `false` | Enables network request telemetry |
+All options are opt-in — nothing is collected by default.
+
+| Option                                 | Type    | Default | Description                                               |
+| -------------------------------------- | ------- | ------- | --------------------------------------------------------- |
+| `telemetry.network.enabled`            | Boolean | `false` | Enables network request telemetry                         |
+| `telemetry.bufferSample.enabled`       | Boolean | `false` | Enables periodic buffer state sampling                    |
+| `telemetry.bufferSample.includeRanges` | Boolean | `true`  | Includes buffered time ranges in the `mse.sample` payload |
+| `telemetry.decodingSample.enabled`     | Boolean | `false` | Enables periodic decoding quality sampling                |
+| `telemetry.sampleIntervalMs`           | Number  | `0`     | Sampling frequency in ms. When `0` (default), no automatic interval is started and only on-demand snapshots via `snapshot()` are available |
 
 ## Consuming telemetry events
 
@@ -116,7 +132,10 @@ class MyTelemetryConsumer extends Clappr.ContainerPlugin {
   }
 
   onTrace(envelope) {
-    // Process the telemetry envelope
+    if (envelope.type === 'mse.sample') {
+      const { buffer, decoding } = envelope.data
+      // buffer and decoding keys are only present when the respective sampler is enabled
+    }
   }
 }
 ```
@@ -134,7 +153,7 @@ This event is registered when the TelemetryPlugin is instantiated. It is the pub
 
 ## Envelope format
 
-Every emission on `containerTelemetryTrace` carries a versioned envelope:
+Every emission on `CONTAINER_TELEMETRY_TRACE` carries a versioned envelope:
 
 | Field    | Type   | Description                                                 |
 | -------- | ------ | ----------------------------------------------------------- |
@@ -150,34 +169,135 @@ Every emission on `containerTelemetryTrace` carries a versioned envelope:
 
 Adapters connect the plugin to specific playback engines. Each adapter implements `static isSupported(playback)` and `bind()`.
 
-| Adapter                | Engine                | Status    |
-| ---------------------- | --------------------- | --------- |
-| `ShakaNetworkAdapter`  | `dash-shaka-playback` | Available |
-| HLS.js Network Adapter | `hlsjs-playback`      | Planned   |
-             
-    
-                  |
+| Adapter               | Engine                | Status    |
+| --------------------- | --------------------- | --------- |
+| `ShakaNetworkAdapter` | `dash-shaka-playback` | Available |
+| `HlsNetworkAdapter`   | `hlsjs-playback`      | Available |
+
 ### Sources (`source`)
 
-The `source` field identifies which telemetry area emitted the event. Each adapter owns one source.
-
-| `source`  | Area                                                    | Status    |
-| --------- | ------------------------------------------------------- | --------- |
-| `network` | Network request metrics (segments, manifests, licenses) | Available |
+| `source`            | Area                                                    |
+| ------------------- | ------------------------------------------------------- |
+| `network`           | Network request metrics (segments, manifests, licenses) |
+| `sampler-registry` | Periodic MSE metrics (buffer state, decoding quality)   |
 
 
 ### Event types (`type`)
 
-The `type` field identifies what happened. As new telemetry areas are added (MSE, engine, playback state), new types will appear here.
+| `type`                   | `source`            | Description                                           |
+| ------------------------ | ------------------- | ----------------------------------------------------- |
+| `request:start`          | `network`           | A network request was initiated                       |
+| `request:end`            | `network`           | A network request completed                           |
+| `request:error`          | `network`           | A network request failed                              |
+| `bitrate:change`         | `network`           | ABR algorithm switched to a different quality variant |
+| `drm:session:update`     | `network`           | A DRM session was updated                             |
+| `drm:expiration:updated` | `network`           | A DRM license expiration time was updated             |
+| `mse.sample`             | `sampler-registry` | Periodic snapshot of buffer and/or decoding state     |
 
-| `type`                   | `source`  | Description                                           |
-| ------------------------ | --------- | ----------------------------------------------------- |
-| `request:start`          | `network` | A network request was initiated                       |
-| `request:end`            | `network` | A network request completed                           |
-| `request:error`  | `network` | A network request failed (includes `details` and `fatal`) |
-| `bitrate:change`         | `network` | ABR algorithm switched to a different quality variant |
-| `drm:session:update`     | `network` | A DRM session was updated                             |
-| `drm:expiration:updated` | `network` | A DRM license expiration time was updated             |
+### `mse.sample` payload
+
+Emitted once per tick by the `SamplerRegistry`. Each key is only present when the respective sampler is enabled and has data to report (the `decoding` key is absent on the first tick while the baseline is being established).
+
+```javascript
+{
+  buffer: {
+    bufferAhead:   20,       // seconds buffered ahead of current position
+    currentTime:   10,       // current playback position in seconds
+    rangesCompact: [[0, 30]] // buffered time ranges (omitted if includeRanges: false)
+  },
+  decoding: {
+    decodedFps:   24,        // frames decoded per second in the interval
+    droppedFps:    1,        // frames dropped per second in the interval
+    dropRatio:  0.04,        // ratio of dropped frames over total in the interval
+    currentTime:   10,       // current playback position in seconds
+    totalDropped:   2,       // cumulative dropped frames since playback started
+    totalDecoded: 537        // cumulative decoded frames since playback started
+  }
+}
+```
+
+## Custom samplers
+
+The sampler registry is extensible. You can add your own sampler and have it participate in the same `mse.sample` tick without forking the package.
+
+### Contract
+
+A custom sampler must implement three members:
+
+| Member | Description |
+| --- | --- |
+| `static isEnabled(cfg)` | Returns `true` when the sampler should be active. `cfg` is `container.options.telemetry` |
+| `collect()` | Called every tick. Returns a plain object with the data to include, or `null` to skip this tick |
+| `destroy()` | Called when the registry is destroyed. Clean up any internal state here |
+
+### Example
+
+```javascript
+import {
+  SamplerRegistry,
+  emitTelemetry,
+  getBufferAhead
+} from '@clappr/telemetry'
+
+class AudioSampler {
+  static isEnabled(cfg) {
+    return cfg?.audioSample?.enabled === true
+  }
+
+  constructor(playback) {
+    this._playback = playback
+  }
+
+  collect() {
+    const videoEl = this._playback?.el
+    if (!videoEl) return null
+    return { volume: videoEl.volume, muted: videoEl.muted }
+  }
+
+  destroy() {
+    this._playback = null
+  }
+}
+
+// register before instantiating the player
+SamplerRegistry.register('audio', AudioSampler)
+
+new Clappr.Player({
+  plugins: [ClapprTelemetry],
+  telemetry: {
+    audioSample: { enabled: true }
+  }
+})
+```
+
+The result appears under the `audio` key in the `mse.sample` payload:
+
+```javascript
+{
+  buffer:  { ... },
+  decoding:{ ... },
+  audio:   { volume: 1, muted: false }
+}
+```
+
+To remove a previously registered sampler:
+
+```javascript
+SamplerRegistry.unregister('audio')
+```
+
+### On-demand snapshot
+
+The `TelemetryPlugin` exposes a `snapshot` getter that returns the current sampler data immediately, without waiting for the next tick and without emitting any event:
+
+```javascript
+const telemetry = player.getPlugin('telemetry')
+const data = telemetry.snapshot
+// { buffer: { bufferAhead: 20, currentTime: 10 }, decoding: { ... } }
+```
+
+Returns an empty object if called before the player is ready.
+
 
 
 ## Development

--- a/packages/clappr-telemetry/public/index.html
+++ b/packages/clappr-telemetry/public/index.html
@@ -44,6 +44,16 @@
       font-weight: bold;
     }
 
+    .toggle-label {
+      font-size: 13px;
+      color: #444;
+      font-weight: normal;
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      cursor: pointer;
+    }
+
     #examples {
       padding: 8px 12px;
       font-size: 14px;
@@ -200,6 +210,28 @@
       <select id="examples" onchange="switchExample(this.value)"></select>
     </div>
 
+    <div class="controls">
+      <label>Adapter:</label>
+      <label class="toggle-label"><input type="checkbox" id="chk-network" checked> Network</label>
+    </div>
+
+    <div class="controls">
+      <label>Sampler:</label>
+      <label class="toggle-label"><input type="checkbox" id="chk-buffer" checked> Buffer</label>
+      <label class="toggle-label"><input type="checkbox" id="chk-decoding" checked> Decoding</label>
+      <label class="toggle-label"><input type="checkbox" id="chk-audio"> Audio (custom)</label>
+      <label for="sample-interval" style="margin-left: 10px">Interval:</label>
+      <select id="sample-interval" onchange="app.build()">
+        <option value="0" selected>snapshot only</option>
+        <option value="1000">1s</option>
+        <option value="5000">5s</option>
+        <option value="10000">10s</option>
+        <option value="30000">30s</option>
+        <option value="60000">60s</option>
+      </select>
+      <button onclick="takeSnapshot()" style="margin-left: auto">Snapshot</button>
+    </div>
+
     <div id="custom-config">
       <div class="custom-guide">
         <strong>How to get your stream configuration from DevTools</strong>
@@ -251,19 +283,41 @@
       }
     }
 
+    // Custom sampler example — follows the contract documented in the README:
+    // static isEnabled(cfg), collect(), destroy()
+    class AudioSampler {
+      static isEnabled(cfg) {
+        return cfg?.audioSample?.enabled === true
+      }
+
+      constructor(playback) {
+        this._playback = playback
+      }
+
+      collect() {
+        const videoEl = this._playback?.el
+        if (!videoEl) return null
+        return { volume: videoEl.volume, muted: videoEl.muted }
+      }
+
+      destroy() {
+        this._playback = null
+      }
+    }
+
+    ClapprTelemetry.SamplerRegistry.register('audio', AudioSampler)
+
     class PlayerFactory {
       static engines = {
         'hls-hlsjs': {
           label: 'HLS.js',
           source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
           plugins: [HlsjsPlayback, ClapprTelemetry, SimpleTelemetryLogger],
-          telemetry: { network: { enabled: true } }
         },
         'dash-shaka': {
           label: 'Shaka DASH',
           source: 'https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd',
           plugins: [DashShakaPlayback, ClapprTelemetry, SimpleTelemetryLogger],
-          telemetry: { network: { enabled: true } }
         },
         'dash-shaka-widevine': {
           label: 'Shaka DASH + Widevine',
@@ -273,7 +327,16 @@
           label: 'HTML5 Video',
           source: 'http://clappr.io/highline.mp4',
           plugins: [Clappr.HTML5Video, ClapprTelemetry, SimpleTelemetryLogger],
-          telemetry: { network: { enabled: true } }
+        }
+      }
+
+      static getTelemetryConfig() {
+        return {
+          network:          { enabled: document.getElementById('chk-network').checked },
+          bufferSample:     { enabled: document.getElementById('chk-buffer').checked },
+          decodingSample:   { enabled: document.getElementById('chk-decoding').checked },
+          audioSample:      { enabled: document.getElementById('chk-audio').checked },
+          sampleIntervalMs: Number(document.getElementById('sample-interval').value),
         }
       }
 
@@ -287,8 +350,7 @@
           muted: true,
           autoPlay: false,
           plugins: config.plugins,
-          telemetry: config.telemetry,
-          ...(config.shakaConfiguration && { shakaConfiguration: config.shakaConfiguration })
+          telemetry: this.getTelemetryConfig(),
         })
       }
 
@@ -305,7 +367,7 @@
           muted: true,
           autoPlay: false,
           plugins: [DashShakaPlayback, ClapprTelemetry, SimpleTelemetryLogger],
-          telemetry: { network: { enabled: true } },
+          telemetry: this.getTelemetryConfig(),
           ...(shakaConfiguration && { shakaConfiguration })
         })
       }
@@ -371,6 +433,16 @@
     function switchExample(exampleKey) {
       app.switchExample(exampleKey)
     }
+
+    function takeSnapshot() {
+      const telemetry = app.player?.getPlugin('telemetry')
+      if (!telemetry) { console.warn('[SNAPSHOT] No player or telemetry plugin active'); return }
+      console.log('[SNAPSHOT]', telemetry.snapshot)
+    }
+
+    ;['chk-network', 'chk-buffer', 'chk-decoding', 'chk-audio'].forEach(id => {
+      document.getElementById(id).addEventListener('change', () => app.build())
+    })
   </script>
 </body>
 </html>

--- a/packages/clappr-telemetry/src/__fixtures__/index.js
+++ b/packages/clappr-telemetry/src/__fixtures__/index.js
@@ -1,0 +1,5 @@
+export const makeBuffered = (ranges) => ({
+  length: ranges.length,
+  start: (i) => ranges[i][0],
+  end: (i) => ranges[i][1]
+})

--- a/packages/clappr-telemetry/src/main.js
+++ b/packages/clappr-telemetry/src/main.js
@@ -1,13 +1,16 @@
 import TelemetryPlugin from './telemetry_plugin'
 
-export { findNetworkAdapter, ShakaNetworkAdapter } from './adapters'
+export { findNetworkAdapter, ShakaNetworkAdapter, HlsNetworkAdapter } from './adapters'
+export { SamplerRegistry, BufferSampler, DecodingSampler } from './samplers'
 export {
   TELEMETRY_CONTRACT_VERSION,
   EVENT_TYPES,
   TELEMETRY_SOURCES,
   createEnvelope,
   emitTelemetry,
-  calculateThroughput
+  calculateThroughput,
+  getBufferAhead,
+  getBufferedRanges
 } from './utils'
 
 export default TelemetryPlugin

--- a/packages/clappr-telemetry/src/samplers/buffer_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/buffer_sampler.js
@@ -1,0 +1,53 @@
+import { getBufferAhead, getBufferedRanges, round1 } from '../utils/helpers'
+
+/**
+ * Periodically samples the video buffer state and returns it to the scheduler.
+ *
+ * Reads the buffer state directly from the `<video>` element on each `collect()` call.
+ *
+ * **Configuration** via `container.options.telemetry.bufferSample`:
+ * - `enabled`       {boolean} — opt-in, must be `true` to activate (default: false)
+ * - `includeRanges` {boolean} — whether to include buffered ranges in the payload (default: true)
+ */
+export default class BufferSampler {
+  static get name() { return 'buffer-sampler' }
+
+  static isEnabled(cfg) {
+    return cfg?.bufferSample?.enabled === true
+  }
+
+  constructor(playback, container) {
+    this._playback = playback
+    this._destroyed = false
+    this._includeRanges = container.options?.telemetry?.bufferSample?.includeRanges !== false
+  }
+
+  /**
+   * Collects the current buffer state and returns it.
+   * Returns `null` if the video element is not available.
+   *
+   * @returns {{ bufferAhead: number, currentTime: number, rangesCompact?: number[][] } | null}
+   */
+  collect() {
+    if (this._destroyed) return null
+    const videoEl = this._playback?.el
+    if (!videoEl) return null
+
+    const currentTime = videoEl.currentTime
+    if (!isFinite(currentTime)) return null
+
+    const data = {
+      bufferAhead: round1(getBufferAhead(videoEl)),
+      currentTime: round1(currentTime)
+    }
+    if (this._includeRanges) data.rangesCompact = getBufferedRanges(videoEl.buffered)
+
+    return data
+  }
+
+  destroy() {
+    this._destroyed = true
+    this._playback = null
+    this._includeRanges = null
+  }
+}

--- a/packages/clappr-telemetry/src/samplers/buffer_sampler.test.js
+++ b/packages/clappr-telemetry/src/samplers/buffer_sampler.test.js
@@ -1,0 +1,101 @@
+import BufferSampler from './buffer_sampler'
+import { makeBuffered } from '../__fixtures__'
+
+const makeVideoEl = ({ currentTime = 10, ranges = [[0, 30]] } = {}) => ({
+  currentTime,
+  buffered: makeBuffered(ranges)
+})
+
+const makePlayback = (videoEl) => ({ el: videoEl })
+
+const makeContainer = (cfg = {}) => ({
+  options: { telemetry: { bufferSample: cfg } }
+})
+
+describe('BufferSampler', () => {
+  let sampler
+  let container
+  let playback
+
+  beforeEach(() => {
+    container = makeContainer()
+    playback = makePlayback(makeVideoEl())
+    sampler = new BufferSampler(playback, container)
+  })
+
+  describe('isEnabled()', () => {
+    it('returns false by default', () => {
+      expect(BufferSampler.isEnabled({})).toBe(false)
+    })
+
+    it('returns true when bufferSample.enabled is true', () => {
+      expect(BufferSampler.isEnabled({ bufferSample: { enabled: true } })).toBe(true)
+    })
+
+    it('returns false when bufferSample.enabled is false', () => {
+      expect(BufferSampler.isEnabled({ bufferSample: { enabled: false } })).toBe(false)
+    })
+
+    it('returns false when cfg is null', () => {
+      expect(BufferSampler.isEnabled(null)).toBe(false)
+    })
+  })
+
+  describe('collect()', () => {
+    it('returns bufferAhead and currentTime', () => {
+      const result = sampler.collect()
+      expect(result).toEqual(expect.objectContaining({ bufferAhead: 20, currentTime: 10 }))
+    })
+
+    it('includes rangesCompact by default', () => {
+      const result = sampler.collect()
+      expect(result.rangesCompact).toEqual([[0, 30]])
+    })
+
+    it('omits rangesCompact when includeRanges is false', () => {
+      const c = makeContainer({ includeRanges: false })
+      const s = new BufferSampler(makePlayback(makeVideoEl()), c)
+      const result = s.collect()
+      expect(result).not.toHaveProperty('rangesCompact')
+    })
+
+    it('returns null when videoEl is null', () => {
+      sampler = new BufferSampler({ el: null }, container)
+      expect(sampler.collect()).toBeNull()
+    })
+
+    it('returns null when playback is null', () => {
+      sampler = new BufferSampler(null, container)
+      expect(sampler.collect()).toBeNull()
+    })
+
+    it('returns bufferAhead 0 when currentTime is in a gap between ranges', () => {
+      sampler = new BufferSampler(makePlayback(makeVideoEl({ currentTime: 15, ranges: [[0, 10], [20, 30]] })), container)
+      expect(sampler.collect().bufferAhead).toBe(0)
+    })
+
+    it('returns null when currentTime is NaN', () => {
+      sampler = new BufferSampler(makePlayback(makeVideoEl({ currentTime: NaN })), container)
+      expect(sampler.collect()).toBeNull()
+    })
+
+    it('returns null when currentTime is Infinity', () => {
+      sampler = new BufferSampler(makePlayback(makeVideoEl({ currentTime: Infinity })), container)
+      expect(sampler.collect()).toBeNull()
+    })
+  })
+
+  describe('destroy()', () => {
+    it('collect() returns null after destroy', () => {
+      sampler.destroy()
+      expect(sampler.collect()).toBeNull()
+    })
+
+    it('is safe to call multiple times', () => {
+      expect(() => {
+        sampler.destroy()
+        sampler.destroy()
+      }).not.toThrow()
+    })
+  })
+})

--- a/packages/clappr-telemetry/src/samplers/decoding_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/decoding_sampler.js
@@ -1,0 +1,107 @@
+/**
+ * Periodically samples video decoding quality and returns it to the scheduler.
+ *
+ * Uses `HTMLVideoElement.getVideoPlaybackQuality()`, which returns cumulative
+ * counters since playback started. The sampler keeps the previous sample state
+ * to compute per-interval deltas.
+ *
+ * **Configuration** via `container.options.telemetry.decodingSample.enabled: true`
+ */
+
+import { round1, round4 } from '../utils/helpers'
+
+export default class DecodingSampler {
+  static get name() {
+    return 'decoding-sampler'
+  }
+
+  static isEnabled(cfg) {
+    return cfg?.decodingSample?.enabled === true
+  }
+
+  constructor(playback, _container) {
+    this._playback = playback
+    this._destroyed = false
+    this._lastTs = null
+    this._lastTotal = null
+    this._lastDropped = null
+    this._seed()
+  }
+
+  _videoEl() {
+    return this._playback?.el ?? null
+  }
+
+  _seed() {
+    const el = this._videoEl()
+    if (!el?.getVideoPlaybackQuality) return
+    const quality = el.getVideoPlaybackQuality()
+    this._lastTs = performance.now()
+    this._lastTotal = quality.totalVideoFrames
+    this._lastDropped = quality.droppedVideoFrames
+  }
+
+  /**
+   * Collects and returns decoding metrics for the current interval.
+   *
+   * The browser does not expose fps directly — `getVideoPlaybackQuality()` returns
+   * cumulative counters since playback started. To get per-interval values,
+   * we subtract the previous sample counters from the current ones.
+   *
+   * The baseline is captured in the constructor. If the video element was not
+   * available at construction time, the first `collect()` call captures it and
+   * returns `null`.
+   *
+   * @returns {{ decodedFps: number, droppedFps: number, dropRatio: number, currentTime: number, totalDropped: number, totalDecoded: number } | null}
+   */
+  collect() {
+    if (this._destroyed) return null
+    const videoEl = this._videoEl()
+    if (!videoEl?.getVideoPlaybackQuality) return null
+
+    if (this._lastTs === null) {
+      this._seed()
+      return null
+    }
+
+    const quality = videoEl.getVideoPlaybackQuality()
+    const now = performance.now()
+
+    const elapsedSec = (now - this._lastTs) / 1000
+    const prevTotal = this._lastTotal
+    const prevDropped = this._lastDropped
+
+    const framesDecodedInInterval = quality.totalVideoFrames - prevTotal
+    const framesDroppedInInterval = quality.droppedVideoFrames - prevDropped
+
+    this._lastTs = now
+    this._lastTotal = quality.totalVideoFrames
+    this._lastDropped = quality.droppedVideoFrames
+
+    if (elapsedSec <= 0) return null
+
+    if (framesDecodedInInterval < 0 || framesDroppedInInterval < 0) {
+      return null
+    }
+
+    const totalFramesInInterval = framesDecodedInInterval + framesDroppedInInterval
+    const dropRatio = totalFramesInInterval > 0 ? framesDroppedInInterval / totalFramesInInterval : 0
+
+    return {
+      decodedFps: round1(framesDecodedInInterval / elapsedSec),
+      droppedFps: round1(framesDroppedInInterval / elapsedSec),
+      dropRatio: round4(dropRatio),
+      currentTime: round1(videoEl.currentTime),
+      totalDropped: quality.droppedVideoFrames,
+      totalDecoded: quality.totalVideoFrames
+    }
+  }
+
+  destroy() {
+    this._destroyed = true
+    this._playback = null
+    this._lastTs = null
+    this._lastTotal = null
+    this._lastDropped = null
+  }
+}

--- a/packages/clappr-telemetry/src/samplers/decoding_sampler.test.js
+++ b/packages/clappr-telemetry/src/samplers/decoding_sampler.test.js
@@ -1,0 +1,170 @@
+import DecodingSampler from './decoding_sampler'
+
+const makeQuality = ({ totalVideoFrames = 0, droppedVideoFrames = 0 } = {}) => ({
+  totalVideoFrames,
+  droppedVideoFrames
+})
+
+const makeVideoEl = ({ currentTime = 5, quality = makeQuality() } = {}) => ({
+  currentTime,
+  getVideoPlaybackQuality: () => quality
+})
+
+const makePlayback = videoEl => ({ el: videoEl })
+
+describe('DecodingSampler', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('isEnabled()', () => {
+    it('returns false by default', () => {
+      expect(DecodingSampler.isEnabled({})).toBe(false)
+    })
+
+    it('returns true when decodingSample.enabled is true', () => {
+      expect(DecodingSampler.isEnabled({ decodingSample: { enabled: true } })).toBe(true)
+    })
+
+    it('returns false when decodingSample.enabled is false', () => {
+      expect(DecodingSampler.isEnabled({ decodingSample: { enabled: false } })).toBe(false)
+    })
+
+    it('returns false when cfg is null', () => {
+      expect(DecodingSampler.isEnabled(null)).toBe(false)
+    })
+  })
+
+  describe('collect()', () => {
+    it('returns data on the first call — seed happens in constructor', () => {
+      jest
+        .spyOn(performance, 'now')
+        .mockReturnValueOnce(0) // constructor _seed()
+        .mockReturnValueOnce(1000) // collect()
+      const sampler = new DecodingSampler(makePlayback(makeVideoEl()))
+      expect(sampler.collect()).not.toBeNull()
+    })
+
+    it('computes correct fps and dropRatio', () => {
+      jest
+        .spyOn(performance, 'now')
+        .mockReturnValueOnce(0) // constructor _seed()
+        .mockReturnValueOnce(1000) // collect()
+
+      const el = {
+        currentTime: 5,
+        getVideoPlaybackQuality: jest
+          .fn()
+          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 0, droppedVideoFrames: 0 })) // constructor
+          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 24, droppedVideoFrames: 6 })) // collect
+      }
+
+      const result = new DecodingSampler({ el }).collect()
+
+      expect(result.decodedFps).toBeCloseTo(24)
+      expect(result.droppedFps).toBeCloseTo(6)
+      expect(result.dropRatio).toBeCloseTo(6 / 30)
+      expect(result.totalDecoded).toBe(24)
+      expect(result.totalDropped).toBe(6)
+    })
+
+    it('returns dropRatio of 0 when no frames were processed', () => {
+      jest.spyOn(performance, 'now').mockReturnValueOnce(0).mockReturnValueOnce(1000)
+
+      const el = {
+        currentTime: 0,
+        getVideoPlaybackQuality: jest
+          .fn()
+          .mockReturnValueOnce(makeQuality()) // constructor
+          .mockReturnValueOnce(makeQuality()) // collect
+      }
+
+      expect(new DecodingSampler({ el }).collect().dropRatio).toBe(0)
+    })
+
+    it('returns null when elapsed time is zero (timer precision edge case)', () => {
+      jest.spyOn(performance, 'now').mockReturnValue(0)
+      const el = { currentTime: 0, getVideoPlaybackQuality: jest.fn().mockReturnValue(makeQuality()) }
+      const sampler = new DecodingSampler({ el })
+      expect(sampler.collect()).toBeNull()
+    })
+
+    it('returns null when videoEl is null', () => {
+      expect(new DecodingSampler({ el: null }).collect()).toBeNull()
+    })
+
+    it('returns null when getVideoPlaybackQuality is not available', () => {
+      expect(new DecodingSampler({ el: { currentTime: 0 } }).collect()).toBeNull()
+    })
+
+    it('returns null when playback is null', () => {
+      expect(new DecodingSampler(null).collect()).toBeNull()
+    })
+
+    it('returns null and re-seeds when droppedVideoFrames delta exceeds totalVideoFrames delta', () => {
+      jest
+        .spyOn(performance, 'now')
+        .mockReturnValueOnce(0)// constructor _seed()
+        .mockReturnValueOnce(1000) // collect()
+        .mockReturnValueOnce(2000) // _seed() re-baseline
+
+      const el = {
+        currentTime: 5,
+        getVideoPlaybackQuality: jest
+          .fn()
+          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 100, droppedVideoFrames: 10 })) // constructor
+          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 105, droppedVideoFrames: 0 }))  // collect — dropped reset
+          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 105, droppedVideoFrames: 0 }))  // _seed()
+      }
+
+      const sampler = new DecodingSampler({ el })
+      expect(sampler.collect()).toBeNull()
+    })
+
+    it('returns null and re-seeds when counters reset (source change)', () => {
+      jest
+        .spyOn(performance, 'now')
+        .mockReturnValueOnce(0) // constructor _seed()
+        .mockReturnValueOnce(1000) // collect()
+        .mockReturnValueOnce(2000) // _seed() inside collect after reset
+
+      const el = {
+        currentTime: 5,
+        getVideoPlaybackQuality: jest
+          .fn()
+          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 100, droppedVideoFrames: 2 })) // constructor
+          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 10, droppedVideoFrames: 0 }))  // collect — counters reset
+          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 10, droppedVideoFrames: 0 }))  // _seed() re-baseline
+      }
+
+      const sampler = new DecodingSampler({ el })
+      expect(sampler.collect()).toBeNull()
+    })
+
+    it('returns null on first collect() when element was unavailable at construction', () => {
+      jest.spyOn(performance, 'now').mockReturnValue(1000)
+      const playback = { el: { currentTime: 0 } } // no getVideoPlaybackQuality at construction
+      const s = new DecodingSampler(playback)
+      playback.el.getVideoPlaybackQuality = () => makeQuality() // becomes available later
+      expect(s.collect()).toBeNull() // fallback seed, returns null
+    })
+  })
+
+  describe('destroy()', () => {
+    it('collect() returns null after destroy', () => {
+      jest.spyOn(performance, 'now').mockReturnValue(0)
+      const sampler = new DecodingSampler(makePlayback(makeVideoEl()))
+      sampler.destroy()
+      expect(sampler.collect()).toBeNull()
+    })
+
+    it('is safe to call multiple times', () => {
+      jest.spyOn(performance, 'now').mockReturnValue(0)
+      const sampler = new DecodingSampler(makePlayback(makeVideoEl()))
+      expect(() => {
+        sampler.destroy()
+        sampler.destroy()
+      }).not.toThrow()
+    })
+  })
+})

--- a/packages/clappr-telemetry/src/samplers/decoding_sampler.test.js
+++ b/packages/clappr-telemetry/src/samplers/decoding_sampler.test.js
@@ -113,8 +113,8 @@ describe('DecodingSampler', () => {
         getVideoPlaybackQuality: jest
           .fn()
           .mockReturnValueOnce(makeQuality({ totalVideoFrames: 100, droppedVideoFrames: 10 })) // constructor
-          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 105, droppedVideoFrames: 0 }))  // collect — dropped reset
-          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 105, droppedVideoFrames: 0 }))  // _seed()
+          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 105, droppedVideoFrames: 0 })) // collect — dropped reset
+          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 105, droppedVideoFrames: 0 })) // _seed()
       }
 
       const sampler = new DecodingSampler({ el })
@@ -133,8 +133,8 @@ describe('DecodingSampler', () => {
         getVideoPlaybackQuality: jest
           .fn()
           .mockReturnValueOnce(makeQuality({ totalVideoFrames: 100, droppedVideoFrames: 2 })) // constructor
-          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 10, droppedVideoFrames: 0 }))  // collect — counters reset
-          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 10, droppedVideoFrames: 0 }))  // _seed() re-baseline
+          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 10, droppedVideoFrames: 0 })) // collect — counters reset
+          .mockReturnValueOnce(makeQuality({ totalVideoFrames: 10, droppedVideoFrames: 0 })) // _seed() re-baseline
       }
 
       const sampler = new DecodingSampler({ el })

--- a/packages/clappr-telemetry/src/samplers/index.js
+++ b/packages/clappr-telemetry/src/samplers/index.js
@@ -1,0 +1,3 @@
+export { default as SamplerRegistry } from './sampler_registry'
+export { default as BufferSampler } from './buffer_sampler'
+export { default as DecodingSampler } from './decoding_sampler'

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.js
@@ -45,7 +45,7 @@ export default class SamplerRegistry {
     const missing = [
       typeof SamplerClass.isEnabled !== 'function' && 'static isEnabled()',
       typeof proto?.collect !== 'function' && 'collect()',
-      typeof proto?.destroy !== 'function' && 'destroy()',
+      typeof proto?.destroy !== 'function' && 'destroy()'
     ].filter(Boolean)
 
     if (missing.length > 0) {

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.js
@@ -1,0 +1,126 @@
+import { Log } from '@clappr/core'
+import { emitTelemetry } from '../utils'
+import { EVENT_TYPES } from '../utils/constants'
+import BufferSampler from './buffer_sampler'
+import DecodingSampler from './decoding_sampler'
+
+const DISABLED_INTERVAL = 0
+
+const _registry = new Map([
+  ['buffer', BufferSampler],
+  ['decoding', DecodingSampler]
+])
+
+/**
+ * Drives all active samplers from a single `setInterval`.
+ *
+ * On construction, filters the sampler registry by each sampler's `isEnabled()`
+ * and instantiates only those that are enabled. On every tick, calls `collect()`
+ * on each active sampler and emits a single `MSE_SAMPLE` event with the results
+ * grouped by key (`buffer`, `decoding`). Keys are omitted when the sampler
+ * returns `null` (e.g. decoding seed call).
+ *
+ * The registry is extensible via `SamplerRegistry.register()` — external samplers
+ * can be added before the player is instantiated.
+ *
+ * **Configuration** via `container.options.telemetry`:
+ * - `sampleIntervalMs` {number} — tick frequency in ms (default: 0 — disabled, use snapshot() for on-demand collection)
+ */
+export default class SamplerRegistry {
+  static get name() { return 'sampler-registry' }
+
+  /**
+   * Registers an external sampler class into the global registry.
+   * Must be called before the player is instantiated.
+   *
+   * **Note:** This method modifies a module-level registry shared by all
+   * SamplerRegistry instances. It is intended to be called once during
+   * app bootstrap, before any player is created.
+   *
+   * @param {string} key - Key used in the `mse.sample` payload (e.g. `'metrics'`)
+   * @param {Function} SamplerClass - Class implementing `static isEnabled()`, `collect()`, and `destroy()`
+   */
+  static register(key, SamplerClass) {
+    const proto = SamplerClass.prototype
+    const missing = [
+      typeof SamplerClass.isEnabled !== 'function' && 'static isEnabled()',
+      typeof proto?.collect !== 'function' && 'collect()',
+      typeof proto?.destroy !== 'function' && 'destroy()',
+    ].filter(Boolean)
+
+    if (missing.length > 0) {
+      Log.warn('[SamplerRegistry]', `${key}: missing ${missing.join(', ')} — skipping`)
+      return
+    }
+    _registry.set(key, SamplerClass)
+  }
+
+  /**
+   * Removes a previously registered sampler from the global registry.
+   *
+   * @param {string} key - The key used when registering the sampler
+   */
+  static unregister(key) {
+    _registry.delete(key)
+  }
+
+  constructor(playback, container) {
+    const cfg = container.options?.telemetry || {}
+    this._container = container
+    const raw = cfg.sampleIntervalMs
+    this._intervalMs = (typeof raw === 'number' && raw > 0) ? raw : DISABLED_INTERVAL
+    this._samplers = [..._registry.entries()]
+      .filter(([, S]) => S.isEnabled(cfg))
+      .map(([key, S]) => [key, new S(playback, container)])
+    this._timerId = null
+  }
+
+  /**
+   * Starts the sampling interval. Idempotent — safe to call multiple times.
+   * If `sampleIntervalMs` is 0 (default), the interval is not started and
+   * only on-demand snapshots via `snapshot()` are available.
+   */
+  bind() {
+    if (this._timerId !== null || this._intervalMs === 0) return
+    this._timerId = setInterval(() => this._tick(), this._intervalMs)
+  }
+
+  /**
+   * Collects data from all active samplers and returns it directly.
+   * Can be called at any time regardless of the interval state.
+   *
+   * @returns {Object} Snapshot of all active samplers, keyed by sampler name
+   */
+  snapshot() {
+    const data = {}
+    for (const [key, sampler] of this._samplers) {
+      try {
+        const result = sampler.collect()
+        if (result !== null) data[key] = result
+      } catch (err) {
+        Log.warn('[SamplerRegistry]', `${key}: collect() threw`, err)
+      }
+    }
+    return data
+  }
+
+  _tick() {
+    const data = this.snapshot()
+    if (Object.keys(data).length > 0) {
+      emitTelemetry(this._container, EVENT_TYPES.MSE_SAMPLE, data, SamplerRegistry.name)
+    }
+  }
+
+  /**
+   * Stops the interval and destroys all active samplers.
+   */
+  destroy() {
+    if (this._timerId !== null) {
+      clearInterval(this._timerId)
+      this._timerId = null
+    }
+    this._samplers.forEach(([, s]) => s.destroy())
+    this._samplers = []
+    this._container = null
+  }
+}

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.test.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.test.js
@@ -1,0 +1,275 @@
+import SamplerRegistry from './sampler_registry'
+import BufferSampler from './buffer_sampler'
+import DecodingSampler from './decoding_sampler'
+import { emitTelemetry } from '../utils'
+import { EVENT_TYPES } from '../utils/constants'
+import { Log } from '@clappr/core'
+
+jest.mock('./buffer_sampler', () => {
+  const mock = jest.fn()
+  mock.isEnabled = jest.fn(() => true)
+  return { __esModule: true, default: mock }
+})
+
+jest.mock('./decoding_sampler', () => {
+  const mock = jest.fn()
+  mock.isEnabled = jest.fn(() => true)
+  return { __esModule: true, default: mock }
+})
+
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  emitTelemetry: jest.fn()
+}))
+
+const makeContainer = (cfg = {}) => ({
+  options: { telemetry: { sampleIntervalMs: 1000, ...cfg } },
+  trigger: jest.fn()
+})
+
+describe('SamplerRegistry', () => {
+  let mockBufferInstance
+  let mockDecodingInstance
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.clearAllMocks()
+
+    mockBufferInstance = { collect: jest.fn(() => ({ bufferAhead: 20, currentTime: 10 })), destroy: jest.fn() }
+    mockDecodingInstance = { collect: jest.fn(() => ({ decodedFps: 24, droppedFps: 0, dropRatio: 0, totalDecoded: 100, totalDropped: 0, currentTime: 10 })), destroy: jest.fn() }
+
+    BufferSampler.mockImplementation(() => mockBufferInstance)
+    DecodingSampler.mockImplementation(() => mockDecodingInstance)
+    BufferSampler.isEnabled.mockReturnValue(true)
+    DecodingSampler.isEnabled.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('bind()', () => {
+    it('does not start a timer when sampleIntervalMs is 0', () => {
+      const scheduler = new SamplerRegistry({}, makeContainer({ sampleIntervalMs: 0 }))
+      scheduler.bind()
+      jest.advanceTimersByTime(10000)
+      expect(emitTelemetry).not.toHaveBeenCalled()
+    })
+
+    it('emits MSE_SAMPLE with grouped data on each tick', () => {
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      jest.advanceTimersByTime(1000)
+
+      expect(emitTelemetry).toHaveBeenCalledWith(
+        expect.any(Object),
+        EVENT_TYPES.MSE_SAMPLE,
+        { buffer: expect.any(Object), decoding: expect.any(Object) },
+        SamplerRegistry.name
+      )
+    })
+
+    it('fires every 1000ms when configured', () => {
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      jest.advanceTimersByTime(3000)
+
+      expect(emitTelemetry).toHaveBeenCalledTimes(3)
+    })
+
+    it('respects custom sampleIntervalMs', () => {
+      const scheduler = new SamplerRegistry({}, makeContainer({ sampleIntervalMs: 500 }))
+      scheduler.bind()
+      jest.advanceTimersByTime(1000)
+
+      expect(emitTelemetry).toHaveBeenCalledTimes(2)
+    })
+
+    it('is idempotent — two bind() calls produce one timer', () => {
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      scheduler.bind()
+      jest.advanceTimersByTime(1000)
+
+      expect(emitTelemetry).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('_tick()', () => {
+    it('continues emitting other samplers when one collect() throws', () => {
+      mockBufferInstance.collect.mockImplementation(() => { throw new Error('boom') })
+
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      jest.advanceTimersByTime(1000)
+
+      const [, , data] = emitTelemetry.mock.calls[0]
+      expect(data).not.toHaveProperty('buffer')
+      expect(data).toHaveProperty('decoding')
+    })
+
+    it('omits key when collect() returns null', () => {
+      mockDecodingInstance.collect.mockReturnValue(null)
+
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      jest.advanceTimersByTime(1000)
+
+      const [, , data] = emitTelemetry.mock.calls[0]
+      expect(data).toHaveProperty('buffer')
+      expect(data).not.toHaveProperty('decoding')
+    })
+
+    it('does not emit when all collect() return null', () => {
+      mockBufferInstance.collect.mockReturnValue(null)
+      mockDecodingInstance.collect.mockReturnValue(null)
+
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      jest.advanceTimersByTime(1000)
+
+      expect(emitTelemetry).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('sampler filtering via isEnabled()', () => {
+    it('excludes disabled samplers', () => {
+      BufferSampler.isEnabled.mockReturnValue(false)
+
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      jest.advanceTimersByTime(1000)
+
+      const [, , data] = emitTelemetry.mock.calls[0]
+      expect(data).not.toHaveProperty('buffer')
+      expect(data).toHaveProperty('decoding')
+    })
+
+    it('does not emit when all samplers are disabled', () => {
+      BufferSampler.isEnabled.mockReturnValue(false)
+      DecodingSampler.isEnabled.mockReturnValue(false)
+
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      jest.advanceTimersByTime(1000)
+
+      expect(emitTelemetry).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('register()', () => {
+    afterEach(() => {
+      SamplerRegistry.unregister('custom')
+    })
+
+    it('skips registration and warns when SamplerClass is missing required methods', () => {
+      const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {})
+      SamplerRegistry.register('custom', class {})
+
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      jest.advanceTimersByTime(1000)
+
+      const [, , data] = emitTelemetry.mock.calls[0]
+      expect(data).not.toHaveProperty('custom')
+      expect(warnSpy).toHaveBeenCalled()
+
+      scheduler.destroy()
+    })
+
+    it('includes a registered external sampler in the tick', () => {
+      const customInstance = { collect: jest.fn(() => ({ foo: 'bar' })), destroy: jest.fn() }
+      const CustomSampler = jest.fn(() => customInstance)
+      CustomSampler.isEnabled = jest.fn(() => true)
+      CustomSampler.prototype.collect = jest.fn()
+      CustomSampler.prototype.destroy = jest.fn()
+
+      SamplerRegistry.register('custom', CustomSampler)
+
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      jest.advanceTimersByTime(1000)
+
+      const [, , data] = emitTelemetry.mock.calls[0]
+      expect(data).toHaveProperty('custom')
+      expect(data.custom).toEqual({ foo: 'bar' })
+
+      scheduler.destroy()
+    })
+
+    it('excludes a registered external sampler when isEnabled returns false', () => {
+      const CustomSampler = jest.fn()
+      CustomSampler.isEnabled = jest.fn(() => false)
+      CustomSampler.prototype.collect = jest.fn()
+      CustomSampler.prototype.destroy = jest.fn()
+
+      SamplerRegistry.register('custom', CustomSampler)
+
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      jest.advanceTimersByTime(1000)
+
+      expect(emitTelemetry).toHaveBeenCalled()
+      const [, , data] = emitTelemetry.mock.calls[0]
+      expect(data).not.toHaveProperty('custom')
+
+      scheduler.destroy()
+    })
+  })
+
+  describe('snapshot()', () => {
+    it('returns collected data keyed by sampler name', () => {
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      const result = scheduler.snapshot()
+      expect(result).toEqual({ buffer: expect.any(Object), decoding: expect.any(Object) })
+    })
+
+    it('omits key when collect() returns null', () => {
+      mockDecodingInstance.collect.mockReturnValue(null)
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      const result = scheduler.snapshot()
+      expect(result).not.toHaveProperty('decoding')
+      expect(result).toHaveProperty('buffer')
+    })
+
+    it('returns empty object when all collect() return null', () => {
+      mockBufferInstance.collect.mockReturnValue(null)
+      mockDecodingInstance.collect.mockReturnValue(null)
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      expect(scheduler.snapshot()).toEqual({})
+    })
+  })
+
+  describe('destroy()', () => {
+    it('stops the timer', () => {
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      scheduler.destroy()
+      jest.advanceTimersByTime(2000)
+
+      expect(emitTelemetry).not.toHaveBeenCalled()
+    })
+
+    it('calls destroy() on each sampler', () => {
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.destroy()
+
+      expect(mockBufferInstance.destroy).toHaveBeenCalled()
+      expect(mockDecodingInstance.destroy).toHaveBeenCalled()
+    })
+
+    it('is safe to call without bind', () => {
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      expect(() => scheduler.destroy()).not.toThrow()
+    })
+
+    it('is safe to call multiple times', () => {
+      const scheduler = new SamplerRegistry({}, makeContainer())
+      scheduler.bind()
+      expect(() => {
+        scheduler.destroy()
+        scheduler.destroy()
+      }).not.toThrow()
+    })
+  })
+})

--- a/packages/clappr-telemetry/src/telemetry_plugin.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.js
@@ -1,5 +1,6 @@
 import { ContainerPlugin, Log, Events } from '@clappr/core'
 import { findNetworkAdapter } from './adapters'
+import { SamplerRegistry } from './samplers'
 
 /**
  * @event CONTAINER_TELEMETRY_TRACE
@@ -14,9 +15,18 @@ Events.register('CONTAINER_TELEMETRY_TRACE')
  * Integrates with container's telemetry bus to forward network and playback metrics.
  */
 export default class TelemetryPlugin extends ContainerPlugin {
+  /**
+   * UMD access point for `SamplerRegistry.register()`.
+   * The UMD build exposes only the plugin class as the global, so named exports
+   * are not reachable. This static getter bridges that gap for script-tag consumers.
+   * ESM consumers should import `SamplerRegistry` directly from the package.
+   */
+  static get SamplerRegistry() { return SamplerRegistry }
+
   constructor(container) {
     super(container)
     this.adapter = null
+    this.samplerRegistry = null
   }
 
   get name() {
@@ -25,6 +35,16 @@ export default class TelemetryPlugin extends ContainerPlugin {
 
   get supportedVersion() {
     return { min: '0.13.1' }
+  }
+
+  /**
+   * Returns a snapshot of all active samplers at the current moment.
+   * Returns an empty object if the scheduler is not yet initialized.
+   *
+   * @returns {Object} Sampler data keyed by sampler name (e.g. `{ buffer: {...}, decoding: {...} }`)
+   */
+  get snapshot() {
+    return this.samplerRegistry?.snapshot() ?? {}
   }
 
   bindEvents() {
@@ -37,31 +57,35 @@ export default class TelemetryPlugin extends ContainerPlugin {
 
   onPlaybackRead(playback) {
     const telemetryConfig = this.container.options?.telemetry || {}
-    const networkEnabled = telemetryConfig.network?.enabled === true
 
-    if (!networkEnabled) {
-      return
+    if (telemetryConfig.network?.enabled === true) {
+      const AdapterClass = findNetworkAdapter(playback)
+
+      if (!AdapterClass) {
+        Log.warn(`[TelemetryPlugin] No network adapter for playback: ${playback.name || playback.constructor.name || 'unknown'}`)
+      } else {
+        if (this.adapter) this.adapter.destroy()
+        this.adapter = new AdapterClass(playback, this.container)
+        this.adapter.bind()
+      }
     }
 
-    const AdapterClass = findNetworkAdapter(playback)
-
-    if (!AdapterClass) {
-      Log.warn(`[TelemetryPlugin] No network adapter for playback: ${playback.name || playback.constructor.name || 'unknown'}`)
-      return
-    }
-
-    if (this.adapter) {
-      this.adapter.destroy()
-    }
-
-    this.adapter = new AdapterClass(playback, this.container)
-    this.adapter.bind()
+    // The scheduler is always instantiated regardless of which built-in samplers
+    // are enabled — external samplers registered via SamplerRegistry.register()
+    // must also be able to run without requiring the built-ins to be on.
+    if (this.samplerRegistry) this.samplerRegistry.destroy()
+    this.samplerRegistry = new SamplerRegistry(playback, this.container)
+    this.samplerRegistry.bind()
   }
 
   destroy() {
     if (this.adapter) {
       this.adapter.destroy()
       this.adapter = null
+    }
+    if (this.samplerRegistry) {
+      this.samplerRegistry.destroy()
+      this.samplerRegistry = null
     }
     super.destroy()
   }

--- a/packages/clappr-telemetry/src/telemetry_plugin.test.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.test.js
@@ -1,10 +1,18 @@
 import { Log, Events } from '@clappr/core'
 import TelemetryPlugin from './telemetry_plugin'
 import { findNetworkAdapter } from './adapters'
+import MockSamplerRegistryClass from './samplers/sampler_registry'
 
 jest.mock('./adapters', () => ({
   findNetworkAdapter: jest.fn()
 }))
+
+jest.mock('./samplers/sampler_registry', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+let mockSamplerRegistry
 
 describe('TelemetryPlugin', () => {
   let plugin, mockContainer, mockPlayback
@@ -15,6 +23,9 @@ describe('TelemetryPlugin', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    findNetworkAdapter.mockReturnValue(null)
+    mockSamplerRegistry = { bind: jest.fn(), destroy: jest.fn() }
+    MockSamplerRegistryClass.mockImplementation(() => mockSamplerRegistry)
 
     mockPlayback = { name: 'dash_shaka_playback' }
     mockContainer = {
@@ -186,5 +197,61 @@ describe('TelemetryPlugin', () => {
     )
     plugin.destroy()
     expect(parentDestroy).toHaveBeenCalled()
+  })
+
+  describe('snapshot getter', () => {
+    it('delegates to samplerScheduler.snapshot()', () => {
+      mockSamplerRegistry.snapshot = jest.fn(() => ({ buffer: { bufferAhead: 10 } }))
+      plugin.onPlaybackRead(mockPlayback)
+      expect(plugin.snapshot).toEqual({ buffer: { bufferAhead: 10 } })
+      expect(mockSamplerRegistry.snapshot).toHaveBeenCalled()
+    })
+
+    it('returns empty object when samplerScheduler is null', () => {
+      plugin.samplerRegistry = null
+      expect(plugin.snapshot).toEqual({})
+    })
+  })
+
+  describe('SamplerRegistry lifecycle', () => {
+    it('should instantiate and bind samplerScheduler on onPlaybackRead', () => {
+      plugin.onPlaybackRead(mockPlayback)
+
+      expect(MockSamplerRegistryClass).toHaveBeenCalledWith(mockPlayback, mockContainer)
+      expect(mockSamplerRegistry.bind).toHaveBeenCalled()
+      expect(plugin.samplerRegistry).toBe(mockSamplerRegistry)
+    })
+
+    it('should destroy previous samplerScheduler on re-bind', () => {
+      plugin.onPlaybackRead(mockPlayback)
+      plugin.onPlaybackRead(mockPlayback)
+
+      expect(mockSamplerRegistry.destroy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should destroy samplerScheduler on plugin destroy', () => {
+      plugin.onPlaybackRead(mockPlayback)
+      plugin.destroy()
+
+      expect(mockSamplerRegistry.destroy).toHaveBeenCalled()
+      expect(plugin.samplerRegistry).toBeNull()
+    })
+
+    it('should not throw on destroy when samplerScheduler is null', () => {
+      plugin.samplerRegistry = null
+      expect(() => plugin.destroy()).not.toThrow()
+    })
+
+    it('should instantiate samplerScheduler even when network adapter is disabled', () => {
+      const c = {
+        on: jest.fn(), off: jest.fn(), playback: null,
+        options: { telemetry: { network: { enabled: false } } }
+      }
+      const p = new TelemetryPlugin(c)
+      p.onPlaybackRead(mockPlayback)
+
+      expect(p.samplerRegistry).toBe(mockSamplerRegistry)
+      expect(p.adapter).toBeNull()
+    })
   })
 })

--- a/packages/clappr-telemetry/src/utils/constants.js
+++ b/packages/clappr-telemetry/src/utils/constants.js
@@ -70,5 +70,14 @@ export const EVENT_TYPES = {
    *
    * @event DRM_EXPIRATION_UPDATED
    */
-  DRM_EXPIRATION_UPDATED: 'drm:expiration:updated'
+  DRM_EXPIRATION_UPDATED: 'drm:expiration:updated',
+
+  /**
+   * Emitted once per scheduler tick with a combined snapshot of buffer and decoding state.
+   * Payload shape: `{ buffer?: {...}, decoding?: {...} }` — keys are present only
+   * when the respective sampler is enabled and has data to report.
+   *
+   * @event MSE_SAMPLE
+   */
+  MSE_SAMPLE: 'mse.sample'
 }

--- a/packages/clappr-telemetry/src/utils/helpers.js
+++ b/packages/clappr-telemetry/src/utils/helpers.js
@@ -6,6 +6,10 @@ const BITS_PER_BYTE = 8
 const BITS_PER_MEGABIT = 1e6
 const THROUGHPUT_DECIMAL_PLACES = 2
 
+export const round1 = v => Math.round(v * 10) / 10
+export const round4 = v => Math.round(v * 10000) / 10000
+const round2 = v => Math.round(v * 100) / 100
+
 /**
  * Creates a telemetry envelope with monotonic and wall-clock timestamps.
  *
@@ -77,6 +81,37 @@ export const hashUrl = url => {
     h = Math.imul(h, 0x01000193) >>> 0
   }
   return h.toString(16).padStart(8, '0')
+}
+
+/**
+ * Returns how many seconds of video are buffered ahead of the current playback position.
+ *
+ * @param {HTMLVideoElement} videoEl
+ * @returns {number} Seconds buffered ahead (0 if currentTime is outside all ranges)
+ */
+export const getBufferAhead = (videoEl) => {
+  const { buffered, currentTime } = videoEl
+  for (let i = 0; i < buffered.length; i++) {
+    if (currentTime >= buffered.start(i) && currentTime <= buffered.end(i)) {
+      return buffered.end(i) - currentTime
+    }
+  }
+  return 0
+}
+
+/**
+ * Converts a TimeRanges object into a compact array of [start, end] pairs.
+ * Values are rounded to 2 decimal places.
+ *
+ * @param {TimeRanges} buffered
+ * @returns {Array<[number, number]>}
+ */
+export const getBufferedRanges = (buffered) => {
+  const ranges = []
+  for (let i = 0; i < buffered.length; i++) {
+    ranges.push([round2(buffered.start(i)), round2(buffered.end(i))])
+  }
+  return ranges
 }
 
 /**

--- a/packages/clappr-telemetry/src/utils/helpers.test.js
+++ b/packages/clappr-telemetry/src/utils/helpers.test.js
@@ -1,6 +1,7 @@
-import { emitTelemetry, createEnvelope, calculateThroughput, sanitizeLicenseUri } from './helpers'
+import { emitTelemetry, createEnvelope, calculateThroughput, sanitizeLicenseUri, getBufferAhead, getBufferedRanges } from './helpers'
 import { Events, Log } from '@clappr/core'
 import { EVENT_TYPES } from './constants'
+import { makeBuffered } from '../__fixtures__'
 
 Events.register('CONTAINER_TELEMETRY_TRACE')
 const CONTAINER_TELEMETRY_TRACE = Events.Custom.CONTAINER_TELEMETRY_TRACE
@@ -124,6 +125,56 @@ describe('sanitizeLicenseUri', () => {
 
   it('returns null origin and empty params when uri is invalid', () => {
     expect(sanitizeLicenseUri('not-a-url')).toEqual({ licenseServerOrigin: null, licenseServerParams: [] })
+  })
+})
+
+describe('getBufferAhead', () => {
+  it('returns 0 when buffered is empty', () => {
+    const videoEl = { buffered: makeBuffered([]), currentTime: 5 }
+    expect(getBufferAhead(videoEl)).toBe(0)
+  })
+
+  it('returns end - currentTime when currentTime is inside a range', () => {
+    const videoEl = { buffered: makeBuffered([[0, 30]]), currentTime: 10 }
+    expect(getBufferAhead(videoEl)).toBe(20)
+  })
+
+  it('returns 0 when currentTime is outside all ranges', () => {
+    const videoEl = { buffered: makeBuffered([[0, 10], [20, 30]]), currentTime: 15 }
+    expect(getBufferAhead(videoEl)).toBe(0)
+  })
+
+  it('matches the correct range among multiple ranges', () => {
+    const videoEl = { buffered: makeBuffered([[0, 10], [15, 40]]), currentTime: 20 }
+    expect(getBufferAhead(videoEl)).toBe(20)
+  })
+
+  it('returns 0 when currentTime equals the end of a range', () => {
+    const videoEl = { buffered: makeBuffered([[0, 10]]), currentTime: 10 }
+    expect(getBufferAhead(videoEl)).toBe(0)
+  })
+
+  it('returns full range when currentTime equals range start', () => {
+    const videoEl = { buffered: makeBuffered([[10, 30]]), currentTime: 10 }
+    expect(getBufferAhead(videoEl)).toBe(20)
+  })
+})
+
+describe('getBufferedRanges', () => {
+  it('returns empty array when buffered is empty', () => {
+    expect(getBufferedRanges(makeBuffered([]))).toEqual([])
+  })
+
+  it('returns one pair for a single range', () => {
+    expect(getBufferedRanges(makeBuffered([[0, 30]]))).toEqual([[0, 30]])
+  })
+
+  it('returns multiple pairs for multiple ranges', () => {
+    expect(getBufferedRanges(makeBuffered([[0, 10], [20, 30]]))).toEqual([[0, 10], [20, 30]])
+  })
+
+  it('rounds values to 2 decimal places', () => {
+    expect(getBufferedRanges(makeBuffered([[1.123456, 29.999999]]))).toEqual([[1.12, 30]])
   })
 })
 

--- a/packages/clappr-telemetry/src/utils/index.js
+++ b/packages/clappr-telemetry/src/utils/index.js
@@ -1,2 +1,10 @@
 export { TELEMETRY_CONTRACT_VERSION, EVENT_TYPES, TELEMETRY_SOURCES } from './constants'
-export { createEnvelope, emitTelemetry, calculateThroughput, sanitizeLicenseUri, hashUrl } from './helpers'
+export {
+  createEnvelope,
+  emitTelemetry,
+  calculateThroughput,
+  sanitizeLicenseUri,
+  hashUrl,
+  getBufferAhead,
+  getBufferedRanges
+} from './helpers'


### PR DESCRIPTION
This MR introduces the second stage of player observability: what is happening in the buffer and the video decoder, in real time,.

### What was added

**Buffer sampling** — on each configured tick, the plugin captures how many seconds of video are available ahead of the current playhead position, the currentTime, and optionally the exact buffered ranges. 

**Decoding sampling** — using the browser's native API, the plugin calculates how many frames were decoded and how many were dropped within each interval. From that it derives the effective FPS and drop ratio.

The decoding sampler payload currently emits the following fields: decodedFps (frames decoded per second in the interval), droppedFps (frames dropped per second in the interval), dropRatio (ratio of dropped frames over the total in the interval), currentTime (current playback position in seconds), totalDecoded (cumulative decoded frames since playback started) and totalDropped (cumulative dropped frames since playback started).

All fields were intentionally included to maximize the diagnostic data available, but some have a processing cost and can be evaluated during this MR review. Fields such as dropRatio, decodedFps and droppedFps can be removed from the payload without loss of information, as they are derivable from the cumulative totals and the envelope timestamps — that derivation can be done by the consumer or by a downstream processing layer.

Both samplers are optional and disabled by default. When active, they share a single timer and emit together in one mse.sample event per tick, without creating the overhead of multiple intervals.

### Extensibility

The sampler system was designed to be open. Any team can register a custom sampler — for audio, DRM, latency — and it will join the same tick and appear in the same event, without touching the plugin's code. The contract requires only three members: isEnabled, collect and destroy.

### On-demand snapshot

In addition to the periodic mode, sampler data is available at any time via telemetry.snapshot — a silent read of the current buffer and decoding state, without emitting an event and without depending on the timer cadence.

This paves the way for a next step: once we integrate Clappr's playback events, the snapshot can be called at the exact moment of each relevant occurrence — a stall, a high join time, a rebuffer, a playback error — and the buffer and decoding data from that instant can be attached to the payload already being sent to the backend, enriching the diagnosis without generating extra traffic.

### What does not change

The plugin's public interface was not changed. Anyone already consuming CONTAINER_TELEMETRY_TRACE continues to work. The new data appears in the envelope only when the samplers are enabled in the configuration.

### Testing

Run the dev server:

yarn workspace @clappr/telemetry dev

Open http://localhost:8080 in the browser. The demo page loads a player with Buffer, Decoding and Network samplers already enabled. Open the browser console — telemetry events are logged to CONTAINER_TELEMETRY_TRACE on the container bus.

To verify the samplers:

Press play and watch the console. mse.sample events should appear at the configured interval, each carrying a buffer and/or decoding key with the current metrics. The Snapshot button triggers an on-demand read and logs the result immediately, outside the interval cadence.

Expected in the console per tick:
- buffer: bufferAhead, currentTime and rangesCompact
- decoding: decodedFps, droppedFps, dropRatio, currentTime, totalDecoded and totalDropped

---
Este MR introduz a segunda etapa da observabilidade do player: o que está acontecendo no buffer e no decodificador de vídeo, em tempo real.

### O que foi adicionado

**Buffer sampling** — a cada tick configurado, o plugin captura quantos segundos de vídeo estão disponíveis à frente da posição atual do playhead, o currentTime, e opcionalmente os intervalos exatos de buffer. 

**Decoding sampling** — usando a API nativa do browser, o plugin calcula quantos frames foram decodificados e quantos foram descartados dentro de cada intervalo. A partir disso deriva o FPS efetivo e o drop ratio.
No payload do decoding sampler são emitidos atualmente os seguintes campos: decodedFps (frames decodificados por segundo no intervalo), droppedFps (frames descartados por segundo no intervalo), dropRatio (proporção de frames descartados sobre o total no intervalo), currentTime (posição atual do playback em segundos), totalDecoded (total acumulado de frames decodificados desde o início) e totalDropped (total acumulado de frames descartados desde o início).

Todos os campos foram incluídos intencionalmente para maximizar o diagnóstico disponível, mas alguns têm custo de processamento e podem ser avaliados durante a revisão deste MR. Campos como dropRatio, decodedFps e droppedFps podem ser removidos do payload sem perda de informação, pois são deriváveis a partir dos totais acumulados e dos timestamps do envelop, essa derivação pode ser feita pelo servidor ou por uma camada de processamento posterior.

Ambos os samplers são opcionais e desativados por padrão. Quando ativos, participam de um timer único e emitem juntos em um único evento mse.sample por tick, sem criar overhead de múltiplos intervalos.

### Extensibilidade

O sistema de samplers foi desenhado para ser aberto. Qualquer equipe pode registrar um sampler próprio — de áudio, de DRM, de latência — e ele passa a participar do mesmo tick e aparecer no mesmo evento, sem precisar tocar no código do plugin. O registro exige apenas três membros: isEnabled, collect e destroy.

### Snapshot on-demand

Além do modo periódico, os dados dos samplers ficam disponíveis a qualquer momento via telemetry.snapshot — uma leitura silenciosa do estado atual de buffer e decoding, sem emitir evento e sem depender da cadência do timer.

Isso abre caminho para uma próxima etapa: ao integrarmos os eventos de playback do Clappr, o snapshot poderá ser chamado no momento exato de cada ocorrência relevante — um stall, um join time alto, um rebuffer, um erro de reprodução — e o dado de buffer e decoding.

### O que não muda

A interface pública do plugin não foi alterada. Quem já consome o CONTAINER_TELEMETRY_TRACE continua funcionando. Os novos dados aparecem no envelope somente quando os samplers estão habilitados na configuração.

### Testando

Inicie o servidor de desenvolvimento:

yarn workspace @clappr/telemetry dev

Abra http://localhost:8080 no navegador. A página de demo carrega o player com os samplers de Buffer, Decoding e Network já habilitados. Abra o console do navegador, os eventos de telemetria são logados no canal CONTAINER_TELEMETRY_TRACE do barramento do container.

Para verificar os samplers:

Dê play e observe o console. Eventos mse.sample devem aparecer no intervalo configurado, cada um com as chaves buffer e/ou decoding contendo as métricas do momento. O botão Snapshot dispara uma leitura sob demanda e loga o resultado imediatamente, fora da cadência do intervalo.

Esperado no console a cada tick:
- buffer: bufferAhead, currentTime e rangesCompact
- decoding: decodedFps, droppedFps, dropRatio, currentTime, totalDecoded e totalDropped