### PR TITLE
feat(telemetry): add video event observer, observer registry and playback state sampler

### DIFF
--- a/packages/clappr-telemetry/CHANGELOG.md
+++ b/packages/clappr-telemetry/CHANGELOG.md
@@ -18,4 +18,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - HLS.js network adapter for telemetry collection
 - HLS.js `request:start` event: emitted when a fragment, manifest, or key request is initiated
 - HLS.js `request:end` event: emitted when a fragment, manifest, or key request completes
-- HLS.js `bitrate:change` event: emitted when the ABR algorithm switches to a different quality variant 
+- HLS.js `bitrate:change` event: emitted when the ABR algorithm switches to a different quality variant
+- `VideoEventObserver` and `ObserverRegistry`: observe native `HTMLVideoElement` events and emit `media.event` traces
+- `BufferSampler`: samples buffer state on each tick
+- `DecodingSampler`: samples decoded/dropped frames on each tick
+- `PlaybackStateSampler`: samples playback state on each tick

--- a/packages/clappr-telemetry/README.md
+++ b/packages/clappr-telemetry/README.md
@@ -2,16 +2,17 @@
 
 [![npm version](https://img.shields.io/badge/npm-v0.1.0-cb3837)](https://www.npmjs.com/package/@clappr/telemetry)
 
-A telemetry plugin for [Clappr](https://github.com/clappr/clappr). Collects network, buffer, and decoding metrics from the player and exposes them through a single unified event on the container bus.
+A telemetry plugin for [Clappr](https://github.com/clappr/clappr). Collects network, buffer, decoding, and playback state metrics from the player and exposes them through a single unified event on the container bus.
 
 ## Overview
 
 `@clappr/telemetry` is a `ContainerPlugin` that automatically detects the active playback engine and activates the appropriate adapter for metrics collection. All telemetry data — regardless of source or event type — flows through the same registered event channel using a versioned envelope format, keeping consumers decoupled from internal implementation details.
 
-The plugin is built around two extensible subsystems:
+The plugin is built around three extensible subsystems:
 
 - **Network adapters** — hook into the streaming engine (Shaka, HLS.js) to capture request timings, bitrate changes, and DRM events
-- **Sampler registry** — drives a set of periodic samplers from a single timer, emitting one `mse.sample` event per tick with buffer and decoding data grouped under their respective keys
+- **Sampler registry** — drives a set of periodic samplers from a single timer, emitting one `mse.sample` event per tick with data grouped by key (`buffer`, `decoding`, `playbackState`)
+- **Observer registry** — manages active observers and fires lifecycle calls on each; extensible via `ObserverRegistry.register()` so custom observers can be added without forking the package
 
 ## Installation
 
@@ -39,9 +40,12 @@ Via CDN (jsDelivr):
     source: 'https://example.com/stream.mpd',
     plugins: [DashShakaPlayback, ClapprTelemetry],
     telemetry: {
-      network:        { enabled: true },
-      bufferSample:   { enabled: true },
-      decodingSample: { enabled: true }
+      network:             { enabled: true },
+      bufferSample:        { enabled: true },
+      decodingSample:      { enabled: true },
+      playbackStateSample: { enabled: true },
+      sampleIntervalMs:    1000,
+      videoState:          { enabled: true }
     }
   })
 </script>
@@ -59,9 +63,12 @@ const player = new Clappr.Player({
   source: 'https://example.com/stream.mpd',
   plugins: [DashShakaPlayback, ClapprTelemetry],
   telemetry: {
-    network:        { enabled: true },
-    bufferSample:   { enabled: true },
-    decodingSample: { enabled: true }
+    network:             { enabled: true },
+    bufferSample:        { enabled: true },
+    decodingSample:      { enabled: true },
+    playbackStateSample: { enabled: true },
+    sampleIntervalMs:    1000,
+    videoState:          { enabled: true }
   }
 })
 ```
@@ -80,11 +87,19 @@ Available from `dist/clappr-telemetry.esm.js`:
 
 **Samplers**
 
-| Export              | Description                                              |
-| ------------------- | -------------------------------------------------------- |
-| `SamplerRegistry`  | Registry class — use to register custom samplers         |
-| `BufferSampler`     | Built-in buffer state sampler                            |
-| `DecodingSampler`   | Built-in decoding quality sampler                        |
+| Export                | Description                                                      |
+| --------------------- | ---------------------------------------------------------------- |
+| `SamplerRegistry`     | Registry class — use to register custom samplers                 |
+| `BufferSampler`       | Built-in buffer state sampler                                    |
+| `DecodingSampler`     | Built-in decoding quality sampler                                |
+| `PlaybackStateSampler`| Built-in sampler for `networkState`, `paused` and `playbackRate` |
+
+**Observers**
+
+| Export               | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
+| `ObserverRegistry`   | Registry class — use to register custom observers               |
+| `VideoEventObserver` | Built-in observer for native `<video>` DOM events               |
 
 **Utils**
 
@@ -98,6 +113,7 @@ Available from `dist/clappr-telemetry.esm.js`:
 | `calculateThroughput`        | Mbps helper used by network adapters                             |
 | `getBufferAhead`             | Returns seconds buffered ahead of the current position           |
 | `getBufferedRanges`          | Converts `TimeRanges` to a compact `[[start, end], ...]` array   |
+| `DEFAULT_VIDEO_EVENTS`       | Array with the 14 default `HTMLVideoElement` event names observed |
 
 The UMD build (`dist/clappr-telemetry.js` / CDN) exposes **only** the plugin as the global `ClapprTelemetry`. Use the ESM file if you need named exports.
 
@@ -105,13 +121,16 @@ The UMD build (`dist/clappr-telemetry.js` / CDN) exposes **only** the plugin as 
 
 All options are opt-in — nothing is collected by default.
 
-| Option                                 | Type    | Default | Description                                               |
-| -------------------------------------- | ------- | ------- | --------------------------------------------------------- |
-| `telemetry.network.enabled`            | Boolean | `false` | Enables network request telemetry                         |
-| `telemetry.bufferSample.enabled`       | Boolean | `false` | Enables periodic buffer state sampling                    |
-| `telemetry.bufferSample.includeRanges` | Boolean | `true`  | Includes buffered time ranges in the `mse.sample` payload |
-| `telemetry.decodingSample.enabled`     | Boolean | `false` | Enables periodic decoding quality sampling                |
-| `telemetry.sampleIntervalMs`           | Number  | `0`     | Sampling frequency in ms. When `0` (default), no automatic interval is started and only on-demand snapshots via `snapshot()` are available |
+| Option                                   | Type     | Default   | Description                                                                                                                                |
+| ---------------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `telemetry.network.enabled`              | Boolean  | `false`   | Enables network request telemetry                                                                                                          |
+| `telemetry.bufferSample.enabled`         | Boolean  | `false`   | Enables periodic buffer state sampling                                                                                                     |
+| `telemetry.bufferSample.includeRanges`   | Boolean  | `true`    | Includes buffered time ranges in the `mse.sample` payload                                                                                  |
+| `telemetry.decodingSample.enabled`       | Boolean  | `false`   | Enables periodic decoding quality sampling                                                                                                 |
+| `telemetry.playbackStateSample.enabled`  | Boolean  | `false`   | Enables periodic `networkState`, `paused` and `playbackRate` sampling                                                                      |
+| `telemetry.sampleIntervalMs`             | Number   | `0`       | Sampling frequency in ms. When `0` (default), no automatic interval is started and only on-demand snapshots via `snapshot()` are available |
+| `telemetry.videoState.enabled`           | Boolean  | `false`   | Enables the `VideoEventObserver`                                                                                                           |
+| `telemetry.videoState.videoEvents`       | String[] | see below | List of `HTMLVideoElement` event names to observe. Defaults to the full set (see **VideoEventObserver**)                                   |
 
 ## Consuming telemetry events
 
@@ -119,13 +138,8 @@ All telemetry data is emitted on a single event registered by the plugin: `Clapp
 
 ```javascript
 class MyTelemetryConsumer extends Clappr.ContainerPlugin {
-  get name() {
-    return 'my_telemetry_consumer'
-  }
-
-  get supportedVersion() {
-    return { min: '0.13.1' }
-  }
+  get name() { return 'my_telemetry_consumer' }
+  get supportedVersion() { return { min: '0.13.1' } }
 
   bindEvents() {
     this.listenTo(this.container, Clappr.Events.Custom.CONTAINER_TELEMETRY_TRACE, this.onTrace)
@@ -133,8 +147,10 @@ class MyTelemetryConsumer extends Clappr.ContainerPlugin {
 
   onTrace(envelope) {
     if (envelope.type === 'mse.sample') {
-      const { buffer, decoding } = envelope.data
-      // buffer and decoding keys are only present when the respective sampler is enabled
+      const { buffer, decoding, playbackState } = envelope.data
+    }
+    if (envelope.type === 'media.event') {
+      const { name, currentTime, readyState, snapshot } = envelope.data
     }
   }
 }
@@ -176,23 +192,24 @@ Adapters connect the plugin to specific playback engines. Each adapter implement
 
 ### Sources (`source`)
 
-| `source`            | Area                                                    |
-| ------------------- | ------------------------------------------------------- |
-| `network`           | Network request metrics (segments, manifests, licenses) |
-| `sampler-registry` | Periodic MSE metrics (buffer state, decoding quality)   |
-
+| `source`               | Area                                                              |
+| ---------------------- | ----------------------------------------------------------------- |
+| `network`              | Network request metrics (segments, manifests, licenses)           |
+| `sampler-registry`     | Periodic MSE metrics (buffer, decoding, playback state)           |
+| `video-event-observer` | Native `<video>` DOM events                                       |
 
 ### Event types (`type`)
 
-| `type`                   | `source`            | Description                                           |
-| ------------------------ | ------------------- | ----------------------------------------------------- |
-| `request:start`          | `network`           | A network request was initiated                       |
-| `request:end`            | `network`           | A network request completed                           |
-| `request:error`          | `network`           | A network request failed                              |
-| `bitrate:change`         | `network`           | ABR algorithm switched to a different quality variant |
-| `drm:session:update`     | `network`           | A DRM session was updated                             |
-| `drm:expiration:updated` | `network`           | A DRM license expiration time was updated             |
-| `mse.sample`             | `sampler-registry` | Periodic snapshot of buffer and/or decoding state     |
+| `type`                   | `source`               | Description                                           |
+| ------------------------ | ---------------------- | ----------------------------------------------------- |
+| `request:start`          | `network`              | A network request was initiated                       |
+| `request:end`            | `network`              | A network request completed                           |
+| `request:error`          | `network`              | A network request failed                              |
+| `bitrate:change`         | `network`              | ABR algorithm switched to a different quality variant |
+| `drm:session:update`     | `network`              | A DRM session was updated                             |
+| `drm:expiration:updated` | `network`              | A DRM license expiration time was updated             |
+| `mse.sample`             | `sampler-registry`     | Periodic snapshot of buffer, decoding and/or playback state |
+| `media.event`            | `video-event-observer` | A native `HTMLVideoElement` DOM event fired           |
 
 ### `mse.sample` payload
 
@@ -212,8 +229,51 @@ Emitted once per tick by the `SamplerRegistry`. Each key is only present when th
     currentTime:   10,       // current playback position in seconds
     totalDropped:   2,       // cumulative dropped frames since playback started
     totalDecoded: 537        // cumulative decoded frames since playback started
+  },
+  playbackState: {
+    networkState:  2,        // HTMLVideoElement.networkState (0–3)
+    paused:        false,    // whether the player is paused
+    playbackRate:  1,        // current playback rate
+    currentTime:   10        // current playback position in seconds
   }
 }
+```
+
+## VideoEventObserver
+
+The `VideoEventObserver` watches the native `HTMLVideoElement` and is engine-agnostic — it works identically with Shaka, HLS.js, or any other playback engine.
+
+It emits `media.event` whenever one of the observed DOM events fires on the `<video>` element:
+
+```javascript
+{
+  name:        'waiting',   // the DOM event name
+  currentTime: 10.4,        // position at the moment of the event
+  readyState:  2,           // HTMLVideoElement.readyState
+  snapshot:    {            // current sampler data at the moment of the event
+    buffer:        { bufferAhead: 0.2, currentTime: 10.4 },
+    decoding:      { decodedFps: 24, droppedFps: 0, ... },
+    playbackState: { networkState: 2, paused: false, playbackRate: 1, currentTime: 10.4 }
+  }
+}
+```
+
+`snapshot` reflects the last sampler tick. Keys are only present when the respective sampler is enabled. If no sampler is active, `snapshot` is `{}`.
+
+Default observed events: `waiting`, `playing`, `stalled`, `seeking`, `seeked`, `ended`, `canplay`, `canplaythrough`, `loadedmetadata`, `loadeddata`, `error`, `emptied`, `suspend`, `abort`.
+
+### Configuration
+
+```javascript
+new Clappr.Player({
+  plugins: [ClapprTelemetry],
+  telemetry: {
+    videoState: {
+      enabled:     true,                           // default: false
+      videoEvents: ['waiting', 'stalled', 'error'] // default: full list above
+    }
+  }
+})
 ```
 
 ## Custom samplers
@@ -233,11 +293,7 @@ A custom sampler must implement three members:
 ### Example
 
 ```javascript
-import {
-  SamplerRegistry,
-  emitTelemetry,
-  getBufferAhead
-} from '@clappr/telemetry'
+import { SamplerRegistry } from '@clappr/telemetry'
 
 class AudioSampler {
   static isEnabled(cfg) {
@@ -265,6 +321,7 @@ SamplerRegistry.register('audio', AudioSampler)
 new Clappr.Player({
   plugins: [ClapprTelemetry],
   telemetry: {
+    sampleIntervalMs: 1000,
     audioSample: { enabled: true }
   }
 })
@@ -274,9 +331,10 @@ The result appears under the `audio` key in the `mse.sample` payload:
 
 ```javascript
 {
-  buffer:  { ... },
-  decoding:{ ... },
-  audio:   { volume: 1, muted: false }
+  buffer:        { ... },
+  decoding:      { ... },
+  playbackState: { ... },
+  audio:         { volume: 1, muted: false }
 }
 ```
 
@@ -293,12 +351,59 @@ The `TelemetryPlugin` exposes a `snapshot` getter that returns the current sampl
 ```javascript
 const telemetry = player.getPlugin('telemetry')
 const data = telemetry.snapshot
-// { buffer: { bufferAhead: 20, currentTime: 10 }, decoding: { ... } }
+// { buffer: { bufferAhead: 20, currentTime: 10 }, decoding: { ... }, playbackState: { ... } }
 ```
 
 Returns an empty object if called before the player is ready.
 
 
+## Custom observers
+
+The observer registry is extensible. You can add your own observer and have it managed alongside the built-in ones.
+
+### Contract
+
+A custom observer must implement two members:
+
+| Member      | Description                                                                 |
+| ----------- | --------------------------------------------------------------------------- |
+| `bind()`    | Called after instantiation. Attach event listeners and start collecting     |
+| `destroy()` | Called when the registry is destroyed. Remove listeners and clean up state  |
+
+The constructor receives `(playback, container, samplerRegistry)` — the same arguments as `VideoEventObserver`.
+
+### Example
+
+```javascript
+import { ObserverRegistry } from '@clappr/telemetry'
+
+class PlaybackEventObserver {
+  constructor(playback, container, samplerRegistry) {
+    this._container = container
+    this._samplerRegistry = samplerRegistry
+  }
+
+  bind() {
+    this._container.on('playback:play', () => {
+      console.log('play', this._samplerRegistry?.snapshot())
+    })
+  }
+
+  destroy() {
+    this._container = null
+    this._samplerRegistry = null
+  }
+}
+
+// register before instantiating the player
+ObserverRegistry.register('playbackEvents', PlaybackEventObserver)
+```
+
+To remove a previously registered observer:
+
+```javascript
+ObserverRegistry.unregister('playbackEvents')
+```
 
 ## Development
 

--- a/packages/clappr-telemetry/public/index.html
+++ b/packages/clappr-telemetry/public/index.html
@@ -212,14 +212,20 @@
 
     <div class="controls">
       <label>Adapter:</label>
-      <label class="toggle-label"><input type="checkbox" id="chk-network" checked> Network</label>
+      <label class="toggle-label"><input type="checkbox" id="chk-network"> Network</label>
     </div>
 
     <div class="controls">
       <label>Sampler:</label>
-      <label class="toggle-label"><input type="checkbox" id="chk-buffer" checked> Buffer</label>
-      <label class="toggle-label"><input type="checkbox" id="chk-decoding" checked> Decoding</label>
+      <label class="toggle-label"><input type="checkbox" id="chk-buffer"> Buffer</label>
+      <label class="toggle-label"><input type="checkbox" id="chk-decoding"> Decoding</label>
+      <label class="toggle-label"><input type="checkbox" id="chk-playback-state"> Playback State</label>
       <label class="toggle-label"><input type="checkbox" id="chk-audio"> Audio (custom)</label>
+    </div>
+
+    <div class="controls">
+      <label>Observer:</label>
+      <label class="toggle-label"><input type="checkbox" id="chk-video-state"> Video State</label>
       <label for="sample-interval" style="margin-left: 10px">Interval:</label>
       <select id="sample-interval" onchange="app.build()">
         <option value="0" selected>snapshot only</option>
@@ -275,11 +281,9 @@
       }
 
       bindEvents() {
-        this.listenTo(
-          this.container,
-          TELEMETRY_TRACE_EVENT,
-          (envelope) => console.log('[TELEMETRY]', envelope)
-        )
+        this.listenTo(this.container, TELEMETRY_TRACE_EVENT, (envelope) => {
+          console.log('[TELEMETRY]', envelope)
+        })
       }
     }
 
@@ -333,10 +337,12 @@
       static getTelemetryConfig() {
         return {
           network:          { enabled: document.getElementById('chk-network').checked },
-          bufferSample:     { enabled: document.getElementById('chk-buffer').checked },
-          decodingSample:   { enabled: document.getElementById('chk-decoding').checked },
-          audioSample:      { enabled: document.getElementById('chk-audio').checked },
+          bufferSample:        { enabled: document.getElementById('chk-buffer').checked },
+          decodingSample:      { enabled: document.getElementById('chk-decoding').checked },
+          playbackStateSample: { enabled: document.getElementById('chk-playback-state').checked },
+          audioSample:         { enabled: document.getElementById('chk-audio').checked },
           sampleIntervalMs: Number(document.getElementById('sample-interval').value),
+          videoState:       { enabled: document.getElementById('chk-video-state').checked },
         }
       }
 
@@ -440,7 +446,7 @@
       console.log('[SNAPSHOT]', telemetry.snapshot)
     }
 
-    ;['chk-network', 'chk-buffer', 'chk-decoding', 'chk-audio'].forEach(id => {
+    ;['chk-network', 'chk-buffer', 'chk-decoding', 'chk-playback-state', 'chk-audio', 'chk-video-state'].forEach(id => {
       document.getElementById(id).addEventListener('change', () => app.build())
     })
   </script>

--- a/packages/clappr-telemetry/src/main.js
+++ b/packages/clappr-telemetry/src/main.js
@@ -1,11 +1,13 @@
 import TelemetryPlugin from './telemetry_plugin'
 
 export { findNetworkAdapter, ShakaNetworkAdapter, HlsNetworkAdapter } from './adapters'
-export { SamplerRegistry, BufferSampler, DecodingSampler } from './samplers'
+export { SamplerRegistry, BufferSampler, DecodingSampler, PlaybackStateSampler } from './samplers'
+export { ObserverRegistry, VideoEventObserver } from './observers'
 export {
   TELEMETRY_CONTRACT_VERSION,
   EVENT_TYPES,
   TELEMETRY_SOURCES,
+  DEFAULT_VIDEO_EVENTS,
   createEnvelope,
   emitTelemetry,
   calculateThroughput,

--- a/packages/clappr-telemetry/src/observers/index.js
+++ b/packages/clappr-telemetry/src/observers/index.js
@@ -1,0 +1,2 @@
+export { default as VideoEventObserver } from './video_event_observer'
+export { default as ObserverRegistry } from './observer_registry'

--- a/packages/clappr-telemetry/src/observers/observer_registry.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.js
@@ -1,0 +1,62 @@
+import { Log } from '@clappr/core'
+import VideoEventObserver from './video_event_observer'
+
+const _registry = new Map([
+  ['videoState', VideoEventObserver]
+])
+
+/**
+ * Manages all active observers, instantiating and delegating lifecycle calls to each.
+ *
+ * Extensible via `ObserverRegistry.register()` — external observers can be added
+ * before the player is instantiated.
+ *
+ * Observer contract: must implement `bind()` and `destroy()` on the prototype.
+ */
+export default class ObserverRegistry {
+  static get name() { return 'observer-registry' }
+
+  /**
+   * Registers an external observer class into the global registry.
+   * Must be called before the player is instantiated.
+   *
+   * @param {string} key - Identifier for the observer (e.g. `'customEvents'`)
+   * @param {Function} ObserverClass - Class implementing `bind()` and `destroy()`
+   */
+  static register(key, ObserverClass) {
+    const proto = ObserverClass.prototype
+    const missing = [
+      typeof proto.bind !== 'function' && 'bind()',
+      typeof proto.destroy !== 'function' && 'destroy()'
+    ].filter(Boolean)
+
+    if (missing.length > 0) {
+      Log.warn('[ObserverRegistry]', `${key}: missing ${missing.join(', ')} — skipping`)
+      return
+    }
+    _registry.set(key, ObserverClass)
+  }
+
+  /**
+   * Removes a previously registered observer from the global registry.
+   *
+   * @param {string} key - The key used when registering the observer
+   */
+  static unregister(key) {
+    _registry.delete(key)
+  }
+
+  constructor(playback, container, samplerRegistry) {
+    this._observers = [..._registry.values()]
+      .map(ObserverClass => new ObserverClass(playback, container, samplerRegistry))
+  }
+
+  bind() {
+    this._observers.forEach(o => o.bind())
+  }
+
+  destroy() {
+    this._observers.forEach(o => o.destroy())
+    this._observers = []
+  }
+}

--- a/packages/clappr-telemetry/src/observers/observer_registry.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.js
@@ -11,7 +11,7 @@ const _registry = new Map([
  * Extensible via `ObserverRegistry.register()` — external observers can be added
  * before the player is instantiated.
  *
- * Observer contract: must implement `bind()` and `destroy()` on the prototype.
+ * Observer contract: must implement `static isEnabled(cfg)`, `bind()` and `destroy()` on the prototype.
  */
 export default class ObserverRegistry {
   static get name() { return 'observer-registry' }
@@ -21,11 +21,12 @@ export default class ObserverRegistry {
    * Must be called before the player is instantiated.
    *
    * @param {string} key - Identifier for the observer (e.g. `'customEvents'`)
-   * @param {Function} ObserverClass - Class implementing `bind()` and `destroy()`
+   * @param {Function} ObserverClass - Class implementing `static isEnabled()`, `bind()` and `destroy()`
    */
   static register(key, ObserverClass) {
     const proto = ObserverClass.prototype
     const missing = [
+      typeof ObserverClass.isEnabled !== 'function' && 'static isEnabled()',
       typeof proto.bind !== 'function' && 'bind()',
       typeof proto.destroy !== 'function' && 'destroy()'
     ].filter(Boolean)
@@ -47,8 +48,10 @@ export default class ObserverRegistry {
   }
 
   constructor(playback, container, samplerRegistry) {
-    this._observers = [..._registry.values()]
-      .map(ObserverClass => new ObserverClass(playback, container, samplerRegistry))
+    const cfg = container.options?.telemetry || {}
+    this._observers = [..._registry.entries()]
+      .filter(([, O]) => O.isEnabled(cfg))
+      .map(([, ObserverClass]) => new ObserverClass(playback, container, samplerRegistry))
   }
 
   bind() {

--- a/packages/clappr-telemetry/src/observers/observer_registry.test.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.test.js
@@ -1,0 +1,105 @@
+import ObserverRegistry from './observer_registry'
+import VideoEventObserver from './video_event_observer'
+import { Log } from '@clappr/core'
+
+jest.mock('./video_event_observer', () => {
+  const mock = jest.fn()
+  return { __esModule: true, default: mock }
+})
+
+const makeContainer = (cfg = {}) => ({
+  options: { telemetry: { ...cfg } },
+  trigger: jest.fn()
+})
+
+describe('ObserverRegistry', () => {
+  let mockVideoObserverInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockVideoObserverInstance = { bind: jest.fn(), destroy: jest.fn() }
+    VideoEventObserver.mockImplementation(() => mockVideoObserverInstance)
+  })
+
+  describe('bind()', () => {
+    it('calls bind() on all registered observers', () => {
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      registry.bind()
+      expect(mockVideoObserverInstance.bind).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('destroy()', () => {
+    it('calls destroy() on all observers', () => {
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      registry.destroy()
+      expect(mockVideoObserverInstance.destroy).toHaveBeenCalledTimes(1)
+    })
+
+    it('is safe to call multiple times', () => {
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      expect(() => {
+        registry.destroy()
+        registry.destroy()
+      }).not.toThrow()
+    })
+
+    it('is safe to call without bind', () => {
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      expect(() => registry.destroy()).not.toThrow()
+    })
+  })
+
+  describe('register()', () => {
+    afterEach(() => {
+      ObserverRegistry.unregister('custom')
+    })
+
+    it('skips registration and warns when ObserverClass is missing required methods', () => {
+      const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {})
+      ObserverRegistry.register('custom', class {})
+      expect(warnSpy).toHaveBeenCalled()
+    })
+
+    it('includes a registered external observer and calls bind() on it', () => {
+      const customInstance = { bind: jest.fn(), destroy: jest.fn() }
+      const CustomObserver = jest.fn(() => customInstance)
+      CustomObserver.prototype.bind = jest.fn()
+      CustomObserver.prototype.destroy = jest.fn()
+
+      ObserverRegistry.register('custom', CustomObserver)
+
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      registry.bind()
+
+      expect(customInstance.bind).toHaveBeenCalledTimes(1)
+    })
+
+    it('passes samplerRegistry to each observer constructor', () => {
+      const fakeSamplerRegistry = { snapshot: jest.fn() }
+      const registry = new ObserverRegistry({}, makeContainer(), fakeSamplerRegistry)
+      registry.destroy()
+      expect(VideoEventObserver).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        fakeSamplerRegistry
+      )
+    })
+  })
+
+  describe('unregister()', () => {
+    it('removes a previously registered observer', () => {
+      const customInstance = { bind: jest.fn(), destroy: jest.fn() }
+      const CustomObserver = jest.fn(() => customInstance)
+      CustomObserver.prototype.bind = jest.fn()
+      CustomObserver.prototype.destroy = jest.fn()
+
+      ObserverRegistry.register('custom', CustomObserver)
+      ObserverRegistry.unregister('custom')
+
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      registry.destroy()
+      expect(CustomObserver).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/clappr-telemetry/src/observers/observer_registry.test.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.test.js
@@ -4,6 +4,7 @@ import { Log } from '@clappr/core'
 
 jest.mock('./video_event_observer', () => {
   const mock = jest.fn()
+  mock.isEnabled = jest.fn(() => true)
   return { __esModule: true, default: mock }
 })
 
@@ -61,9 +62,21 @@ describe('ObserverRegistry', () => {
       expect(warnSpy).toHaveBeenCalled()
     })
 
+    it('skips registration and warns when static isEnabled() is missing', () => {
+      const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {})
+      const CustomObserver = jest.fn()
+      CustomObserver.prototype.bind = jest.fn()
+      CustomObserver.prototype.destroy = jest.fn()
+
+      ObserverRegistry.register('custom', CustomObserver)
+      expect(warnSpy).toHaveBeenCalled()
+      expect(warnSpy.mock.calls[0].join(' ')).toContain('static isEnabled()')
+    })
+
     it('includes a registered external observer and calls bind() on it', () => {
       const customInstance = { bind: jest.fn(), destroy: jest.fn() }
       const CustomObserver = jest.fn(() => customInstance)
+      CustomObserver.isEnabled = jest.fn(() => true)
       CustomObserver.prototype.bind = jest.fn()
       CustomObserver.prototype.destroy = jest.fn()
 
@@ -87,10 +100,48 @@ describe('ObserverRegistry', () => {
     })
   })
 
+  describe('observer filtering via isEnabled()', () => {
+    afterEach(() => {
+      ObserverRegistry.unregister('custom')
+    })
+
+    it('excludes observers whose isEnabled returns false', () => {
+      VideoEventObserver.isEnabled.mockReturnValue(false)
+
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      registry.destroy()
+      expect(VideoEventObserver).not.toHaveBeenCalled()
+      VideoEventObserver.isEnabled.mockReturnValue(true)
+    })
+
+    it('includes observers whose isEnabled returns true', () => {
+      VideoEventObserver.isEnabled.mockReturnValue(true)
+
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      registry.bind()
+      expect(VideoEventObserver).toHaveBeenCalled()
+    })
+
+    it('excludes a registered external observer when isEnabled returns false', () => {
+      const customInstance = { bind: jest.fn(), destroy: jest.fn() }
+      const CustomObserver = jest.fn(() => customInstance)
+      CustomObserver.isEnabled = jest.fn(() => false)
+      CustomObserver.prototype.bind = jest.fn()
+      CustomObserver.prototype.destroy = jest.fn()
+
+      ObserverRegistry.register('custom', CustomObserver)
+
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      registry.bind()
+      expect(CustomObserver).not.toHaveBeenCalled()
+    })
+  })
+
   describe('unregister()', () => {
     it('removes a previously registered observer', () => {
       const customInstance = { bind: jest.fn(), destroy: jest.fn() }
       const CustomObserver = jest.fn(() => customInstance)
+      CustomObserver.isEnabled = jest.fn(() => true)
       CustomObserver.prototype.bind = jest.fn()
       CustomObserver.prototype.destroy = jest.fn()
 

--- a/packages/clappr-telemetry/src/observers/video_event_observer.js
+++ b/packages/clappr-telemetry/src/observers/video_event_observer.js
@@ -1,0 +1,75 @@
+import { emitTelemetry } from '../utils'
+import { EVENT_TYPES, TELEMETRY_SOURCES, DEFAULT_VIDEO_EVENTS } from '../utils/constants'
+
+/**
+ * Listens to native `HTMLVideoElement` DOM events and emits a `media.event` telemetry trace
+ * for each one. Engine-agnostic: works with Shaka, HLS.js or any other playback backend.
+ *
+ * Each event carries `{ name, currentTime, readyState, snapshot }`, where `snapshot` reflects
+ * the last sampler tick (empty object when no sampler is active).
+ *
+ * Enable via `telemetry.videoState.enabled: true`. Observed events default to
+ * `DEFAULT_VIDEO_EVENTS` and can be narrowed with `telemetry.videoState.videoEvents`.
+ */
+export default class VideoEventObserver {
+  constructor(playback, container, samplerRegistry = null) {
+    this._playback = playback
+    this._container = container
+    this._samplerRegistry = samplerRegistry
+
+    const opts = container.options?.telemetry?.videoState || {}
+    this._enabled = opts.enabled === true
+    this._videoEvents = [...new Set(opts.videoEvents || DEFAULT_VIDEO_EVENTS)]
+
+    this._eventHandlers = new Map()
+  }
+
+  bind() {
+    if (!this._enabled || this._eventHandlers.size > 0) return
+    this._attachVideoListeners()
+  }
+
+  _getVideoElement() {
+    return this._playback?.el
+  }
+
+  _attachVideoListeners() {
+    const videoEl = this._getVideoElement()
+    if (!videoEl) return
+
+    this._videoEvents.forEach((eventName) => {
+      const handler = () => this._onVideoEvent(eventName)
+      this._eventHandlers.set(eventName, handler)
+      videoEl.addEventListener(eventName, handler, { passive: true })
+    })
+  }
+
+  _detachVideoListeners() {
+    const videoEl = this._getVideoElement()
+    if (videoEl) {
+      this._eventHandlers.forEach((handler, eventName) => {
+        videoEl.removeEventListener(eventName, handler)
+      })
+    }
+    this._eventHandlers.clear()
+  }
+
+  _onVideoEvent(eventName) {
+    const videoEl = this._getVideoElement()
+    if (!videoEl) return
+
+    emitTelemetry(this._container, EVENT_TYPES.MEDIA_EVENT, {
+      name: eventName,
+      currentTime: videoEl.currentTime,
+      readyState: videoEl.readyState,
+      snapshot: this._samplerRegistry?.snapshot() ?? {}
+    }, TELEMETRY_SOURCES.VIDEO_EVENT_OBSERVER)
+  }
+
+  destroy() {
+    this._detachVideoListeners()
+    this._playback = null
+    this._container = null
+    this._samplerRegistry = null
+  }
+}

--- a/packages/clappr-telemetry/src/observers/video_event_observer.js
+++ b/packages/clappr-telemetry/src/observers/video_event_observer.js
@@ -12,20 +12,23 @@ import { EVENT_TYPES, TELEMETRY_SOURCES, DEFAULT_VIDEO_EVENTS } from '../utils/c
  * `DEFAULT_VIDEO_EVENTS` and can be narrowed with `telemetry.videoState.videoEvents`.
  */
 export default class VideoEventObserver {
+  static isEnabled(cfg) {
+    return cfg?.videoState?.enabled === true
+  }
+
   constructor(playback, container, samplerRegistry = null) {
     this._playback = playback
     this._container = container
     this._samplerRegistry = samplerRegistry
 
     const opts = container.options?.telemetry?.videoState || {}
-    this._enabled = opts.enabled === true
     this._videoEvents = [...new Set(opts.videoEvents || DEFAULT_VIDEO_EVENTS)]
 
     this._eventHandlers = new Map()
   }
 
   bind() {
-    if (!this._enabled || this._eventHandlers.size > 0) return
+    if (this._eventHandlers.size > 0) return
     this._attachVideoListeners()
   }
 

--- a/packages/clappr-telemetry/src/observers/video_event_observer.test.js
+++ b/packages/clappr-telemetry/src/observers/video_event_observer.test.js
@@ -1,0 +1,166 @@
+import VideoEventObserver from './video_event_observer'
+import { emitTelemetry } from '../utils'
+import { EVENT_TYPES, TELEMETRY_SOURCES, DEFAULT_VIDEO_EVENTS } from '../utils/constants'
+
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  emitTelemetry: jest.fn()
+}))
+
+const makeVideoEl = (overrides = {}) => ({
+  currentTime: 10,
+  readyState: 4,
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  ...overrides
+})
+
+const makePlayback = (videoEl) => ({ el: videoEl })
+
+const makeContainer = (cfg = {}) => ({
+  options: { telemetry: { videoState: cfg } },
+  trigger: jest.fn()
+})
+
+describe('VideoEventObserver', () => {
+  let observer, container, playback, videoEl
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    videoEl = makeVideoEl()
+    playback = makePlayback(videoEl)
+    container = makeContainer({ enabled: true })
+    observer = new VideoEventObserver(playback, container)
+  })
+
+  describe('constructor', () => {
+    it('is disabled by default when enabled is not set', () => {
+      const o = new VideoEventObserver(playback, makeContainer())
+      expect(o._enabled).toBe(false)
+    })
+
+    it('reads enabled: true from options', () => {
+      const o = new VideoEventObserver(playback, makeContainer({ enabled: true }))
+      expect(o._enabled).toBe(true)
+    })
+
+    it('reads enabled: false from options', () => {
+      const o = new VideoEventObserver(playback, makeContainer({ enabled: false }))
+      expect(o._enabled).toBe(false)
+    })
+
+    it('uses DEFAULT_VIDEO_EVENTS when not configured', () => {
+      expect(observer._videoEvents).toEqual(DEFAULT_VIDEO_EVENTS)
+    })
+
+    it('reads custom videoEvents list', () => {
+      const o = new VideoEventObserver(playback, makeContainer({ videoEvents: ['waiting', 'error'] }))
+      expect(o._videoEvents).toEqual(['waiting', 'error'])
+    })
+  })
+
+  describe('bind()', () => {
+    it('attaches one listener per configured event', () => {
+      observer.bind()
+      expect(videoEl.addEventListener).toHaveBeenCalledTimes(observer._videoEvents.length)
+    })
+
+    it('does nothing when disabled', () => {
+      const o = new VideoEventObserver(playback, makeContainer({ enabled: false }))
+      o.bind()
+      expect(videoEl.addEventListener).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when videoEl is null', () => {
+      const o = new VideoEventObserver({ el: null }, container)
+      expect(() => o.bind()).not.toThrow()
+      expect(emitTelemetry).not.toHaveBeenCalled()
+    })
+
+    it('does not attach duplicate listeners when called twice', () => {
+      observer.bind()
+      observer.bind()
+      expect(videoEl.addEventListener).toHaveBeenCalledTimes(observer._videoEvents.length)
+    })
+  })
+
+  describe('_onVideoEvent()', () => {
+    it('emits MEDIA_EVENT with event name, currentTime, readyState and snapshot', () => {
+      observer.bind()
+      const handler = videoEl.addEventListener.mock.calls.find(([name]) => name === 'waiting')?.[1]
+      handler?.()
+      expect(emitTelemetry).toHaveBeenCalledWith(
+        container,
+        EVENT_TYPES.MEDIA_EVENT,
+        { name: 'waiting', currentTime: 10, readyState: 4, snapshot: {} },
+        TELEMETRY_SOURCES.VIDEO_EVENT_OBSERVER
+      )
+    })
+
+    it('includes snapshot from samplerRegistry when provided', () => {
+      const snapshotData = { buffer: { bufferAhead: 5 } }
+      const mockSamplerRegistry = { snapshot: jest.fn(() => snapshotData) }
+      const o = new VideoEventObserver(playback, container, mockSamplerRegistry)
+      o.bind()
+      const handler = videoEl.addEventListener.mock.calls.find(([name]) => name === 'waiting')?.[1]
+      handler?.()
+      expect(emitTelemetry).toHaveBeenCalledWith(
+        container,
+        EVENT_TYPES.MEDIA_EVENT,
+        expect.objectContaining({ snapshot: snapshotData }),
+        TELEMETRY_SOURCES.VIDEO_EVENT_OBSERVER
+      )
+    })
+
+    it('uses empty object as snapshot when samplerRegistry is null', () => {
+      const o = new VideoEventObserver(playback, container, null)
+      o.bind()
+      const handler = videoEl.addEventListener.mock.calls.find(([name]) => name === 'waiting')?.[1]
+      handler?.()
+      expect(emitTelemetry).toHaveBeenCalledWith(
+        container,
+        EVENT_TYPES.MEDIA_EVENT,
+        expect.objectContaining({ snapshot: {} }),
+        TELEMETRY_SOURCES.VIDEO_EVENT_OBSERVER
+      )
+    })
+
+    it('does nothing when videoEl is null', () => {
+      const o = new VideoEventObserver({ el: null }, container)
+      o._onVideoEvent('waiting')
+      expect(emitTelemetry).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('destroy()', () => {
+    it('removes all attached event listeners', () => {
+      observer.bind()
+      observer.destroy()
+      expect(videoEl.removeEventListener).toHaveBeenCalledTimes(observer._videoEvents.length)
+    })
+
+    it('clears event handlers map even when videoEl is null', () => {
+      observer._eventHandlers.set('waiting', jest.fn())
+      observer._playback = { el: null }
+      expect(() => observer.destroy()).not.toThrow()
+      expect(observer._eventHandlers.size).toBe(0)
+    })
+
+    it('is safe to call multiple times', () => {
+      observer.bind()
+      expect(() => {
+        observer.destroy()
+        observer.destroy()
+      }).not.toThrow()
+    })
+
+    it('nulls playback, container and samplerRegistry references', () => {
+      const mockSamplerRegistry = { snapshot: jest.fn() }
+      const o = new VideoEventObserver(playback, container, mockSamplerRegistry)
+      o.destroy()
+      expect(o._playback).toBeNull()
+      expect(o._container).toBeNull()
+      expect(o._samplerRegistry).toBeNull()
+    })
+  })
+})

--- a/packages/clappr-telemetry/src/observers/video_event_observer.test.js
+++ b/packages/clappr-telemetry/src/observers/video_event_observer.test.js
@@ -33,22 +33,25 @@ describe('VideoEventObserver', () => {
     observer = new VideoEventObserver(playback, container)
   })
 
+  describe('static isEnabled()', () => {
+    it('returns true when videoState.enabled is true', () => {
+      expect(VideoEventObserver.isEnabled({ videoState: { enabled: true } })).toBe(true)
+    })
+
+    it('returns false when videoState.enabled is false', () => {
+      expect(VideoEventObserver.isEnabled({ videoState: { enabled: false } })).toBe(false)
+    })
+
+    it('returns false when videoState is undefined', () => {
+      expect(VideoEventObserver.isEnabled({})).toBe(false)
+    })
+
+    it('returns false when cfg is undefined', () => {
+      expect(VideoEventObserver.isEnabled(undefined)).toBe(false)
+    })
+  })
+
   describe('constructor', () => {
-    it('is disabled by default when enabled is not set', () => {
-      const o = new VideoEventObserver(playback, makeContainer())
-      expect(o._enabled).toBe(false)
-    })
-
-    it('reads enabled: true from options', () => {
-      const o = new VideoEventObserver(playback, makeContainer({ enabled: true }))
-      expect(o._enabled).toBe(true)
-    })
-
-    it('reads enabled: false from options', () => {
-      const o = new VideoEventObserver(playback, makeContainer({ enabled: false }))
-      expect(o._enabled).toBe(false)
-    })
-
     it('uses DEFAULT_VIDEO_EVENTS when not configured', () => {
       expect(observer._videoEvents).toEqual(DEFAULT_VIDEO_EVENTS)
     })
@@ -63,12 +66,6 @@ describe('VideoEventObserver', () => {
     it('attaches one listener per configured event', () => {
       observer.bind()
       expect(videoEl.addEventListener).toHaveBeenCalledTimes(observer._videoEvents.length)
-    })
-
-    it('does nothing when disabled', () => {
-      const o = new VideoEventObserver(playback, makeContainer({ enabled: false }))
-      o.bind()
-      expect(videoEl.addEventListener).not.toHaveBeenCalled()
     })
 
     it('does nothing when videoEl is null', () => {

--- a/packages/clappr-telemetry/src/samplers/index.js
+++ b/packages/clappr-telemetry/src/samplers/index.js
@@ -1,3 +1,4 @@
 export { default as SamplerRegistry } from './sampler_registry'
 export { default as BufferSampler } from './buffer_sampler'
 export { default as DecodingSampler } from './decoding_sampler'
+export { default as PlaybackStateSampler } from './playback_state_sampler'

--- a/packages/clappr-telemetry/src/samplers/playback_state_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/playback_state_sampler.js
@@ -1,0 +1,40 @@
+import { round1 } from '../utils/helpers'
+
+/**
+ * Periodic sampler that captures low-level playback state from the `HTMLVideoElement`.
+ *
+ * Contributes a `playbackState` key to each `mse.sample` envelope:
+ * `{ networkState, paused, playbackRate, currentTime }`.
+ *
+ * Enable via `telemetry.playbackStateSample.enabled: true`.
+ */
+export default class PlaybackStateSampler {
+  static get name() { return 'playback-state-sampler' }
+
+  static isEnabled(cfg) {
+    return cfg?.playbackStateSample?.enabled === true
+  }
+
+  constructor(playback, _container) {
+    this._playback = playback
+    this._destroyed = false
+  }
+
+  collect() {
+    if (this._destroyed) return null
+    const el = this._playback?.el
+    if (!el) return null
+
+    return {
+      networkState: el.networkState,
+      paused: el.paused,
+      playbackRate: el.playbackRate,
+      currentTime: round1(el.currentTime)
+    }
+  }
+
+  destroy() {
+    this._destroyed = true
+    this._playback = null
+  }
+}

--- a/packages/clappr-telemetry/src/samplers/playback_state_sampler.test.js
+++ b/packages/clappr-telemetry/src/samplers/playback_state_sampler.test.js
@@ -1,0 +1,91 @@
+import PlaybackStateSampler from './playback_state_sampler'
+
+const makeVideoEl = (overrides = {}) => ({
+  networkState: 2,
+  paused: false,
+  playbackRate: 1,
+  currentTime: 10,
+  ...overrides
+})
+
+const makePlayback = (videoEl) => ({ el: videoEl })
+
+describe('PlaybackStateSampler', () => {
+  let sampler, playback
+
+  beforeEach(() => {
+    playback = makePlayback(makeVideoEl())
+    sampler = new PlaybackStateSampler(playback)
+  })
+
+  describe('isEnabled()', () => {
+    it('returns false by default', () => {
+      expect(PlaybackStateSampler.isEnabled({})).toBe(false)
+    })
+
+    it('returns true when playbackStateSample.enabled is true', () => {
+      expect(PlaybackStateSampler.isEnabled({ playbackStateSample: { enabled: true } })).toBe(true)
+    })
+
+    it('returns false when playbackStateSample.enabled is false', () => {
+      expect(PlaybackStateSampler.isEnabled({ playbackStateSample: { enabled: false } })).toBe(false)
+    })
+
+    it('returns false when cfg is null', () => {
+      expect(PlaybackStateSampler.isEnabled(null)).toBe(false)
+    })
+  })
+
+  describe('collect()', () => {
+    it('returns networkState, paused, playbackRate and currentTime', () => {
+      expect(sampler.collect()).toEqual({
+        networkState: 2,
+        paused: false,
+        playbackRate: 1,
+        currentTime: 10
+      })
+    })
+
+    it('rounds currentTime to 1 decimal', () => {
+      const p = makePlayback(makeVideoEl({ currentTime: 10.456 }))
+      const s = new PlaybackStateSampler(p)
+      expect(s.collect().currentTime).toBe(10.5)
+    })
+
+    it('returns null when videoEl is null', () => {
+      const s = new PlaybackStateSampler({ el: null })
+      expect(s.collect()).toBeNull()
+    })
+
+    it('returns null when playback is null', () => {
+      const s = new PlaybackStateSampler(null)
+      expect(s.collect()).toBeNull()
+    })
+
+    it('reflects paused: true', () => {
+      const p = makePlayback(makeVideoEl({ paused: true }))
+      const s = new PlaybackStateSampler(p)
+      expect(s.collect().paused).toBe(true)
+    })
+
+    it('reflects custom playbackRate', () => {
+      const p = makePlayback(makeVideoEl({ playbackRate: 1.5 }))
+      const s = new PlaybackStateSampler(p)
+      expect(s.collect().playbackRate).toBe(1.5)
+    })
+  })
+
+  describe('destroy()', () => {
+    it('collect() returns null after destroy', () => {
+      sampler.destroy()
+      expect(sampler.collect()).toBeNull()
+    })
+
+    it('is safe to call multiple times', () => {
+      expect(() => {
+        sampler.destroy()
+        sampler.destroy()
+      }).not.toThrow()
+    })
+  })
+})

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.js
@@ -3,12 +3,14 @@ import { emitTelemetry } from '../utils'
 import { EVENT_TYPES } from '../utils/constants'
 import BufferSampler from './buffer_sampler'
 import DecodingSampler from './decoding_sampler'
+import PlaybackStateSampler from './playback_state_sampler'
 
 const DISABLED_INTERVAL = 0
 
 const _registry = new Map([
   ['buffer', BufferSampler],
-  ['decoding', DecodingSampler]
+  ['decoding', DecodingSampler],
+  ['playbackState', PlaybackStateSampler]
 ])
 
 /**

--- a/packages/clappr-telemetry/src/telemetry_plugin.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.js
@@ -1,6 +1,7 @@
 import { ContainerPlugin, Log, Events } from '@clappr/core'
 import { findNetworkAdapter } from './adapters'
 import { SamplerRegistry } from './samplers'
+import { ObserverRegistry } from './observers'
 
 /**
  * @event CONTAINER_TELEMETRY_TRACE
@@ -22,11 +23,13 @@ export default class TelemetryPlugin extends ContainerPlugin {
    * ESM consumers should import `SamplerRegistry` directly from the package.
    */
   static get SamplerRegistry() { return SamplerRegistry }
+  static get ObserverRegistry() { return ObserverRegistry }
 
   constructor(container) {
     super(container)
     this.adapter = null
     this.samplerRegistry = null
+    this.observerRegistry = null
   }
 
   get name() {
@@ -76,6 +79,10 @@ export default class TelemetryPlugin extends ContainerPlugin {
     if (this.samplerRegistry) this.samplerRegistry.destroy()
     this.samplerRegistry = new SamplerRegistry(playback, this.container)
     this.samplerRegistry.bind()
+
+    if (this.observerRegistry) this.observerRegistry.destroy()
+    this.observerRegistry = new ObserverRegistry(playback, this.container, this.samplerRegistry)
+    this.observerRegistry.bind()
   }
 
   destroy() {
@@ -86,6 +93,10 @@ export default class TelemetryPlugin extends ContainerPlugin {
     if (this.samplerRegistry) {
       this.samplerRegistry.destroy()
       this.samplerRegistry = null
+    }
+    if (this.observerRegistry) {
+      this.observerRegistry.destroy()
+      this.observerRegistry = null
     }
     super.destroy()
   }

--- a/packages/clappr-telemetry/src/telemetry_plugin.test.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.test.js
@@ -2,6 +2,7 @@ import { Log, Events } from '@clappr/core'
 import TelemetryPlugin from './telemetry_plugin'
 import { findNetworkAdapter } from './adapters'
 import MockSamplerRegistryClass from './samplers/sampler_registry'
+import MockObserverRegistryClass from './observers/observer_registry'
 
 jest.mock('./adapters', () => ({
   findNetworkAdapter: jest.fn()
@@ -12,7 +13,13 @@ jest.mock('./samplers/sampler_registry', () => ({
   default: jest.fn()
 }))
 
+jest.mock('./observers/observer_registry', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
 let mockSamplerRegistry
+let mockObserverRegistry
 
 describe('TelemetryPlugin', () => {
   let plugin, mockContainer, mockPlayback
@@ -26,6 +33,8 @@ describe('TelemetryPlugin', () => {
     findNetworkAdapter.mockReturnValue(null)
     mockSamplerRegistry = { bind: jest.fn(), destroy: jest.fn() }
     MockSamplerRegistryClass.mockImplementation(() => mockSamplerRegistry)
+    mockObserverRegistry = { bind: jest.fn(), destroy: jest.fn() }
+    MockObserverRegistryClass.mockImplementation(() => mockObserverRegistry)
 
     mockPlayback = { name: 'dash_shaka_playback' }
     mockContainer = {
@@ -65,7 +74,7 @@ describe('TelemetryPlugin', () => {
   it('should call onPlaybackRead with container.playback when CONTAINER_READY fires', () => {
     mockContainer.playback = mockPlayback
     jest.spyOn(plugin, 'onPlaybackRead').mockImplementation(() => {})
-    jest.spyOn(plugin, 'listenTo').mockImplementation((emitter, event, cb) => cb('container-name'))
+    jest.spyOn(plugin, 'listenTo').mockImplementation((_emitter, _event, cb) => cb('container-name'))
 
     plugin.bindEvents()
 
@@ -75,7 +84,7 @@ describe('TelemetryPlugin', () => {
   it('should not call onPlaybackRead when container.playback is null on CONTAINER_READY', () => {
     mockContainer.playback = null
     jest.spyOn(plugin, 'onPlaybackRead').mockImplementation(() => {})
-    jest.spyOn(plugin, 'listenTo').mockImplementation((emitter, event, cb) => cb('container-name'))
+    jest.spyOn(plugin, 'listenTo').mockImplementation((_emitter, _event, cb) => cb('container-name'))
 
     plugin.bindEvents()
 
@@ -252,6 +261,36 @@ describe('TelemetryPlugin', () => {
 
       expect(p.samplerRegistry).toBe(mockSamplerRegistry)
       expect(p.adapter).toBeNull()
+    })
+  })
+
+  describe('ObserverRegistry lifecycle', () => {
+    it('should instantiate and bind observerRegistry on onPlaybackRead', () => {
+      plugin.onPlaybackRead(mockPlayback)
+
+      expect(MockObserverRegistryClass).toHaveBeenCalledWith(mockPlayback, mockContainer, mockSamplerRegistry)
+      expect(mockObserverRegistry.bind).toHaveBeenCalled()
+      expect(plugin.observerRegistry).toBe(mockObserverRegistry)
+    })
+
+    it('should destroy previous observerRegistry on re-bind', () => {
+      plugin.onPlaybackRead(mockPlayback)
+      plugin.onPlaybackRead(mockPlayback)
+
+      expect(mockObserverRegistry.destroy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should destroy observerRegistry on plugin destroy', () => {
+      plugin.onPlaybackRead(mockPlayback)
+      plugin.destroy()
+
+      expect(mockObserverRegistry.destroy).toHaveBeenCalled()
+      expect(plugin.observerRegistry).toBeNull()
+    })
+
+    it('should not throw on destroy when observerRegistry is null', () => {
+      plugin.observerRegistry = null
+      expect(() => plugin.destroy()).not.toThrow()
     })
   })
 })

--- a/packages/clappr-telemetry/src/utils/constants.js
+++ b/packages/clappr-telemetry/src/utils/constants.js
@@ -12,8 +12,26 @@
 export const TELEMETRY_CONTRACT_VERSION = '1.0'
 
 export const TELEMETRY_SOURCES = {
-  NETWORK: 'network'
+  NETWORK: 'network',
+  VIDEO_EVENT_OBSERVER: 'video-event-observer'
 }
+
+export const DEFAULT_VIDEO_EVENTS = [
+  'waiting',
+  'playing',
+  'stalled',
+  'seeking',
+  'seeked',
+  'ended',
+  'canplay',
+  'canplaythrough',
+  'loadedmetadata',
+  'loadeddata',
+  'error',
+  'emptied',
+  'suspend',
+  'abort'
+]
 
 export const EVENT_TYPES = {
   /**
@@ -79,5 +97,13 @@ export const EVENT_TYPES = {
    *
    * @event MSE_SAMPLE
    */
-  MSE_SAMPLE: 'mse.sample'
+  MSE_SAMPLE: 'mse.sample',
+
+  /**
+   * Emitted when a relevant HTMLVideoElement DOM event fires.
+   * Payload: `{ name, currentTime, readyState, snapshot }`
+   *
+   * @event MEDIA_EVENT
+   */
+  MEDIA_EVENT: 'media.event'
 }

--- a/packages/clappr-telemetry/src/utils/index.js
+++ b/packages/clappr-telemetry/src/utils/index.js
@@ -1,4 +1,4 @@
-export { TELEMETRY_CONTRACT_VERSION, EVENT_TYPES, TELEMETRY_SOURCES } from './constants'
+export { TELEMETRY_CONTRACT_VERSION, EVENT_TYPES, TELEMETRY_SOURCES, DEFAULT_VIDEO_EVENTS } from './constants'
 export {
   createEnvelope,
   emitTelemetry,


### PR DESCRIPTION
Adds native `HTMLVideoElement` event observation to the telemetry pipeline. Engine-agnostic: works with Shaka, HLS.js or any other backend.

### What changed

**`VideoEventObserver`** listens to DOM events on `<video>` and emits a `media.event` trace with `{ name, currentTime, readyState, snapshot }`. Enabled via `telemetry.videoState.enabled: true`.

**`ObserverRegistry`** observer manager, analogous to `SamplerRegistry`. Extensible via `ObserverRegistry.register()` before player instantiation.

**`PlaybackStateSampler`** new periodic sampler that contributes `{ networkState, paused, playbackRate, currentTime }` to the `mse.sample` envelope. Enabled via `telemetry.playbackStateSample.enabled: true`.

### Default observed events

| Event | Scenario |
|---|---|
| `waiting` | Video freezes due to lack of buffer (rebuffer stall) |
| `playing` | Playback resumes after pause or stall |
| `stalled` | Browser failed to receive data while fetching |
| `seeking` / `seeked` | Seek start and end |
| `ended` | Playback completed |
| `canplay` / `canplaythrough` | Buffer ready to start / play through without interruption |
| `loadedmetadata` / `loadeddata` | Metadata and first frame available |
| `error` / `abort` / `emptied` / `suspend` | Load errors and interruptions |

Overridable via `telemetry.videoState.videoEvents`.

### How to test

```bash
cd packages/clappr-telemetry
npm run dev
```

Abra o browser e habilite os toggles **Buffer**, **Decoding**, **Playback State** (Sampler) e **Video State** (Observer). Abra o console — a cada evento do `<video>`, um trace `media.event` é emitido com a seguinte estrutura:

```js
{
  type: 'media.event',
  source: 'video-event-observer',
  data: {
    name: 'waiting',
    currentTime: 12.3,
    readyState: 1,
    snapshot: {
      buffer: { bufferAhead: 0.4, currentTime: 12.3 },
      decoding: { droppedFrames: 2, totalFrames: 360 },
      playbackState: { networkState: 2, paused: false, playbackRate: 1, currentTime: 12.3 }
    }
  }
}
```


### Tests

37 new tests. Full suite: **242 tests, 0 failures**.

### AI Review

Four review rounds with Claude Sonnet. Each round, issues were flagged by the AI and fixed by the author. The 4th pass found no critical, important or minor issues. Lifecycle, idempotency, interface contracts, memory management and test quality were all validated.

---

**pt**

## feat(telemetria): adiciona ObserverRegistry, VideoEventObserver e PlaybackStateSampler

Adiciona observação de eventos nativos do `HTMLVideoElement` ao pipeline de telemetria. Engine-agnostic: funciona com Shaka, HLS.js ou qualquer outro backend.

### O que mudou

**`VideoEventObserver`** escuta eventos DOM do `<video>` e emite um trace `media.event` com `{ name, currentTime, readyState, snapshot }`. Habilitado via `telemetry.videoState.enabled: true`.

**`ObserverRegistry`** gerenciador de observers, análogo ao `SamplerRegistry`. Extensível via `ObserverRegistry.register()` antes da instanciação do player.

**`PlaybackStateSampler`** novo sampler periódico que contribui `{ networkState, paused, playbackRate, currentTime }` ao envelope `mse.sample`. Habilitado via `telemetry.playbackStateSample.enabled: true`.

### Eventos observados por padrão

| Evento | Cenário |
|---|---|
| `waiting` | Vídeo congela por falta de buffer (rebuffer stall) |
| `playing` | Reprodução retoma após pausa ou stall |
| `stalled` | Browser não recebeu dados ao buscar |
| `seeking` / `seeked` | Início e fim de seek |
| `ended` | Reprodução concluída |
| `canplay` / `canplaythrough` | Buffer pronto para iniciar / reproduzir sem interrupção |
| `loadedmetadata` / `loadeddata` | Metadados e primeiro frame disponíveis |
| `error` / `abort` / `emptied` / `suspend` | Erros e interrupções de carregamento |

A lista é sobrescrevível via `telemetry.videoState.videoEvents`.

### Como testar

```bash
cd packages/clappr-telemetry
npm run dev
```

Abra o browser e habilite os toggles **Buffer**, **Decoding**, **Playback State** (Sampler) e **Video State** (Observer). Abra o console — a cada evento do `<video>`, um trace `media.event` é emitido com a seguinte estrutura:

```js
{
  type: 'media.event',
  source: 'video-event-observer',
  data: {
    name: 'waiting',
    currentTime: 12.3,
    readyState: 1,
    snapshot: {
      buffer: { bufferAhead: 0.4, currentTime: 12.3 },
      decoding: { droppedFrames: 2, totalFrames: 360 },
      playbackState: { networkState: 2, paused: false, playbackRate: 1, currentTime: 12.3 }
    }
  }
}
```


### Testes

37 novos testes. Suite completa: **242 testes, 0 falhas**.

### Revisão por IA

Quatro rodadas de revisão com Claude Sonnet. A cada rodada, os problemas foram apontados pela IA e corrigidos pelo autor. A 4ª passagem não encontrou nenhum problema crítico, importante ou sugestão. Lifecycle, idempotência, contratos de interface, gerenciamento de memória e qualidade de testes foram todos validados.
