### PR TITLE
fix(plugins): restore volume after mute toggle in media control

### DIFF
--- a/packages/clappr-plugins/src/plugins/media_control/media_control.js
+++ b/packages/clappr-plugins/src/plugins/media_control/media_control.js
@@ -24,8 +24,8 @@ import hdIcon from '../../icons/08-hd.svg'
 
 const { Config, Fullscreen, formatTime, extend, removeArrayItem } = Utils
 
-/** Volume used when unmuting via toggle and no prior level was stored (e.g. started at 0). */
-const DEFAULT_VOLUME_AFTER_UNMUTE_TOGGLE = 100
+/** Default level when unmuting via toggle and no prior level was stored (e.g. started at 0). */
+const defaultVolumeState = 100
 
 export default class MediaControl extends UICorePlugin {
   get name() { return 'media_control' }
@@ -77,8 +77,8 @@ export default class MediaControl extends UICorePlugin {
   constructor(core) {
     super(core)
     this.persistConfig = this.options.persistConfig
-    /** @type {number|null} Level to restore after mute toggle; cleared on container/options volume init. */
-    this._volumeBeforeMuteToggle = null
+    /** @type {number|null} Last non-zero volume before mute toggle; cleared on volume init. */
+    this._previousVolumeState = null
     this.currentPositionValue = null
     this.currentDurationValue = null
     this.keepVisible = false
@@ -174,7 +174,7 @@ export default class MediaControl extends UICorePlugin {
   }
 
   setInitialVolume() {
-    this._volumeBeforeMuteToggle = null
+    this._previousVolumeState = null
     const initialVolume = (this.persistConfig) ? Config.restore('volume') : 100
     const options = this.container && this.container.options || this.options
     this.setVolume(options.mute ? 0 : initialVolume, true)
@@ -324,15 +324,15 @@ export default class MediaControl extends UICorePlugin {
 
   toggleMute() {
     if (this.muted) {
-      const stored = this._volumeBeforeMuteToggle
-      this._volumeBeforeMuteToggle = null
+      const stored = this._previousVolumeState
+      this._previousVolumeState = null
       const restore =
-        stored != null && stored > 0 ? stored : DEFAULT_VOLUME_AFTER_UNMUTE_TOGGLE
+        stored != null && stored > 0 ? stored : defaultVolumeState
       this.setVolume(restore)
       return
     }
     const current = this.volume
-    this._volumeBeforeMuteToggle = current > 0 ? current : null
+    this._previousVolumeState = current > 0 ? current : null
     this.setVolume(0)
   }
 

--- a/packages/clappr-plugins/src/plugins/media_control/media_control.js
+++ b/packages/clappr-plugins/src/plugins/media_control/media_control.js
@@ -24,7 +24,6 @@ import hdIcon from '../../icons/08-hd.svg'
 
 const { Config, Fullscreen, formatTime, extend, removeArrayItem } = Utils
 
-/** Default level when unmuting via toggle and no prior level was stored (e.g. started at 0). */
 const defaultVolumeState = 100
 
 export default class MediaControl extends UICorePlugin {
@@ -77,7 +76,6 @@ export default class MediaControl extends UICorePlugin {
   constructor(core) {
     super(core)
     this.persistConfig = this.options.persistConfig
-    /** @type {number|null} Last non-zero volume before mute toggle; cleared on volume init. */
     this._previousVolumeState = null
     this.currentPositionValue = null
     this.currentDurationValue = null

--- a/packages/clappr-plugins/src/plugins/media_control/media_control.js
+++ b/packages/clappr-plugins/src/plugins/media_control/media_control.js
@@ -24,6 +24,9 @@ import hdIcon from '../../icons/08-hd.svg'
 
 const { Config, Fullscreen, formatTime, extend, removeArrayItem } = Utils
 
+/** Volume used when unmuting via toggle and no prior level was stored (e.g. started at 0). */
+const DEFAULT_VOLUME_AFTER_UNMUTE_TOGGLE = 100
+
 export default class MediaControl extends UICorePlugin {
   get name() { return 'media_control' }
   get supportedVersion() { return { min: CLAPPR_CORE_VERSION } }
@@ -74,6 +77,8 @@ export default class MediaControl extends UICorePlugin {
   constructor(core) {
     super(core)
     this.persistConfig = this.options.persistConfig
+    /** @type {number|null} Level to restore after mute toggle; cleared on container/options volume init. */
+    this._volumeBeforeMuteToggle = null
     this.currentPositionValue = null
     this.currentDurationValue = null
     this.keepVisible = false
@@ -169,6 +174,7 @@ export default class MediaControl extends UICorePlugin {
   }
 
   setInitialVolume() {
+    this._volumeBeforeMuteToggle = null
     const initialVolume = (this.persistConfig) ? Config.restore('volume') : 100
     const options = this.container && this.container.options || this.options
     this.setVolume(options.mute ? 0 : initialVolume, true)
@@ -317,7 +323,17 @@ export default class MediaControl extends UICorePlugin {
   }
 
   toggleMute() {
-    this.setVolume(this.muted ? 100 : 0)
+    if (this.muted) {
+      const stored = this._volumeBeforeMuteToggle
+      this._volumeBeforeMuteToggle = null
+      const restore =
+        stored != null && stored > 0 ? stored : DEFAULT_VOLUME_AFTER_UNMUTE_TOGGLE
+      this.setVolume(restore)
+      return
+    }
+    const current = this.volume
+    this._volumeBeforeMuteToggle = current > 0 ? current : null
+    this.setVolume(0)
   }
 
   setVolume(value, isInitialVolume = false) {

--- a/packages/clappr-plugins/src/plugins/media_control/media_control.test.js
+++ b/packages/clappr-plugins/src/plugins/media_control/media_control.test.js
@@ -78,6 +78,31 @@ describe('MediaControl', function () {
       expect(this.mediaControl.muted).toBe(true)
     })
 
+    it('restores prior volume after mute toggle instead of jumping to 100', function () {
+      const setVolumeSpy = jest.spyOn(this.container, 'setVolume')
+
+      this.mediaControl.setVolume(10)
+      this.container.trigger(Events.CONTAINER_READY)
+
+      this.mediaControl.toggleMute()
+      expect(this.mediaControl.muted).toBe(true)
+      expect(this.mediaControl.volume).toBe(0)
+
+      this.mediaControl.toggleMute()
+      expect(this.mediaControl.muted).toBe(false)
+      expect(this.mediaControl.volume).toBe(10)
+      expect(setVolumeSpy).toHaveBeenLastCalledWith(10)
+    })
+
+    it('unmute toggle defaults to 100 when there was no stored level (already at 0)', function () {
+      this.mediaControl.setVolume(0)
+      this.container.trigger(Events.CONTAINER_READY)
+
+      this.mediaControl.toggleMute()
+      expect(this.mediaControl.muted).toBe(false)
+      expect(this.mediaControl.volume).toBe(100)
+    })
+
     it('persists volume when persistence is on', function () {
       // expected to be default value (100)
       expect(Config.restore('volume')).toBe(100)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The mute icon in `MediaControl` treated unmute as `setVolume(100)` whenever the current level was 0, so users who had lowered the slider (for example to 10) heard full blast after toggling mute off.

This change stores the non-zero volume before muting via the toggle and restores it on the next toggle. The stored value is cleared when initial volume is applied (`setInitialVolume`), including container switches and option-driven resets, so stale values do not leak across sessions. If the user toggles unmute while already at 0 with nothing stored, behavior stays at 100 as before.

## Testing

Adds unit tests for restore-after-toggle and the edge case of toggling from 0 with no prior level. Run:

`lerna run test --scope=@clappr/plugins -- src/plugins/media_control/media_control.test.js`

Closes #2436 when merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b2d8636-a4f5-4977-8936-c30f9ad586f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b2d8636-a4f5-4977-8936-c30f9ad586f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

