### PR TITLE
Zepto – Remove resetting of read-only attribute

### DIFF
--- a/packages/clappr-zepto/zepto.js
+++ b/packages/clappr-zepto/zepto.js
@@ -1686,8 +1686,6 @@ window.$ === undefined && (window.$ = Zepto)
         event[predicate] = returnFalse
       })
 
-      event.timeStamp || (event.timeStamp = Date.now())
-
       if (source.defaultPrevented !== undefined ? source.defaultPrevented :
           'returnValue' in source ? source.returnValue === false :
           source.getPreventDefault && source.getPreventDefault())


### PR DESCRIPTION
This MR fixes an unhandled, non-fatal issue where one of Clappr Zepto's methods tried to override an `Event` instance's [`timeStamp`](https://developer.mozilla.org/en-US/docs/Web/API/Event/timeStamp) property. This action is not possible as the [`timeStamp`](https://developer.mozilla.org/en-US/docs/Web/API/Event/timeStamp) property is read-only.

