### PR TITLE
Handle fullscreen when blocked by browser permissions policy

### DIFF
--- a/packages/clappr-core/src/components/core/core.js
+++ b/packages/clappr-core/src/components/core/core.js
@@ -15,6 +15,12 @@ import ErrorMixin from '../../base/error_mixin/error_mixin'
 import CoreStyle from './public/style.scss'
 import ResetStyle from './public/optional_reset.scss'
 
+function isFullscreenPolicyBlocked(error) {
+  if (!error) return false
+  const message = error.message || String(error)
+  return /disallowed by permissions policy|permissions policy|fullscreen is not allowed/i.test(message)
+}
+
 /**
  * The Core is responsible to manage Containers and the player state.
  * @class Core
@@ -337,16 +343,37 @@ export default class Core extends UIObject {
       const fullscreenEl = Browser.isiOS ? this.activePlaybackEl : this.el
       if (!fullscreenEl) return
 
-      (Browser.isSafari || Browser.isiOS) // Safari doesn't return a promise like the other browsers. See more in https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen
-        ? Fullscreen.requestFullscreen(fullscreenEl)
-        : Fullscreen.requestFullscreen(fullscreenEl).then(
-          _ => _,
-          error => setTimeout(() => { // fixes the issue https://github.com/clappr/clappr/issues/1860
-            if (!this.isFullscreen()) throw new ReferenceError(error)
-          }, 600)
-        )
+      const addFullscreenClass = () => {
+        !Browser.isiOS && this.$el.addClass('fullscreen')
+      }
 
-      !Browser.isiOS && this.$el.addClass('fullscreen')
+      if (Browser.isSafari || Browser.isiOS) {
+        // Safari doesn't return a promise like the other browsers. See more in https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen
+        Fullscreen.requestFullscreen(fullscreenEl)
+        addFullscreenClass()
+      } else {
+        const requestResult = Fullscreen.requestFullscreen(fullscreenEl)
+        const promise =
+          requestResult != null && typeof requestResult.then === 'function'
+            ? requestResult
+            : Promise.resolve()
+
+        addFullscreenClass()
+
+        promise.then(
+          () => {},
+          (error) => {
+            setTimeout(() => {
+              // fixes the issue https://github.com/clappr/clappr/issues/1860
+              if (!this.isFullscreen()) {
+                this.$el.removeClass('fullscreen')
+                if (isFullscreenPolicyBlocked(error)) return
+                throw new ReferenceError(error.message || String(error))
+              }
+            }, 600)
+          }
+        )
+      }
     }
   }
 

--- a/packages/clappr-core/src/components/core/core.test.js
+++ b/packages/clappr-core/src/components/core/core.test.js
@@ -163,6 +163,23 @@ describe('Core', function () {
           expect(core.$el.addClass).toHaveBeenCalledWith('fullscreen')
           delete core.el.requestFullscreen
         })
+
+        test('removes fullscreen class when requestFullscreen is blocked by permissions policy', async () => {
+          jest.useFakeTimers()
+          const policyError = new TypeError('Disallowed by permissions policy')
+          core.el.requestFullscreen = () => Promise.reject(policyError)
+          jest.spyOn(core.$el, 'removeClass')
+          jest.spyOn(core, 'isFullscreen').mockReturnValue(false)
+
+          core.toggleFullscreen()
+
+          await Promise.resolve()
+          jest.advanceTimersByTime(600)
+
+          expect(core.$el.removeClass).toHaveBeenCalledWith('fullscreen')
+          jest.useRealTimers()
+          delete core.el.requestFullscreen
+        })
       })
 
       describe('and is an iOS Browser', () => {


### PR DESCRIPTION
Handles `TypeError: Disallowed by permissions policy` when `requestFullscreen` is blocked (e.g. iframe without fullscreen delegation).

- Only chains `.then` when the API returns a thenable
- Removes the optimistic `fullscreen` class if fullscreen never activates
- Skips the extra `ReferenceError` for permissions-policy style rejections
- Adds unit test