### PR TITLE
feat(telemetry): extensible registry pattern for adapters, samplers and observers

### DIFF
--- a/packages/clappr-telemetry/README.md
+++ b/packages/clappr-telemetry/README.md
@@ -35,20 +35,23 @@ Via CDN (jsDelivr):
 
 <div id="player"></div>
 <script>
+  const {
+    ShakaNetworkAdapter, HlsNetworkAdapter,
+    BufferSampler, DecodingSampler, PlaybackStateSampler,
+    NetworkSampler, PlaybackTimingSampler, StreamInfoSampler,
+    VideoEventObserver
+  } = ClapprTelemetry
+
   const player = new Clappr.Player({
     parentId: '#player',
     source: 'https://example.com/stream.mpd',
     plugins: [DashShakaPlayback, ClapprTelemetry],
     telemetry: {
-      network:             { enabled: true },
-      bufferSample:        { enabled: true },
-      decodingSample:      { enabled: true },
-      playbackStateSample: { enabled: true },
-      networkSample:       { enabled: true },
-      timingSample:        { enabled: true },
-      streamInfoSample:    { enabled: true },
-      sampleIntervalMs:    1000,
-      videoState:          { enabled: true }
+      adapters:  [ShakaNetworkAdapter, HlsNetworkAdapter],
+      samplers:  [BufferSampler, DecodingSampler, PlaybackStateSampler,
+                  NetworkSampler, PlaybackTimingSampler, StreamInfoSampler],
+      observers: [VideoEventObserver],
+      sampleIntervalMs: 1000,
     }
   })
 </script>
@@ -59,21 +62,23 @@ With npm/ESM:
 ```javascript
 import Clappr from '@clappr/core'
 import DashShakaPlayback from 'dash-shaka-playback'
-import ClapprTelemetry from '@clappr/telemetry'
+import ClapprTelemetry, {
+  ShakaNetworkAdapter, HlsNetworkAdapter,
+  BufferSampler, DecodingSampler, PlaybackStateSampler,
+  NetworkSampler, PlaybackTimingSampler, StreamInfoSampler,
+  VideoEventObserver
+} from '@clappr/telemetry'
 
 const player = new Clappr.Player({
   parentId: '#player',
   source: 'https://example.com/stream.mpd',
   plugins: [DashShakaPlayback, ClapprTelemetry],
   telemetry: {
-    network:             { enabled: true },
-    bufferSample:        { enabled: true },
-    decodingSample:      { enabled: true },
-    playbackStateSample: { enabled: true },
-    networkSample:       { enabled: true },
-    timingSample:        { enabled: true },
-    sampleIntervalMs:    1000,
-    videoState:          { enabled: true }
+    adapters:  [ShakaNetworkAdapter, HlsNetworkAdapter],
+    samplers:  [BufferSampler, DecodingSampler, PlaybackStateSampler,
+                NetworkSampler, PlaybackTimingSampler, StreamInfoSampler],
+    observers: [VideoEventObserver],
+    sampleIntervalMs: 1000,
   }
 })
 ```

--- a/packages/clappr-telemetry/README.md
+++ b/packages/clappr-telemetry/README.md
@@ -84,11 +84,11 @@ Available from `dist/clappr-telemetry.esm.js`:
 
 **Adapters**
 
-| Export                | Description                                                             |
-| --------------------- | ----------------------------------------------------------------------- |
-| `ShakaNetworkAdapter` | Shaka network metrics adapter class                                     |
-| `HlsNetworkAdapter`   | HLS.js network metrics adapter class                                    |
-| `findNetworkAdapter`  | Resolves the adapter class for a playback instance (used by the plugin) |
+| Export                | Description                                                                    |
+| --------------------- | ------------------------------------------------------------------------------ |
+| `NetworkAdapters`     | Registry class — use to register and unregister adapters (none pre-registered) |
+| `ShakaNetworkAdapter` | Shaka network metrics adapter class — must be registered explicitly            |
+| `HlsNetworkAdapter`   | HLS.js network metrics adapter class — must be registered explicitly           |
 
 **Samplers**
 
@@ -117,13 +117,13 @@ Available from `dist/clappr-telemetry.esm.js`:
 | `EVENT_TYPES`                | Canonical `type` strings (`request:start`, `mse.sample`, etc.)  |
 | `TELEMETRY_SOURCES`          | Canonical `source` values (e.g. `network`)                       |
 | `createEnvelope`             | Builds the versioned envelope object                             |
-| `emitTelemetry`              | Triggers `CONTAINER_TELEMETRY_TRACE` on an emitter               |
+| `emitTelemetry`              | Triggers `Events.Custom.CONTAINER_TELEMETRY_TRACE` on an emitter |
 | `calculateThroughput`        | Mbps helper used by network adapters                             |
 | `getBufferAhead`             | Returns seconds buffered ahead of the current position           |
 | `getBufferedRanges`          | Converts `TimeRanges` to a compact `[[start, end], ...]` array   |
 | `DEFAULT_VIDEO_EVENTS`       | Array with the 14 default `HTMLVideoElement` event names observed |
 
-The UMD build (`dist/clappr-telemetry.js` / CDN) exposes **only** the plugin as the global `ClapprTelemetry`. Use the ESM file if you need named exports.
+The UMD build (`dist/clappr-telemetry.js` / CDN) exposes **only** the plugin as the global `ClapprTelemetry`. Adapters must be registered explicitly via `ClapprTelemetry.NetworkAdapters` — no adapter is pre-registered in any build.
 
 ## Configuration
 
@@ -200,6 +200,33 @@ Adapters connect the plugin to specific playback engines. Each adapter implement
 | --------------------- | --------------------- | --------- |
 | `ShakaNetworkAdapter` | `dash-shaka-playback` | Available |
 | `HlsNetworkAdapter`   | `hlsjs-playback`      | Available |
+
+### Registering adapters
+
+All adapters — including the built-ins — must be registered before the player is instantiated. The first registered adapter has the highest priority.
+
+```javascript
+import { NetworkAdapters, ShakaNetworkAdapter, HlsNetworkAdapter } from '@clappr/telemetry'
+
+NetworkAdapters.register(ShakaNetworkAdapter)
+NetworkAdapters.register(HlsNetworkAdapter)
+
+// Custom adapters can also be registered
+NetworkAdapters.register(MyCustomAdapter)
+
+// Remove when no longer needed
+NetworkAdapters.unregister(MyCustomAdapter)
+```
+
+**Adapter contract:**
+
+| Member | Description |
+| --- | --- |
+| `static get name()` | String identifier (optional — used only in log messages) |
+| `static isSupported(playback)` | Returns `true` when this adapter handles the given playback |
+| `constructor(playback, container)` | Receives playback engine and container |
+| `bind()` | Attaches listeners/hooks into the engine |
+| `destroy()` | Detaches listeners and releases resources |
 
 ### Sources (`source`)
 

--- a/packages/clappr-telemetry/README.md
+++ b/packages/clappr-telemetry/README.md
@@ -132,21 +132,46 @@ The UMD build (`dist/clappr-telemetry.js` / CDN) exposes **only** the plugin as 
 
 ## Configuration
 
-All options are opt-in — nothing is collected by default.
+All options are opt-in — nothing is collected by default. Components are activated by including their class in the corresponding array.
 
-| Option                                   | Type     | Default   | Description                                                                                                                                |
-| ---------------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `telemetry.network.enabled`              | Boolean  | `false`   | Enables network request telemetry                                                                                                          |
-| `telemetry.bufferSample.enabled`         | Boolean  | `false`   | Enables periodic buffer state sampling                                                                                                     |
-| `telemetry.bufferSample.includeRanges`   | Boolean  | `true`    | Includes buffered time ranges in the `mse.sample` payload                                                                                  |
-| `telemetry.decodingSample.enabled`       | Boolean  | `false`   | Enables periodic decoding quality sampling                                                                                                 |
-| `telemetry.playbackStateSample.enabled`  | Boolean  | `false`   | Enables periodic `networkState`, `paused`, `playbackRate`, and bitrate sampling                                                            |
-| `telemetry.networkSample.enabled`        | Boolean  | `false`   | Enables periodic request counters, throughput, and segment metrics sampling                                                                |
-| `telemetry.timingSample.enabled`         | Boolean  | `false`   | Enables cumulative playback timing: `timePlayingMs`, `timeWaitingMs`, `joinTimeMs`, and startup/load times                                 |
-| `telemetry.streamInfoSample.enabled`     | Boolean  | `false`   | Enables stream metadata sampling: container format, video/audio codec, and variant count                                                   |
-| `telemetry.sampleIntervalMs`             | Number   | `0`       | Sampling frequency in ms. When `0` (default), no automatic interval is started and only on-demand snapshots via `snapshot()` are available |
-| `telemetry.videoState.enabled`           | Boolean  | `false`   | Enables the `VideoEventObserver`                                                                                                           |
-| `telemetry.videoState.videoEvents`       | String[] | see below | List of `HTMLVideoElement` event names to observe. Defaults to the full set (see **VideoEventObserver**)                                   |
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `telemetry.enabled` | Boolean | `true` | Set to `false` to disable the plugin entirely for this player instance |
+| `telemetry.adapters` | Class[] | `[]` | Network adapter classes to activate. The first registered adapter whose `isSupported(playback)` returns `true` is used |
+| `telemetry.samplers` | Class[] | `[]` | Sampler classes to register for this player instance |
+| `telemetry.observers` | Class[] | `[]` | Observer classes to register for this player instance |
+| `telemetry.sampleIntervalMs` | Number | `0` | Sampling interval in ms. When `0` (default), no automatic interval is started — use `snapshot()` for on-demand collection |
+| `telemetry.<name>.enabled` | Boolean | `true` | Opt-out flag for any registered component. Key is the component's `static get name()` value (e.g. `buffer`, `decoding`, `videoState`) |
+| `telemetry.bufferSample.includeRanges` | Boolean | `true` | Include buffered time ranges in the `mse.sample` payload |
+| `telemetry.videoState.videoEvents` | String[] | 14 events | `HTMLVideoElement` event names for `VideoEventObserver` to observe. Defaults to the full list (see **VideoEventObserver**) |
+
+### Disabling individual components
+
+When components are pre-registered globally (e.g. in a shared SDK setup), use the `<name>.enabled: false` opt-out to disable specific ones for a player instance without affecting others:
+
+```javascript
+new Clappr.Player({
+  telemetry: {
+    samplers:  [BufferSampler, DecodingSampler, NetworkSampler, ...],
+    observers: [VideoEventObserver],
+    // disable specific components by their static get name() value:
+    decoding:   { enabled: false },
+    videoState: { enabled: false },
+  }
+})
+```
+
+The `<name>` key maps to each class's `static get name()` property:
+
+| Class | Key |
+| --- | --- |
+| `BufferSampler` | `buffer` |
+| `DecodingSampler` | `decoding` |
+| `PlaybackStateSampler` | `playbackState` |
+| `NetworkSampler` | `network` |
+| `PlaybackTimingSampler` | `timing` |
+| `StreamInfoSampler` | `streamInfo` |
+| `VideoEventObserver` | `videoState` |
 
 ## Consuming telemetry events
 
@@ -344,12 +369,14 @@ Default observed events: `waiting`, `playing`, `stalled`, `seeking`, `seeked`, `
 
 ### Configuration
 
+Include `VideoEventObserver` in the `observers` array to activate it. Use `videoState.videoEvents` to narrow the observed event list:
+
 ```javascript
 new Clappr.Player({
   plugins: [ClapprTelemetry],
   telemetry: {
+    observers: [VideoEventObserver],
     videoState: {
-      enabled:     true,                           // default: false
       videoEvents: ['waiting', 'stalled', 'error'] // default: full list above
     }
   }
@@ -362,13 +389,12 @@ The sampler registry is extensible. You can add your own sampler and have it par
 
 ### Contract
 
-A custom sampler must implement three members:
-
-| Member | Description |
-| --- | --- |
-| `static isEnabled(cfg)` | Returns `true` when the sampler should be active. `cfg` is `container.options.telemetry` |
-| `collect()` | Called every tick. Returns a plain object with the data to include, or `null` to skip this tick |
-| `destroy()` | Called when the registry is destroyed. Clean up any internal state here |
+| Member | Required | Description |
+| --- | --- | --- |
+| `static get name()` | Yes | Unique string key — used as the registry identifier and as the key in the `mse.sample` payload |
+| `collect()` | Yes | Called every tick. Returns a plain object with the data to include, or `null` to skip this tick |
+| `destroy()` | Yes | Called when the registry is destroyed. Clean up any internal state here |
+| `static isEnabled(cfg)` | No | Override the registry's default enable/disable check. `cfg` is `container.options.telemetry`. Omit to use the standard `cfg[name].enabled` opt-out |
 
 ### Example
 
@@ -376,9 +402,7 @@ A custom sampler must implement three members:
 import { SamplerRegistry } from '@clappr/telemetry'
 
 class AudioSampler {
-  static isEnabled(cfg) {
-    return cfg?.audioSample?.enabled === true
-  }
+  static get name() { return 'audio' }
 
   constructor(playback) {
     this._playback = playback
@@ -396,13 +420,13 @@ class AudioSampler {
 }
 
 // register before instantiating the player
-SamplerRegistry.register('audio', AudioSampler)
+SamplerRegistry.register(AudioSampler)
 
 new Clappr.Player({
   plugins: [ClapprTelemetry],
   telemetry: {
+    samplers: [AudioSampler],
     sampleIntervalMs: 1000,
-    audioSample: { enabled: true }
   }
 })
 ```
@@ -421,7 +445,7 @@ The result appears under the `audio` key in the `mse.sample` payload:
 To remove a previously registered sampler:
 
 ```javascript
-SamplerRegistry.unregister('audio')
+SamplerRegistry.unregister(AudioSampler)
 ```
 
 ### On-demand snapshot
@@ -443,12 +467,12 @@ The observer registry is extensible. You can add your own observer and have it m
 
 ### Contract
 
-A custom observer must implement two members:
-
-| Member      | Description                                                                 |
-| ----------- | --------------------------------------------------------------------------- |
-| `bind()`    | Called after instantiation. Attach event listeners and start collecting     |
-| `destroy()` | Called when the registry is destroyed. Remove listeners and clean up state  |
+| Member | Required | Description |
+| --- | --- | --- |
+| `static get name()` | Yes | Unique string key — used as the registry identifier |
+| `bind()` | Yes | Called after instantiation. Attach event listeners and start collecting |
+| `destroy()` | Yes | Called when the registry is destroyed. Remove listeners and clean up state |
+| `static isEnabled(cfg)` | No | Override the registry's default enable/disable check. Omit to use the standard `cfg[name].enabled` opt-out |
 
 The constructor receives `(playback, container, samplerRegistry)` — the same arguments as `VideoEventObserver`.
 
@@ -458,6 +482,8 @@ The constructor receives `(playback, container, samplerRegistry)` — the same a
 import { ObserverRegistry } from '@clappr/telemetry'
 
 class PlaybackEventObserver {
+  static get name() { return 'playbackEvents' }
+
   constructor(playback, container, samplerRegistry) {
     this._container = container
     this._samplerRegistry = samplerRegistry
@@ -476,13 +502,20 @@ class PlaybackEventObserver {
 }
 
 // register before instantiating the player
-ObserverRegistry.register('playbackEvents', PlaybackEventObserver)
+ObserverRegistry.register(PlaybackEventObserver)
+
+new Clappr.Player({
+  plugins: [ClapprTelemetry],
+  telemetry: {
+    observers: [PlaybackEventObserver],
+  }
+})
 ```
 
 To remove a previously registered observer:
 
 ```javascript
-ObserverRegistry.unregister('playbackEvents')
+ObserverRegistry.unregister(PlaybackEventObserver)
 ```
 
 ## Development

--- a/packages/clappr-telemetry/README.md
+++ b/packages/clappr-telemetry/README.md
@@ -137,7 +137,7 @@ All options are opt-in — nothing is collected by default. Components are activ
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `telemetry.enabled` | Boolean | `true` | Set to `false` to disable the plugin entirely for this player instance |
-| `telemetry.adapters` | Class[] | `[]` | Network adapter classes to activate. The first registered adapter whose `isSupported(playback)` returns `true` is used |
+| `telemetry.adapters` | Class[] | `[]` | Network adapter classes to activate for this player instance. The first one in the array whose `isSupported(playback)` returns `true` is used |
 | `telemetry.samplers` | Class[] | `[]` | Sampler classes to register for this player instance |
 | `telemetry.observers` | Class[] | `[]` | Observer classes to register for this player instance |
 | `telemetry.sampleIntervalMs` | Number | `0` | Sampling interval in ms. When `0` (default), no automatic interval is started — use `snapshot()` for on-demand collection |
@@ -147,7 +147,7 @@ All options are opt-in — nothing is collected by default. Components are activ
 
 ### Disabling individual components
 
-When components are pre-registered globally (e.g. in a shared SDK setup), use the `<name>.enabled: false` opt-out to disable specific ones for a player instance without affecting others:
+Each instance only activates its own `samplers`/`observers`/`adapters` arrays. When sharing a config object across players, use `<name>.enabled: false` to disable a component for one instance without touching the shared array:
 
 ```javascript
 new Clappr.Player({

--- a/packages/clappr-telemetry/jest.config.js
+++ b/packages/clappr-telemetry/jest.config.js
@@ -2,6 +2,7 @@ const path = require('path')
 
 module.exports = {
   testEnvironment: 'jsdom',
+  testEnvironmentOptions: {},
   transform: {
     '^.+\\.js$': 'babel-jest'
   },

--- a/packages/clappr-telemetry/public/index.html
+++ b/packages/clappr-telemetry/public/index.html
@@ -50,7 +50,12 @@
   </section>
 
   <script>
-    const { ShakaNetworkAdapter, HlsNetworkAdapter, BufferSampler, DecodingSampler } = ClapprTelemetry
+    const {
+      ShakaNetworkAdapter, HlsNetworkAdapter,
+      BufferSampler, DecodingSampler, PlaybackStateSampler,
+      NetworkSampler, PlaybackTimingSampler, StreamInfoSampler,
+      VideoEventObserver
+    } = ClapprTelemetry
 
     const TELEMETRY_TRACE_EVENT = Clappr.Events.Custom.CONTAINER_TELEMETRY_TRACE
 
@@ -62,32 +67,82 @@
       }
     }
 
+    const SAMPLERS = `[BufferSampler, DecodingSampler, PlaybackStateSampler,
+                NetworkSampler, PlaybackTimingSampler, StreamInfoSampler]`
+    const OBSERVERS = `[VideoEventObserver]`
+    const INTERVAL = `// enabled: false,        // set to false to disable all telemetry
+    // sampleIntervalMs: 1000, // set interval in ms to enable periodic sampling`
+
     const MEDIAS = {
-      hls:   { label: 'HLS.js',       source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8' },
-      shaka: { label: 'Shaka DASH',   source: 'https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd' },
-      html5: { label: 'HTML5 Video',  source: 'http://clappr.io/highline.mp4' },
-    }
-
-    var MEDIA = MEDIAS.hls.source
-
-    const CODE = `window.player = new Clappr.Player({
+      hls: {
+        label: 'HLS.js',
+        code: `window.player = new Clappr.Player({
   parentId: '#player-wrapper',
-  source: MEDIA,
-  width: 640,
-  height: 360,
-  muted: true,
-  plugins: [HlsjsPlayback, DashShakaPlayback, Clappr.HTML5Video, ClapprTelemetry, SimpleTelemetryLogger],
+  source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
+  width: 640, height: 360, muted: true,
+  plugins: [HlsjsPlayback, ClapprTelemetry, SimpleTelemetryLogger],
   telemetry: {
-    adapters: [HlsNetworkAdapter, ShakaNetworkAdapter],
-    samplers: [BufferSampler, DecodingSampler],
-    sampleIntervalMs: 1000,
+    adapters:  [HlsNetworkAdapter],
+    samplers:  ${SAMPLERS},
+    observers: ${OBSERVERS},
+    ${INTERVAL}
   }
 })`
+      },
+      shaka: {
+        label: 'Shaka DASH',
+        code: `window.player = new Clappr.Player({
+  parentId: '#player-wrapper',
+  source: 'https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd',
+  width: 640, height: 360, muted: true,
+  plugins: [DashShakaPlayback, ClapprTelemetry, SimpleTelemetryLogger],
+  telemetry: {
+    adapters:  [ShakaNetworkAdapter],
+    samplers:  ${SAMPLERS},
+    observers: ${OBSERVERS},
+    ${INTERVAL}
+  }
+})`
+      },
+      widevine: {
+        label: 'Shaka DASH + Widevine',
+        code: `window.player = new Clappr.Player({
+  parentId: '#player-wrapper',
+  source: 'https://storage.googleapis.com/shaka-demo-assets/sintel-widevine/dash.mpd',
+  width: 640, height: 360, muted: true,
+  plugins: [DashShakaPlayback, ClapprTelemetry, SimpleTelemetryLogger],
+  shakaConfiguration: {
+    drm: { servers: { 'com.widevine.alpha': 'https://cwip-shaka-proxy.appspot.com/no_auth' } }
+  },
+  telemetry: {
+    adapters:  [ShakaNetworkAdapter],
+    samplers:  ${SAMPLERS},
+    observers: ${OBSERVERS},
+    ${INTERVAL}
+  }
+})`
+      },
+      html5: {
+        label: 'HTML5 Video',
+        code: `window.player = new Clappr.Player({
+  parentId: '#player-wrapper',
+  source: 'http://clappr.io/highline.mp4',
+  width: 640, height: 360, muted: true,
+  plugins: [Clappr.HTML5Video, ClapprTelemetry, SimpleTelemetryLogger],
+  telemetry: {
+    samplers:  [BufferSampler, DecodingSampler, PlaybackStateSampler, PlaybackTimingSampler],
+    observers: ${OBSERVERS},
+    ${INTERVAL}
+  }
+})`
+      },
+    }
 
     var editor
 
     function selectMedia(key) {
-      MEDIA = (MEDIAS[key] ?? MEDIAS.hls).source
+      const media = MEDIAS[key] ?? MEDIAS.hls
+      editor.getSession().setValue(media.code)
       run()
     }
 
@@ -115,10 +170,10 @@
 
     window.onload = function () {
       const select = document.getElementById('media-select')
-      Object.entries(MEDIAS).forEach(([key, { label, source }]) => {
+      Object.entries(MEDIAS).forEach(([key, { label }]) => {
         const opt = document.createElement('option')
         opt.value = key
-        opt.textContent = `${label} — ${source}`
+        opt.textContent = label
         select.appendChild(opt)
       })
 
@@ -128,7 +183,7 @@
       session.setMode('ace/mode/javascript')
       session.setTabSize(2)
       session.setUseSoftTabs(true)
-      editor.getSession().setValue(CODE)
+      editor.getSession().setValue(MEDIAS.hls.code)
 
       document.querySelector('.run').addEventListener('click', run)
       run()

--- a/packages/clappr-telemetry/public/index.html
+++ b/packages/clappr-telemetry/public/index.html
@@ -274,6 +274,10 @@
   </div>
 
   <script>
+    const { NetworkAdapters, ShakaNetworkAdapter, HlsNetworkAdapter } = ClapprTelemetry
+    NetworkAdapters.register(ShakaNetworkAdapter)
+    NetworkAdapters.register(HlsNetworkAdapter)
+
     const TELEMETRY_TRACE_EVENT = Clappr.Events.Custom.CONTAINER_TELEMETRY_TRACE
 
     class SimpleTelemetryLogger extends Clappr.ContainerPlugin {

--- a/packages/clappr-telemetry/public/index.html
+++ b/packages/clappr-telemetry/public/index.html
@@ -1,464 +1,139 @@
-<!DOCTYPE html>
-<html lang="en">
+<html>
+
 <head>
-  <meta charset="utf-8">
-  <title>Clappr Player — Telemetry Plugin Demo</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>Clappr Telemetry</title>
   <script src="/packages/player/dist/clappr.js"></script>
   <script src="/packages/hlsjs-playback/dist/hlsjs-playback.js"></script>
   <script src="/packages/dash-shaka-playback/dist/dash-shaka-playback.js"></script>
   <script src="/packages/clappr-telemetry/dist/clappr-telemetry.js"></script>
+  <script src="/packages/player/public/j/editor/ace.js"></script>
+  <link rel="stylesheet" href="/packages/player/public/stylesheets/bootstrap.min.css" type="text/css" media="screen">
+  <link rel="stylesheet" href="/packages/player/public/stylesheets/bootstrap-theme.min.css" type="text/css" media="screen">
+  <link rel="stylesheet" href="/packages/player/public/stylesheets/style.css" type="text/css" media="screen">
   <style>
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
-
-    body {
-      font-family: Arial, sans-serif;
-      background: #f5f5f5;
-      padding: 20px;
-    }
-
-    .container {
-      max-width: 960px;
-      margin: 0 auto;
-    }
-
-    h1 {
-      color: #333;
-      margin-bottom: 20px;
-      font-size: 24px;
-    }
-
-    .controls {
-      margin-bottom: 15px;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-
-    label {
-      font-size: 14px;
-      color: #666;
-      font-weight: bold;
-    }
-
-    .toggle-label {
-      font-size: 13px;
-      color: #444;
-      font-weight: normal;
-      display: flex;
-      align-items: center;
-      gap: 5px;
-      cursor: pointer;
-    }
-
-    #examples {
-      padding: 8px 12px;
-      font-size: 14px;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      background: #fff;
-      cursor: pointer;
-    }
-
-    #examples:hover {
-      border-color: #999;
-    }
-
-    #examples:focus {
-      outline: none;
-      border-color: #333;
-      box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
-    }
-
-    #player {
-      width: 100%;
-      height: 500px;
-      background: #000;
-      border-radius: 4px;
-      margin-bottom: 15px;
-    }
-
-    button {
-      padding: 10px 20px;
-      font-size: 14px;
-      background: #333;
-      color: #fff;
-      border: none;
-      border-radius: 4px;
-      cursor: pointer;
-      transition: background 0.2s;
-    }
-
-    button:hover {
-      background: #555;
-    }
-
-    button:active {
-      background: #222;
-    }
-
-    .info {
-      margin-top: 20px;
-      padding: 15px;
-      background: #fff;
-      border-radius: 4px;
-      border-left: 4px solid #333;
-      font-size: 12px;
-      color: #666;
-      line-height: 1.6;
-    }
-
-    #custom-config {
-      display: none;
-      margin-bottom: 15px;
-      padding: 16px;
-      background: #fff;
-      border-radius: 4px;
-      border: 1px solid #ddd;
-      flex-direction: column;
-      gap: 12px;
-    }
-
-    #custom-config.visible {
-      display: flex;
-    }
-
-    .custom-field {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
-
-    .custom-field label {
-      font-size: 12px;
-      color: #555;
-    }
-
-    .custom-field input {
-      padding: 8px 10px;
-      font-size: 13px;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      width: 100%;
-    }
-
-    .custom-field input:focus {
-      outline: none;
-      border-color: #333;
-      box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.08);
-    }
-
-    .custom-actions {
-      display: flex;
-      gap: 8px;
-    }
-
-    #applyCustomBtn {
-      padding: 7px 14px;
-      font-size: 13px;
-      background: #1a7f37;
-    }
-
-    #applyCustomBtn:hover {
-      background: #268040;
-    }
-
-    .custom-guide {
-      background: #f0f4ff;
-      border: 1px solid #c7d4f0;
-      border-radius: 4px;
-      padding: 12px 16px;
-      font-size: 12px;
-      color: #444;
-      line-height: 1.7;
-    }
-
-    .custom-guide strong {
-      display: block;
-      font-size: 13px;
-      color: #222;
-      margin-bottom: 6px;
-    }
-
-    .custom-guide ol {
-      padding-left: 18px;
-      margin: 0;
-    }
-
-    .custom-guide ol li {
-      margin-bottom: 4px;
-    }
-
-    .custom-guide code {
-      background: #e2e8f8;
-      padding: 1px 5px;
-      border-radius: 3px;
-      font-family: monospace;
-    }
+    .presets { margin-bottom: 8px; }
+    .presets .btn { margin-right: 4px; }
+    #player-wrapper { min-width: 640px; min-height: 360px; }
+    #output { margin-top: 20px; }
+    .actions { margin-top: 8px; display: flex; gap: 6px; align-items: flex-start; }
+    .actions .run { display: inline-block; float: none; margin: 0; }
   </style>
 </head>
+
 <body>
-
-  <div class="container">
-    <h1>Clappr Telemetry Plugin Demo</h1>
-
-    <div class="controls">
-      <label for="examples">Example:</label>
-      <select id="examples" onchange="switchExample(this.value)"></select>
-    </div>
-
-    <div class="controls">
-      <label>Adapter:</label>
-      <label class="toggle-label"><input type="checkbox" id="chk-network"> Network</label>
-    </div>
-
-    <div class="controls">
-      <label>Sampler:</label>
-      <label class="toggle-label"><input type="checkbox" id="chk-buffer"> Buffer</label>
-      <label class="toggle-label"><input type="checkbox" id="chk-decoding"> Decoding</label>
-      <label class="toggle-label"><input type="checkbox" id="chk-playback-state"> Playback State</label>
-      <label class="toggle-label"><input type="checkbox" id="chk-network-sample"> Network Sample</label>
-      <label class="toggle-label"><input type="checkbox" id="chk-timing"> Timing</label>
-      <label class="toggle-label"><input type="checkbox" id="chk-stream-info"> Stream Info</label>
-      <label class="toggle-label"><input type="checkbox" id="chk-audio"> Audio (custom)</label>
-    </div>
-
-    <div class="controls">
-      <label>Observer:</label>
-      <label class="toggle-label"><input type="checkbox" id="chk-video-state"> Video State</label>
-      <label for="sample-interval" style="margin-left: 10px">Interval:</label>
-      <select id="sample-interval" onchange="app.build()">
-        <option value="0" selected>snapshot only</option>
-        <option value="1000">1s</option>
-        <option value="5000">5s</option>
-        <option value="10000">10s</option>
-        <option value="30000">30s</option>
-        <option value="60000">60s</option>
-      </select>
-      <button onclick="takeSnapshot()" style="margin-left: auto">Snapshot</button>
-    </div>
-
-    <div id="custom-config">
-      <div class="custom-guide">
-        <strong>How to get your stream configuration from DevTools</strong>
-        <ol>
-          <li>Open your player in another tab and start playback.</li>
-          <li>Open DevTools (<code>F12</code>) → <strong>Network</strong> tab.</li>
-          <li><strong>Stream URL:</strong> filter by <code>.mpd</code> — copy the <em>Request URL</em> of the first result (returns <code>application/dash+xml</code>).</li>
-          <li><strong>License Server URL:</strong> filter by your DRM domain (e.g. <code>drm.</code> or <code>license</code>) — find the <code>POST</code> request and copy its <em>Request URL</em>. If the URL contains auth params (e.g. <code>?deviceId=</code>), include them.</li>
-          <li><strong>Headers:</strong> on that same <code>POST</code> request → <strong>Headers</strong> tab → look for custom request headers such as <code>Authorization</code> or <code>X-*</code>. Add each one below.</li>
-          <li>⚠️ MPD URLs with embedded tokens expire — grab fresh URLs each session.</li>
-        </ol>
-      </div>
-      <div class="custom-field">
-        <label>Stream URL (MPD)</label>
-        <input id="customSource" type="text" placeholder="https://example.com/stream.mpd" />
-      </div>
-      <div class="custom-field">
-        <label>License Server URL (optional)</label>
-        <input id="customLicenseServer" type="text" placeholder="https://drm.example.com/wvs?deviceId=abc123" />
-      </div>
-      <div class="custom-actions" style="margin-top: 4px">
-        <button id="applyCustomBtn" onclick="applyCustom()">Apply</button>
+  <header class="header">
+    <span>Clappr Telemetry</span>
+    <ul>
+      <li>
+        <a href="https://github.com/clappr/clappr/blob/main/packages/clappr-telemetry/README.md">docs</a>
+      </li>
+    </ul>
+  </header>
+  <section class="container">
+    <div class="main">
+      <div id="output">
+        <div id="player-wrapper" class="player"></div>
       </div>
     </div>
-
-    <div id="player"></div>
-
-    <div class="info">
-      <strong>Telemetry Events:</strong> Open the browser console to see telemetry events being tracked in the CONTAINER_TELEMETRY_TRACE channel.
+    <div class="sidebar">
+      <div class="presets">
+        <select id="media-select" class="form-control input-sm" onchange="selectMedia(this.value)"></select>
+      </div>
+      <div id="editor"></div>
+      <div class="actions">
+        <button class="run btn btn-primary">Run</button>
+        <button class="btn btn-default" onclick="snapshot()">Snapshot</button>
+      </div>
+      <div id="console"></div>
     </div>
-  </div>
+  </section>
 
   <script>
-    const { NetworkAdapters, ShakaNetworkAdapter, HlsNetworkAdapter } = ClapprTelemetry
-    NetworkAdapters.register(ShakaNetworkAdapter)
-    NetworkAdapters.register(HlsNetworkAdapter)
+    const { ShakaNetworkAdapter, HlsNetworkAdapter, BufferSampler, DecodingSampler } = ClapprTelemetry
 
     const TELEMETRY_TRACE_EVENT = Clappr.Events.Custom.CONTAINER_TELEMETRY_TRACE
 
     class SimpleTelemetryLogger extends Clappr.ContainerPlugin {
       get name() { return 'simple_telemetry_logger' }
-
-      get supportedVersion() {
-        return { min: '0.13.1' }
-      }
-
+      get supportedVersion() { return { min: '0.13.1' } }
       bindEvents() {
-        this.listenTo(this.container, TELEMETRY_TRACE_EVENT, (envelope) => {
-          console.log('[TELEMETRY]', envelope)
-        })
+        this.listenTo(this.container, TELEMETRY_TRACE_EVENT, (e) => console.log('[TELEMETRY]', e))
       }
     }
 
-    // Custom sampler example — follows the contract documented in the README:
-    // static isEnabled(cfg), collect(), destroy()
-    class AudioSampler {
-      static isEnabled(cfg) {
-        return cfg?.audioSample?.enabled === true
-      }
+    const MEDIAS = {
+      hls:   { label: 'HLS.js',       source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8' },
+      shaka: { label: 'Shaka DASH',   source: 'https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd' },
+      html5: { label: 'HTML5 Video',  source: 'http://clappr.io/highline.mp4' },
+    }
 
-      constructor(playback) {
-        this._playback = playback
-      }
+    var MEDIA = MEDIAS.hls.source
 
-      collect() {
-        const videoEl = this._playback?.el
-        if (!videoEl) return null
-        return { volume: videoEl.volume, muted: videoEl.muted }
-      }
+    const CODE = `window.player = new Clappr.Player({
+  parentId: '#player-wrapper',
+  source: MEDIA,
+  width: 640,
+  height: 360,
+  muted: true,
+  plugins: [HlsjsPlayback, DashShakaPlayback, Clappr.HTML5Video, ClapprTelemetry, SimpleTelemetryLogger],
+  telemetry: {
+    adapters: [HlsNetworkAdapter, ShakaNetworkAdapter],
+    samplers: [BufferSampler, DecodingSampler],
+    sampleIntervalMs: 1000,
+  }
+})`
 
-      destroy() {
-        this._playback = null
+    var editor
+
+    function selectMedia(key) {
+      MEDIA = (MEDIAS[key] ?? MEDIAS.hls).source
+      run()
+    }
+
+    function snapshot() {
+      if (!window.player) return
+      const container = window.player.core.getCurrentContainer()
+      const plugin = container.getPlugin('telemetry')
+      const data = plugin?.snapshot ?? {}
+      console.log('[SNAPSHOT]', data)
+    }
+
+    function run() {
+      const code = editor.getSession().getValue()
+      if (window.player) {
+        window.player.destroy()
+        window.player = null
+      }
+      try {
+        eval(code)
+        document.getElementById('console').textContent = ''
+      } catch (err) {
+        document.getElementById('console').textContent = err.message
       }
     }
 
-    ClapprTelemetry.SamplerRegistry.register('audio', AudioSampler)
-
-    class PlayerFactory {
-      static engines = {
-        'hls-hlsjs': {
-          label: 'HLS.js',
-          source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
-          plugins: [HlsjsPlayback, ClapprTelemetry, SimpleTelemetryLogger],
-        },
-        'dash-shaka': {
-          label: 'Shaka DASH',
-          source: 'https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd',
-          plugins: [DashShakaPlayback, ClapprTelemetry, SimpleTelemetryLogger],
-        },
-        'dash-shaka-widevine': {
-          label: 'Shaka DASH + Widevine',
-          custom: true
-        },
-        'html5-video': {
-          label: 'HTML5 Video',
-          source: 'http://clappr.io/highline.mp4',
-          plugins: [Clappr.HTML5Video, ClapprTelemetry, SimpleTelemetryLogger],
-        }
-      }
-
-      static getTelemetryConfig() {
-        return {
-          network:             { enabled: document.getElementById('chk-network').checked },
-          bufferSample:        { enabled: document.getElementById('chk-buffer').checked },
-          decodingSample:      { enabled: document.getElementById('chk-decoding').checked },
-          playbackStateSample: { enabled: document.getElementById('chk-playback-state').checked },
-          networkSample:       { enabled: document.getElementById('chk-network-sample').checked },
-          timingSample:        { enabled: document.getElementById('chk-timing').checked },
-          streamInfoSample:    { enabled: document.getElementById('chk-stream-info').checked },
-          audioSample:         { enabled: document.getElementById('chk-audio').checked },
-          sampleIntervalMs: Number(document.getElementById('sample-interval').value),
-          videoState:       { enabled: document.getElementById('chk-video-state').checked },
-        }
-      }
-
-      static create(exampleKey) {
-        const config = this.engines[exampleKey]
-        return new Clappr.Player({
-          parentId: '#player',
-          source: config.source,
-          width: '100%',
-          height: 500,
-          muted: true,
-          autoPlay: false,
-          plugins: config.plugins,
-          telemetry: this.getTelemetryConfig(),
-        })
-      }
-
-      static createWidevine({ source, licenseServer }) {
-        const shakaConfiguration = licenseServer
-          ? { drm: { servers: { 'com.widevine.alpha': licenseServer } } }
-          : undefined
-
-        return new Clappr.Player({
-          parentId: '#player',
-          source,
-          width: '100%',
-          height: 500,
-          muted: true,
-          autoPlay: false,
-          plugins: [DashShakaPlayback, ClapprTelemetry, SimpleTelemetryLogger],
-          telemetry: this.getTelemetryConfig(),
-          ...(shakaConfiguration && { shakaConfiguration })
-        })
-      }
-    }
-
-    function populateExamples() {
-      const select = document.getElementById('examples')
-      Object.keys(PlayerFactory.engines).forEach((key, i) => {
-        const option = document.createElement('option')
-        option.value = key
-        option.textContent = PlayerFactory.engines[key].label
-        if (i === 0) option.selected = true
-        select.appendChild(option)
+    window.onload = function () {
+      const select = document.getElementById('media-select')
+      Object.entries(MEDIAS).forEach(([key, { label, source }]) => {
+        const opt = document.createElement('option')
+        opt.value = key
+        opt.textContent = `${label} — ${source}`
+        select.appendChild(opt)
       })
+
+      editor = ace.edit('editor')
+      const session = editor.getSession()
+      editor.setTheme('ace/theme/katzenmilch')
+      session.setMode('ace/mode/javascript')
+      session.setTabSize(2)
+      session.setUseSoftTabs(true)
+      editor.getSession().setValue(CODE)
+
+      document.querySelector('.run').addEventListener('click', run)
+      run()
     }
-
-    function applyCustom() {
-      const source = document.getElementById('customSource').value.trim()
-      if (!source) { alert('Stream URL is required'); return }
-
-      const licenseServer = document.getElementById('customLicenseServer').value.trim()
-
-      if (app.player) app.player.destroy()
-      app.player = PlayerFactory.createWidevine({ source, licenseServer })
-    }
-
-    class PlayerApp {
-      constructor() {
-        this.player = null
-        this.example = null
-        this.init()
-      }
-
-      init() {
-        populateExamples()
-        this.example = Object.keys(PlayerFactory.engines)[0]
-        this.build()
-      }
-
-      build() {
-        if (this.player) this.player.destroy()
-        this.player = PlayerFactory.create(this.example)
-      }
-
-      switchExample(exampleKey) {
-        const customConfig = document.getElementById('custom-config')
-        if (PlayerFactory.engines[exampleKey]?.custom) {
-          customConfig.classList.add('visible')
-          if (this.player) { this.player.destroy(); this.player = null }
-          document.getElementById('player').innerHTML = ''
-          this.example = null
-          return
-        }
-        customConfig.classList.remove('visible')
-        if (exampleKey === this.example) return
-        this.example = exampleKey
-        this.build()
-      }
-    }
-
-    const app = new PlayerApp()
-
-    function switchExample(exampleKey) {
-      app.switchExample(exampleKey)
-    }
-
-    function takeSnapshot() {
-      const telemetry = app.player?.getPlugin('telemetry')
-      if (!telemetry) { console.warn('[SNAPSHOT] No player or telemetry plugin active'); return }
-      console.log('[SNAPSHOT]', telemetry.snapshot)
-    }
-
-    ;['chk-network', 'chk-buffer', 'chk-decoding', 'chk-playback-state', 'chk-network-sample', 'chk-timing', 'chk-stream-info', 'chk-audio', 'chk-video-state'].forEach(id => {
-      document.getElementById(id).addEventListener('change', () => app.build())
-    })
   </script>
 </body>
+
 </html>

--- a/packages/clappr-telemetry/src/adapters/index.js
+++ b/packages/clappr-telemetry/src/adapters/index.js
@@ -1,31 +1,3 @@
-import ShakaNetworkAdapter from './shaka_network_adapter'
-import HlsNetworkAdapter from './hls_network_adapter'
-
-/**
- * Telemetry adapters hook into player components to collect metrics.
- * Different adapter types can capture data from various sources:
- * - Network: streaming engine network requests
- */
-
-/**
- * Network adapters registry.
- * Collects telemetry metrics from streaming engines.
- * Each adapter must implement static isSupported() and bind() methods.
- */
-const NETWORK_ADAPTERS = [
-  ShakaNetworkAdapter,
-  HlsNetworkAdapter
-]
-
-/**
- * Find appropriate network adapter for given playback engine.
- * @param {Object} playback - Playback engine instance
- * @returns {Class|null} Network adapter class if supported, null otherwise
- */
-export function findNetworkAdapter(playback) {
-  const AdapterClass = NETWORK_ADAPTERS.find(adapter => adapter.isSupported(playback))
-  return AdapterClass || null
-}
-
+export { default as NetworkAdapters } from './network_adapters'
 export { default as ShakaNetworkAdapter } from './shaka_network_adapter'
 export { default as HlsNetworkAdapter } from './hls_network_adapter'

--- a/packages/clappr-telemetry/src/adapters/network_adapters.js
+++ b/packages/clappr-telemetry/src/adapters/network_adapters.js
@@ -1,12 +1,13 @@
 import { Log } from '@clappr/core'
 
 const _registry = []
+const _refCounts = new Map()
 
 export default class NetworkAdapters {
   /**
    * Registers an adapter class. Adapters are matched in registration order —
-   * first registered has highest priority.
-   * Must be called before the player is instantiated.
+   * first registered has highest priority. Reference-counted — safe to call
+   * multiple times (e.g. from concurrent player instances).
    *
    * @param {Function} AdapterClass - Class implementing the network adapter contract
    */
@@ -16,16 +17,24 @@ export default class NetworkAdapters {
       return
     }
     if (!_registry.includes(AdapterClass)) _registry.push(AdapterClass)
+    _refCounts.set(AdapterClass, (_refCounts.get(AdapterClass) || 0) + 1)
   }
 
   /**
    * Removes a previously registered adapter class from the registry.
+   * Reference-counted — the class is only removed when all registrations are released.
    *
    * @param {Function} AdapterClass - The class reference used when registering
    */
   static unregister(AdapterClass) {
-    const idx = _registry.indexOf(AdapterClass)
-    if (idx !== -1) _registry.splice(idx, 1)
+    const count = (_refCounts.get(AdapterClass) || 0) - 1
+    if (count <= 0) {
+      const idx = _registry.indexOf(AdapterClass)
+      if (idx !== -1) _registry.splice(idx, 1)
+      _refCounts.delete(AdapterClass)
+    } else {
+      _refCounts.set(AdapterClass, count)
+    }
   }
 
   /**

--- a/packages/clappr-telemetry/src/adapters/network_adapters.js
+++ b/packages/clappr-telemetry/src/adapters/network_adapters.js
@@ -1,0 +1,34 @@
+const _registry = []
+
+export default class NetworkAdapters {
+  /**
+   * Registers an adapter class. Adapters are matched in registration order —
+   * first registered has highest priority.
+   * Must be called before the player is instantiated.
+   *
+   * @param {Function} AdapterClass - Class implementing the network adapter contract
+   */
+  static register(AdapterClass) {
+    if (!_registry.includes(AdapterClass)) _registry.push(AdapterClass)
+  }
+
+  /**
+   * Removes a previously registered adapter class from the registry.
+   *
+   * @param {Function} AdapterClass - The class reference used when registering
+   */
+  static unregister(AdapterClass) {
+    const idx = _registry.indexOf(AdapterClass)
+    if (idx !== -1) _registry.splice(idx, 1)
+  }
+
+  /**
+   * Find the first adapter that supports the given playback instance.
+   *
+   * @param {Object} playback - Playback engine instance
+   * @returns {Function|null} Adapter class if found, null otherwise
+   */
+  static find(playback) {
+    return _registry.find(adapter => adapter.isSupported(playback)) ?? null
+  }
+}

--- a/packages/clappr-telemetry/src/adapters/network_adapters.js
+++ b/packages/clappr-telemetry/src/adapters/network_adapters.js
@@ -1,3 +1,5 @@
+import { Log } from '@clappr/core'
+
 const _registry = []
 
 export default class NetworkAdapters {
@@ -9,6 +11,10 @@ export default class NetworkAdapters {
    * @param {Function} AdapterClass - Class implementing the network adapter contract
    */
   static register(AdapterClass) {
+    if (typeof AdapterClass?.isSupported !== 'function') {
+      Log.warn('[NetworkAdapters]', 'missing static isSupported() — skipping')
+      return
+    }
     if (!_registry.includes(AdapterClass)) _registry.push(AdapterClass)
   }
 
@@ -23,12 +29,28 @@ export default class NetworkAdapters {
   }
 
   /**
-   * Find the first adapter that supports the given playback instance.
+   * Returns true if the given adapter class is already registered.
+   *
+   * @param {Function} AdapterClass
+   * @returns {boolean}
+   */
+  static has(AdapterClass) {
+    return _registry.includes(AdapterClass)
+  }
+
+  /** Number of registered adapters. */
+  static get size() { return _registry.length }
+
+  /**
+   * Find the first adapter that supports the given playback instance and is not disabled.
    *
    * @param {Object} playback - Playback engine instance
+   * @param {Object} [cfg={}] - Telemetry config (`container.options.telemetry`)
    * @returns {Function|null} Adapter class if found, null otherwise
    */
   static find(playback) {
-    return _registry.find(adapter => adapter.isSupported(playback)) ?? null
+    return _registry.find(adapter =>
+      typeof adapter.isSupported === 'function' && adapter.isSupported(playback)
+    ) ?? null
   }
 }

--- a/packages/clappr-telemetry/src/adapters/network_adapters.js
+++ b/packages/clappr-telemetry/src/adapters/network_adapters.js
@@ -5,19 +5,17 @@ const _refCounts = new Map()
 
 export default class NetworkAdapters {
   /**
-   * Registers an adapter class. Adapters are matched in registration order —
-   * first registered has highest priority. Reference-counted — safe to call
-   * multiple times (e.g. from concurrent player instances).
-   *
-   * @param {Function} AdapterClass - Class implementing the network adapter contract
+   * Registers an adapter class. Ref-counted.
+   * @returns {boolean} false if validation failed
    */
   static register(AdapterClass) {
     if (typeof AdapterClass?.isSupported !== 'function') {
       Log.warn('[NetworkAdapters]', 'missing static isSupported() — skipping')
-      return
+      return false
     }
     if (!_registry.includes(AdapterClass)) _registry.push(AdapterClass)
     _refCounts.set(AdapterClass, (_refCounts.get(AdapterClass) || 0) + 1)
+    return true
   }
 
   /**
@@ -51,14 +49,13 @@ export default class NetworkAdapters {
   static get size() { return _registry.length }
 
   /**
-   * Find the first adapter that supports the given playback instance and is not disabled.
-   *
-   * @param {Object} playback - Playback engine instance
-   * @param {Object} [cfg={}] - Telemetry config (`container.options.telemetry`)
-   * @returns {Function|null} Adapter class if found, null otherwise
+   * Returns the first registered adapter from `cfg.adapters` (in order) that
+   * supports the playback instance and is not disabled.
    */
   static find(playback, cfg = {}) {
-    return _registry.find(adapter => {
+    const adapters = cfg.adapters || []
+    return adapters.find(adapter => {
+      if (adapter == null || !NetworkAdapters.has(adapter)) return false
       if (typeof adapter.isEnabled === 'function' && !adapter.isEnabled(cfg)) return false
       if (cfg[adapter.name]?.enabled === false) return false
       return typeof adapter.isSupported === 'function' && adapter.isSupported(playback)

--- a/packages/clappr-telemetry/src/adapters/network_adapters.js
+++ b/packages/clappr-telemetry/src/adapters/network_adapters.js
@@ -48,9 +48,11 @@ export default class NetworkAdapters {
    * @param {Object} [cfg={}] - Telemetry config (`container.options.telemetry`)
    * @returns {Function|null} Adapter class if found, null otherwise
    */
-  static find(playback) {
-    return _registry.find(adapter =>
-      typeof adapter.isSupported === 'function' && adapter.isSupported(playback)
-    ) ?? null
+  static find(playback, cfg = {}) {
+    return _registry.find(adapter => {
+      if (typeof adapter.isEnabled === 'function' && !adapter.isEnabled(cfg)) return false
+      if (cfg[adapter.name]?.enabled === false) return false
+      return typeof adapter.isSupported === 'function' && adapter.isSupported(playback)
+    }) ?? null
   }
 }

--- a/packages/clappr-telemetry/src/adapters/network_adapters.test.js
+++ b/packages/clappr-telemetry/src/adapters/network_adapters.test.js
@@ -25,16 +25,17 @@ describe('NetworkAdapters', () => {
       const adapter = makeAdapter('custom', true)
       register(adapter)
 
-      expect(NetworkAdapters.find({ name: 'anything' })).toBe(adapter)
+      expect(NetworkAdapters.find({ name: 'anything' }, { adapters: [adapter] })).toBe(adapter)
     })
 
-    it('returns the first matching adapter when multiple match', () => {
+    it('returns the first matching adapter from cfg.adapters, in array order', () => {
       const first = makeAdapter('first', true)
       const second = makeAdapter('second', true)
       register(first)
       register(second)
 
-      expect(NetworkAdapters.find({})).toBe(first)
+      expect(NetworkAdapters.find({}, { adapters: [first, second] })).toBe(first)
+      expect(NetworkAdapters.find({}, { adapters: [second, first] })).toBe(second)
     })
 
     it('calls isSupported with the playback instance', () => {
@@ -42,7 +43,7 @@ describe('NetworkAdapters', () => {
       const adapter = makeAdapter('custom', true)
       register(adapter)
 
-      NetworkAdapters.find(playback)
+      NetworkAdapters.find(playback, { adapters: [adapter] })
 
       expect(adapter.isSupported).toHaveBeenCalledWith(playback)
     })
@@ -51,21 +52,27 @@ describe('NetworkAdapters', () => {
       const adapter = makeAdapter('custom', true)
       register(adapter)
 
-      expect(NetworkAdapters.find({}, { custom: { enabled: false } })).toBeNull()
+      expect(NetworkAdapters.find({}, { adapters: [adapter], custom: { enabled: false } })).toBeNull()
     })
 
     it('finds adapter when cfg[name] is not set', () => {
       const adapter = makeAdapter('custom', true)
       register(adapter)
 
-      expect(NetworkAdapters.find({}, {})).toBe(adapter)
+      expect(NetworkAdapters.find({}, { adapters: [adapter] })).toBe(adapter)
     })
 
-    it('is backwards-compatible when called without cfg', () => {
+    it('returns null when called without cfg.adapters, even if the class is registered elsewhere', () => {
       const adapter = makeAdapter('custom', true)
       register(adapter)
 
-      expect(NetworkAdapters.find({})).toBe(adapter)
+      expect(NetworkAdapters.find({})).toBeNull()
+    })
+
+    it('ignores an adapter that is not registered, even if present in cfg.adapters', () => {
+      const adapter = makeAdapter('unregistered', true)
+
+      expect(NetworkAdapters.find({}, { adapters: [adapter] })).toBeNull()
     })
 
     it('defers to static isEnabled(cfg) when defined on the adapter', () => {
@@ -73,8 +80,23 @@ describe('NetworkAdapters', () => {
       adapter.isEnabled = jest.fn(() => false)
       register(adapter)
 
-      expect(NetworkAdapters.find({}, {})).toBeNull()
+      expect(NetworkAdapters.find({}, { adapters: [adapter] })).toBeNull()
       expect(adapter.isEnabled).toHaveBeenCalled()
+    })
+  })
+
+  // ─── isolation ───────────────────────────────────────────────────────────────
+
+  describe('isolation', () => {
+    it('a container only ever matches adapters listed in its own cfg.adapters', () => {
+      const a = makeAdapter('a', true)
+      const b = makeAdapter('b', true)
+      register(a)
+      register(b)
+
+      // both are registered globally, but each "instance" only sees its own list
+      expect(NetworkAdapters.find({}, { adapters: [a] })).toBe(a)
+      expect(NetworkAdapters.find({}, { adapters: [b] })).toBe(b)
     })
   })
 
@@ -85,16 +107,7 @@ describe('NetworkAdapters', () => {
       const adapter = makeAdapter('custom', true)
       register(adapter)
 
-      expect(NetworkAdapters.find({})).toBe(adapter)
-    })
-
-    it('first registered adapter has higher priority', () => {
-      const custom = makeAdapter('custom', true)
-      const builtIn = makeAdapter('built_in', true)
-      register(custom)
-      register(builtIn)
-
-      expect(NetworkAdapters.find({})).toBe(custom)
+      expect(NetworkAdapters.find({}, { adapters: [adapter] })).toBe(adapter)
     })
 
     it('registering the same class twice is a no-op', () => {
@@ -102,7 +115,20 @@ describe('NetworkAdapters', () => {
       register(adapter)
       register(adapter)
 
-      expect(NetworkAdapters.find({})).toBe(adapter)
+      expect(NetworkAdapters.find({}, { adapters: [adapter] })).toBe(adapter)
+    })
+
+    it('returns false and warns when static isSupported() is missing', () => {
+      const adapter = { name: 'bad' }
+
+      expect(NetworkAdapters.register(adapter)).toBe(false)
+    })
+
+    it('returns true when registration succeeds', () => {
+      const adapter = makeAdapter('custom', true)
+      _registered.push(adapter)
+
+      expect(NetworkAdapters.register(adapter)).toBe(true)
     })
   })
 
@@ -114,7 +140,7 @@ describe('NetworkAdapters', () => {
       register(adapter)
       NetworkAdapters.unregister(adapter)
 
-      expect(NetworkAdapters.find({})).toBeNull()
+      expect(NetworkAdapters.find({}, { adapters: [adapter] })).toBeNull()
     })
 
     it('does not throw when unregistering an adapter that was never registered', () => {
@@ -128,7 +154,7 @@ describe('NetworkAdapters', () => {
       register(adapter) // refCount → 1
       register(adapter) // refCount → 2
       NetworkAdapters.unregister(adapter) // refCount → 1 — still in registry
-      expect(NetworkAdapters.find({})).toBe(adapter)
+      expect(NetworkAdapters.find({}, { adapters: [adapter] })).toBe(adapter)
       // afterEach drains the remaining ref via _registered = [adapter, adapter]
     })
   })
@@ -139,9 +165,9 @@ describe('NetworkAdapters', () => {
       NetworkAdapters.register(adapter) // refCount → 1
       NetworkAdapters.register(adapter) // refCount → 2
       NetworkAdapters.unregister(adapter) // refCount → 1 — still findable
-      expect(NetworkAdapters.find({})).toBe(adapter)
+      expect(NetworkAdapters.find({}, { adapters: [adapter] })).toBe(adapter)
       NetworkAdapters.unregister(adapter) // refCount → 0 — removed
-      expect(NetworkAdapters.find({})).toBeNull()
+      expect(NetworkAdapters.find({}, { adapters: [adapter] })).toBeNull()
     })
   })
 })

--- a/packages/clappr-telemetry/src/adapters/network_adapters.test.js
+++ b/packages/clappr-telemetry/src/adapters/network_adapters.test.js
@@ -1,0 +1,105 @@
+import NetworkAdapters from './network_adapters'
+
+const makeAdapter = (name, supported = false) => ({
+  name,
+  isSupported: jest.fn(() => supported)
+})
+
+let _registered = []
+const register = (adapter) => { _registered.push(adapter); NetworkAdapters.register(adapter) }
+
+describe('NetworkAdapters', () => {
+  afterEach(() => {
+    _registered.forEach(a => NetworkAdapters.unregister(a))
+    _registered = []
+  })
+
+  // ─── find ─────────────────────────────────────────────────────────────────────
+
+  describe('find', () => {
+    it('returns null when no adapter supports the playback', () => {
+      expect(NetworkAdapters.find({ name: 'unknown' })).toBeNull()
+    })
+
+    it('returns the matching adapter', () => {
+      const adapter = makeAdapter('custom', true)
+      register(adapter)
+
+      expect(NetworkAdapters.find({ name: 'anything' })).toBe(adapter)
+    })
+
+    it('returns the first matching adapter when multiple match', () => {
+      const first = makeAdapter('first', true)
+      const second = makeAdapter('second', true)
+      register(first)
+      register(second)
+
+      expect(NetworkAdapters.find({})).toBe(first)
+    })
+
+    it('calls isSupported with the playback instance', () => {
+      const playback = { name: 'my_engine' }
+      const adapter = makeAdapter('custom', true)
+      register(adapter)
+
+      NetworkAdapters.find(playback)
+
+      expect(adapter.isSupported).toHaveBeenCalledWith(playback)
+    })
+  })
+
+  // ─── register ────────────────────────────────────────────────────────────────
+
+  describe('register', () => {
+    it('makes a registered adapter discoverable via find()', () => {
+      const adapter = makeAdapter('custom', true)
+      register(adapter)
+
+      expect(NetworkAdapters.find({})).toBe(adapter)
+    })
+
+    it('first registered adapter has higher priority', () => {
+      const custom = makeAdapter('custom', true)
+      const builtIn = makeAdapter('built_in', true)
+      register(custom)
+      register(builtIn)
+
+      expect(NetworkAdapters.find({})).toBe(custom)
+    })
+
+    it('registering the same class twice is a no-op', () => {
+      const adapter = makeAdapter('custom', true)
+      register(adapter)
+      register(adapter)
+
+      expect(NetworkAdapters.find({})).toBe(adapter)
+    })
+  })
+
+  // ─── unregister ──────────────────────────────────────────────────────────────
+
+  describe('unregister', () => {
+    it('removes a previously registered adapter', () => {
+      const adapter = makeAdapter('custom', true)
+      register(adapter)
+      NetworkAdapters.unregister(adapter)
+
+      expect(NetworkAdapters.find({})).toBeNull()
+    })
+
+    it('does not throw when unregistering an adapter that was never registered', () => {
+      const adapter = makeAdapter('ghost')
+
+      expect(() => NetworkAdapters.unregister(adapter)).not.toThrow()
+    })
+
+    it('unregistering after deduplicated register fully removes the adapter', () => {
+      const adapter = makeAdapter('custom', true)
+      register(adapter)
+      register(adapter)
+      NetworkAdapters.unregister(adapter)
+
+      expect(NetworkAdapters.find({})).toBeNull()
+    })
+  })
+})

--- a/packages/clappr-telemetry/src/adapters/network_adapters.test.js
+++ b/packages/clappr-telemetry/src/adapters/network_adapters.test.js
@@ -76,7 +76,6 @@ describe('NetworkAdapters', () => {
       expect(NetworkAdapters.find({}, {})).toBeNull()
       expect(adapter.isEnabled).toHaveBeenCalled()
     })
-
   })
 
   // ─── register ────────────────────────────────────────────────────────────────
@@ -126,8 +125,8 @@ describe('NetworkAdapters', () => {
 
     it('ref-counted: one unregister after two registers still leaves adapter discoverable', () => {
       const adapter = makeAdapter('custom', true)
-      register(adapter)             // refCount → 1
-      register(adapter)             // refCount → 2
+      register(adapter) // refCount → 1
+      register(adapter) // refCount → 2
       NetworkAdapters.unregister(adapter) // refCount → 1 — still in registry
       expect(NetworkAdapters.find({})).toBe(adapter)
       // afterEach drains the remaining ref via _registered = [adapter, adapter]
@@ -137,8 +136,8 @@ describe('NetworkAdapters', () => {
   describe('ref counting', () => {
     it('is reference-counted — removed only after all registrations are released', () => {
       const adapter = makeAdapter('custom', true)
-      NetworkAdapters.register(adapter)  // refCount → 1
-      NetworkAdapters.register(adapter)  // refCount → 2
+      NetworkAdapters.register(adapter) // refCount → 1
+      NetworkAdapters.register(adapter) // refCount → 2
       NetworkAdapters.unregister(adapter) // refCount → 1 — still findable
       expect(NetworkAdapters.find({})).toBe(adapter)
       NetworkAdapters.unregister(adapter) // refCount → 0 — removed

--- a/packages/clappr-telemetry/src/adapters/network_adapters.test.js
+++ b/packages/clappr-telemetry/src/adapters/network_adapters.test.js
@@ -47,6 +47,36 @@ describe('NetworkAdapters', () => {
       expect(adapter.isSupported).toHaveBeenCalledWith(playback)
     })
 
+    it('returns null when adapter is disabled via cfg[name].enabled = false', () => {
+      const adapter = makeAdapter('custom', true)
+      register(adapter)
+
+      expect(NetworkAdapters.find({}, { custom: { enabled: false } })).toBeNull()
+    })
+
+    it('finds adapter when cfg[name] is not set', () => {
+      const adapter = makeAdapter('custom', true)
+      register(adapter)
+
+      expect(NetworkAdapters.find({}, {})).toBe(adapter)
+    })
+
+    it('is backwards-compatible when called without cfg', () => {
+      const adapter = makeAdapter('custom', true)
+      register(adapter)
+
+      expect(NetworkAdapters.find({})).toBe(adapter)
+    })
+
+    it('defers to static isEnabled(cfg) when defined on the adapter', () => {
+      const adapter = makeAdapter('custom', true)
+      adapter.isEnabled = jest.fn(() => false)
+      register(adapter)
+
+      expect(NetworkAdapters.find({}, {})).toBeNull()
+      expect(adapter.isEnabled).toHaveBeenCalled()
+    })
+
   })
 
   // ─── register ────────────────────────────────────────────────────────────────

--- a/packages/clappr-telemetry/src/adapters/network_adapters.test.js
+++ b/packages/clappr-telemetry/src/adapters/network_adapters.test.js
@@ -46,6 +46,7 @@ describe('NetworkAdapters', () => {
 
       expect(adapter.isSupported).toHaveBeenCalledWith(playback)
     })
+
   })
 
   // ─── register ────────────────────────────────────────────────────────────────

--- a/packages/clappr-telemetry/src/adapters/network_adapters.test.js
+++ b/packages/clappr-telemetry/src/adapters/network_adapters.test.js
@@ -124,12 +124,24 @@ describe('NetworkAdapters', () => {
       expect(() => NetworkAdapters.unregister(adapter)).not.toThrow()
     })
 
-    it('unregistering after deduplicated register fully removes the adapter', () => {
+    it('ref-counted: one unregister after two registers still leaves adapter discoverable', () => {
       const adapter = makeAdapter('custom', true)
-      register(adapter)
-      register(adapter)
-      NetworkAdapters.unregister(adapter)
+      register(adapter)             // refCount → 1
+      register(adapter)             // refCount → 2
+      NetworkAdapters.unregister(adapter) // refCount → 1 — still in registry
+      expect(NetworkAdapters.find({})).toBe(adapter)
+      // afterEach drains the remaining ref via _registered = [adapter, adapter]
+    })
+  })
 
+  describe('ref counting', () => {
+    it('is reference-counted — removed only after all registrations are released', () => {
+      const adapter = makeAdapter('custom', true)
+      NetworkAdapters.register(adapter)  // refCount → 1
+      NetworkAdapters.register(adapter)  // refCount → 2
+      NetworkAdapters.unregister(adapter) // refCount → 1 — still findable
+      expect(NetworkAdapters.find({})).toBe(adapter)
+      NetworkAdapters.unregister(adapter) // refCount → 0 — removed
       expect(NetworkAdapters.find({})).toBeNull()
     })
   })

--- a/packages/clappr-telemetry/src/main.js
+++ b/packages/clappr-telemetry/src/main.js
@@ -1,6 +1,6 @@
 import TelemetryPlugin from './telemetry_plugin'
 
-export { findNetworkAdapter, ShakaNetworkAdapter, HlsNetworkAdapter } from './adapters'
+export { NetworkAdapters, ShakaNetworkAdapter, HlsNetworkAdapter } from './adapters'
 export { SamplerRegistry, BufferSampler, DecodingSampler, PlaybackStateSampler, NetworkSampler, PlaybackTimingSampler, StreamInfoSampler } from './samplers'
 export { ObserverRegistry, VideoEventObserver } from './observers'
 export {

--- a/packages/clappr-telemetry/src/main.umd.js
+++ b/packages/clappr-telemetry/src/main.umd.js
@@ -4,12 +4,20 @@
  *   ClapprTelemetry.ShakaNetworkAdapter, ClapprTelemetry.BufferSampler, etc.
  */
 import TelemetryPlugin from './telemetry_plugin'
-import { ShakaNetworkAdapter, HlsNetworkAdapter } from './adapters'
-import { BufferSampler, DecodingSampler } from './samplers'
+import { NetworkAdapters, ShakaNetworkAdapter, HlsNetworkAdapter } from './adapters'
+import { SamplerRegistry, BufferSampler, DecodingSampler, PlaybackStateSampler, NetworkSampler, PlaybackTimingSampler, StreamInfoSampler } from './samplers'
+import { ObserverRegistry, VideoEventObserver } from './observers'
 
 TelemetryPlugin.ShakaNetworkAdapter = ShakaNetworkAdapter
 TelemetryPlugin.HlsNetworkAdapter = HlsNetworkAdapter
+
 TelemetryPlugin.BufferSampler = BufferSampler
 TelemetryPlugin.DecodingSampler = DecodingSampler
+TelemetryPlugin.PlaybackStateSampler = PlaybackStateSampler
+TelemetryPlugin.NetworkSampler = NetworkSampler
+TelemetryPlugin.PlaybackTimingSampler = PlaybackTimingSampler
+TelemetryPlugin.StreamInfoSampler = StreamInfoSampler
+
+TelemetryPlugin.VideoEventObserver = VideoEventObserver
 
 export default TelemetryPlugin

--- a/packages/clappr-telemetry/src/main.umd.js
+++ b/packages/clappr-telemetry/src/main.umd.js
@@ -4,9 +4,9 @@
  *   ClapprTelemetry.ShakaNetworkAdapter, ClapprTelemetry.BufferSampler, etc.
  */
 import TelemetryPlugin from './telemetry_plugin'
-import { NetworkAdapters, ShakaNetworkAdapter, HlsNetworkAdapter } from './adapters'
-import { SamplerRegistry, BufferSampler, DecodingSampler, PlaybackStateSampler, NetworkSampler, PlaybackTimingSampler, StreamInfoSampler } from './samplers'
-import { ObserverRegistry, VideoEventObserver } from './observers'
+import { ShakaNetworkAdapter, HlsNetworkAdapter } from './adapters'
+import { BufferSampler, DecodingSampler, PlaybackStateSampler, NetworkSampler, PlaybackTimingSampler, StreamInfoSampler } from './samplers'
+import { VideoEventObserver } from './observers'
 
 TelemetryPlugin.ShakaNetworkAdapter = ShakaNetworkAdapter
 TelemetryPlugin.HlsNetworkAdapter = HlsNetworkAdapter

--- a/packages/clappr-telemetry/src/main.umd.js
+++ b/packages/clappr-telemetry/src/main.umd.js
@@ -1,5 +1,12 @@
 /**
- * UMD entry: default export only so the global `ClapprTelemetry` stays the plugin class
- * (same as before named exports were added on the ESM entry).
+ * UMD entry: the global `ClapprTelemetry` is the plugin class.
+ * Adapters are exposed as static properties for explicit registration:
+ *   ClapprTelemetry.NetworkAdapters.register(ClapprTelemetry.ShakaNetworkAdapter)
  */
-export { default } from './telemetry_plugin'
+import TelemetryPlugin from './telemetry_plugin'
+import { ShakaNetworkAdapter, HlsNetworkAdapter } from './adapters'
+
+TelemetryPlugin.ShakaNetworkAdapter = ShakaNetworkAdapter
+TelemetryPlugin.HlsNetworkAdapter = HlsNetworkAdapter
+
+export default TelemetryPlugin

--- a/packages/clappr-telemetry/src/main.umd.js
+++ b/packages/clappr-telemetry/src/main.umd.js
@@ -1,12 +1,15 @@
 /**
  * UMD entry: the global `ClapprTelemetry` is the plugin class.
- * Adapters are exposed as static properties for explicit registration:
- *   ClapprTelemetry.NetworkAdapters.register(ClapprTelemetry.ShakaNetworkAdapter)
+ * Named exports are attached as static properties for script-tag consumers:
+ *   ClapprTelemetry.ShakaNetworkAdapter, ClapprTelemetry.BufferSampler, etc.
  */
 import TelemetryPlugin from './telemetry_plugin'
 import { ShakaNetworkAdapter, HlsNetworkAdapter } from './adapters'
+import { BufferSampler, DecodingSampler } from './samplers'
 
 TelemetryPlugin.ShakaNetworkAdapter = ShakaNetworkAdapter
 TelemetryPlugin.HlsNetworkAdapter = HlsNetworkAdapter
+TelemetryPlugin.BufferSampler = BufferSampler
+TelemetryPlugin.DecodingSampler = DecodingSampler
 
 export default TelemetryPlugin

--- a/packages/clappr-telemetry/src/observers/observer_registry.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.js
@@ -1,6 +1,8 @@
 import { Log } from '@clappr/core'
+import { isComponentEnabled } from '../utils'
 
 const _registry = new Map()
+const _refCounts = new Map()
 
 /**
  * Manages all active observers, instantiating and delegating lifecycle calls to each.
@@ -15,6 +17,7 @@ export default class ObserverRegistry {
 
   /**
    * Registers an observer class. The class's `name` property is used as the registry key.
+   * Reference-counted — safe to call multiple times (e.g. from concurrent player instances).
    *
    * @param {Function} ObserverClass - Class implementing `bind()` and `destroy()`
    */
@@ -30,16 +33,30 @@ export default class ObserverRegistry {
       Log.warn('[ObserverRegistry]', `missing ${missing.join(', ')} — skipping`)
       return
     }
-    _registry.set(ObserverClass.name, ObserverClass)
+    const name = ObserverClass.name
+    if (_registry.has(name) && _registry.get(name) !== ObserverClass) {
+      Log.warn('[ObserverRegistry]', `name collision on '${name}' — overwriting existing class`)
+    }
+    _registry.set(name, ObserverClass)
+    _refCounts.set(name, (_refCounts.get(name) || 0) + 1)
   }
 
   /**
    * Removes a previously registered observer class from the registry.
+   * Reference-counted — the class is only removed when all registrations are released.
    *
    * @param {Function} ObserverClass - The class reference used when registering
    */
   static unregister(ObserverClass) {
-    if (ObserverClass?.name) _registry.delete(ObserverClass.name)
+    if (!ObserverClass?.name) return
+    const name = ObserverClass.name
+    const count = (_refCounts.get(name) || 0) - 1
+    if (count <= 0) {
+      _registry.delete(name)
+      _refCounts.delete(name)
+    } else {
+      _refCounts.set(name, count)
+    }
   }
 
   /**
@@ -55,10 +72,7 @@ export default class ObserverRegistry {
   constructor(playback, container, samplerRegistry) {
     const cfg = container.options?.telemetry || {}
     this._observers = [..._registry.values()]
-      .filter(Obs => {
-        if (typeof Obs.isEnabled === 'function') return Obs.isEnabled(cfg)
-        return cfg[Obs.name]?.enabled !== false
-      })
+      .filter(Obs => isComponentEnabled(Obs, cfg))
       .map(ObserverClass => new ObserverClass(playback, container, samplerRegistry))
   }
 

--- a/packages/clappr-telemetry/src/observers/observer_registry.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.js
@@ -21,7 +21,7 @@ export default class ObserverRegistry {
   static register(ObserverClass) {
     const proto = ObserverClass?.prototype
     const missing = [
-      typeof ObserverClass?.name !== 'string' && 'static get name()',
+      !ObserverClass?.name && 'static get name()',
       typeof proto?.bind !== 'function' && 'bind()',
       typeof proto?.destroy !== 'function' && 'destroy()'
     ].filter(Boolean)
@@ -39,7 +39,17 @@ export default class ObserverRegistry {
    * @param {Function} ObserverClass - The class reference used when registering
    */
   static unregister(ObserverClass) {
-    _registry.delete(ObserverClass.name)
+    if (ObserverClass?.name) _registry.delete(ObserverClass.name)
+  }
+
+  /**
+   * Returns true if an observer with the given class's name is already registered.
+   *
+   * @param {Function} ObserverClass
+   * @returns {boolean}
+   */
+  static has(ObserverClass) {
+    return _registry.has(ObserverClass?.name)
   }
 
   constructor(playback, container, samplerRegistry) {

--- a/packages/clappr-telemetry/src/observers/observer_registry.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.js
@@ -53,7 +53,12 @@ export default class ObserverRegistry {
   }
 
   constructor(playback, container, samplerRegistry) {
+    const cfg = container.options?.telemetry || {}
     this._observers = [..._registry.values()]
+      .filter(Obs => {
+        if (typeof Obs.isEnabled === 'function') return Obs.isEnabled(cfg)
+        return cfg[Obs.name]?.enabled !== false
+      })
       .map(ObserverClass => new ObserverClass(playback, container, samplerRegistry))
   }
 

--- a/packages/clappr-telemetry/src/observers/observer_registry.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.js
@@ -1,9 +1,6 @@
 import { Log } from '@clappr/core'
-import VideoEventObserver from './video_event_observer'
 
-const _registry = new Map([
-  ['videoState', VideoEventObserver]
-])
+const _registry = new Map()
 
 /**
  * Manages all active observers, instantiating and delegating lifecycle calls to each.
@@ -11,47 +8,43 @@ const _registry = new Map([
  * Extensible via `ObserverRegistry.register()` — external observers can be added
  * before the player is instantiated.
  *
- * Observer contract: must implement `static isEnabled(cfg)`, `bind()` and `destroy()` on the prototype.
+ * Observer contract: must implement `bind()` and `destroy()` on the prototype.
  */
 export default class ObserverRegistry {
   static get name() { return 'observer-registry' }
 
   /**
-   * Registers an external observer class into the global registry.
-   * Must be called before the player is instantiated.
+   * Registers an observer class. The class's `name` property is used as the registry key.
    *
-   * @param {string} key - Identifier for the observer (e.g. `'customEvents'`)
-   * @param {Function} ObserverClass - Class implementing `static isEnabled()`, `bind()` and `destroy()`
+   * @param {Function} ObserverClass - Class implementing `bind()` and `destroy()`
    */
-  static register(key, ObserverClass) {
-    const proto = ObserverClass.prototype
+  static register(ObserverClass) {
+    const proto = ObserverClass?.prototype
     const missing = [
-      typeof ObserverClass.isEnabled !== 'function' && 'static isEnabled()',
-      typeof proto.bind !== 'function' && 'bind()',
-      typeof proto.destroy !== 'function' && 'destroy()'
+      typeof ObserverClass?.name !== 'string' && 'static get name()',
+      typeof proto?.bind !== 'function' && 'bind()',
+      typeof proto?.destroy !== 'function' && 'destroy()'
     ].filter(Boolean)
 
     if (missing.length > 0) {
-      Log.warn('[ObserverRegistry]', `${key}: missing ${missing.join(', ')} — skipping`)
+      Log.warn('[ObserverRegistry]', `missing ${missing.join(', ')} — skipping`)
       return
     }
-    _registry.set(key, ObserverClass)
+    _registry.set(ObserverClass.name, ObserverClass)
   }
 
   /**
-   * Removes a previously registered observer from the global registry.
+   * Removes a previously registered observer class from the registry.
    *
-   * @param {string} key - The key used when registering the observer
+   * @param {Function} ObserverClass - The class reference used when registering
    */
-  static unregister(key) {
-    _registry.delete(key)
+  static unregister(ObserverClass) {
+    _registry.delete(ObserverClass.name)
   }
 
   constructor(playback, container, samplerRegistry) {
-    const cfg = container.options?.telemetry || {}
-    this._observers = [..._registry.entries()]
-      .filter(([, O]) => O.isEnabled(cfg))
-      .map(([, ObserverClass]) => new ObserverClass(playback, container, samplerRegistry))
+    this._observers = [..._registry.values()]
+      .map(ObserverClass => new ObserverClass(playback, container, samplerRegistry))
   }
 
   bind() {

--- a/packages/clappr-telemetry/src/observers/observer_registry.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.js
@@ -11,27 +11,34 @@ const _refCounts = new Map()
  * before the player is instantiated.
  *
  * Observer contract: must implement `bind()` and `destroy()` on the prototype.
+ *
+ * The registry only validates and ref-counts classes; each instance only
+ * instantiates its own container's `telemetry.observers`.
  */
 export default class ObserverRegistry {
   static get name() { return 'observer-registry' }
 
+  /** True if `Cls` declares its own `static get name()`, not the auto-assigned one. */
+  static _hasOwnNameGetter(Cls) {
+    return typeof Cls === 'function' &&
+      typeof Object.getOwnPropertyDescriptor(Cls, 'name')?.get === 'function'
+  }
+
   /**
-   * Registers an observer class. The class's `name` property is used as the registry key.
-   * Reference-counted — safe to call multiple times (e.g. from concurrent player instances).
-   *
-   * @param {Function} ObserverClass - Class implementing `bind()` and `destroy()`
+   * Registers an observer class, keyed by `static get name()`. Ref-counted.
+   * @returns {boolean} false if validation failed
    */
   static register(ObserverClass) {
     const proto = ObserverClass?.prototype
     const missing = [
-      !ObserverClass?.name && 'static get name()',
+      !ObserverRegistry._hasOwnNameGetter(ObserverClass) && 'static get name()',
       typeof proto?.bind !== 'function' && 'bind()',
       typeof proto?.destroy !== 'function' && 'destroy()'
     ].filter(Boolean)
 
     if (missing.length > 0) {
       Log.warn('[ObserverRegistry]', `missing ${missing.join(', ')} — skipping`)
-      return
+      return false
     }
     const name = ObserverClass.name
     if (_registry.has(name) && _registry.get(name) !== ObserverClass) {
@@ -39,6 +46,7 @@ export default class ObserverRegistry {
     }
     _registry.set(name, ObserverClass)
     _refCounts.set(name, (_refCounts.get(name) || 0) + 1)
+    return true
   }
 
   /**
@@ -71,8 +79,9 @@ export default class ObserverRegistry {
 
   constructor(playback, container, samplerRegistry) {
     const cfg = container.options?.telemetry || {}
-    this._observers = [..._registry.values()]
-      .filter(Obs => isComponentEnabled(Obs, cfg))
+    const observers = cfg.observers || []
+    this._observers = observers
+      .filter(Obs => Obs != null && ObserverRegistry.has(Obs) && isComponentEnabled(Obs, cfg))
       .map(ObserverClass => new ObserverClass(playback, container, samplerRegistry))
   }
 

--- a/packages/clappr-telemetry/src/observers/observer_registry.test.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.test.js
@@ -17,7 +17,9 @@ const makeObserverClass = (overrides = {}) => {
 
 describe('ObserverRegistry', () => {
   afterEach(() => {
-    ObserverRegistry.unregister({ name: 'MockObserver' })
+    while (ObserverRegistry.has({ name: 'MockObserver' })) {
+      ObserverRegistry.unregister({ name: 'MockObserver' })
+    }
   })
 
   describe('register()', () => {
@@ -136,6 +138,28 @@ describe('ObserverRegistry', () => {
       new ObserverRegistry({}, makeContainer(), null) // eslint-disable-line no-new
       expect(Cls.isEnabled).toHaveBeenCalled()
       expect(Cls).not.toHaveBeenCalled()
+    })
+
+    it('does not instantiate when isEnabled returns true but cfg[name].enabled is false', () => {
+      const { Cls } = makeObserverClass()
+      Cls.isEnabled = jest.fn(() => true)
+      ObserverRegistry.register(Cls)
+      const registry = new ObserverRegistry({}, makeContainer({ MockObserver: { enabled: false } }), null)
+      expect(Cls.isEnabled).toHaveBeenCalled()
+      expect(Cls).not.toHaveBeenCalled()
+      registry.destroy()
+    })
+  })
+
+  describe('ref counting', () => {
+    it('is reference-counted — class removed only after all registrations are released', () => {
+      const { Cls } = makeObserverClass()
+      ObserverRegistry.register(Cls)  // refCount → 1
+      ObserverRegistry.register(Cls)  // refCount → 2
+      ObserverRegistry.unregister(Cls) // refCount → 1 — still registered
+      expect(ObserverRegistry.has(Cls)).toBe(true)
+      ObserverRegistry.unregister(Cls) // refCount → 0 — removed
+      expect(ObserverRegistry.has(Cls)).toBe(false)
     })
   })
 

--- a/packages/clappr-telemetry/src/observers/observer_registry.test.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.test.js
@@ -104,6 +104,41 @@ describe('ObserverRegistry', () => {
     })
   })
 
+  describe('isEnabled filtering', () => {
+    it('does not instantiate when cfg[name].enabled is false', () => {
+      const { Cls } = makeObserverClass()
+      ObserverRegistry.register(Cls)
+      const registry = new ObserverRegistry({}, makeContainer({ MockObserver: { enabled: false } }), null)
+      expect(Cls).not.toHaveBeenCalled()
+      registry.destroy()
+    })
+
+    it('instantiates when no enabled flag is set', () => {
+      const { Cls } = makeObserverClass()
+      ObserverRegistry.register(Cls)
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      expect(Cls).toHaveBeenCalledTimes(1)
+      registry.destroy()
+    })
+
+    it('instantiates when cfg[name].enabled is true', () => {
+      const { Cls } = makeObserverClass()
+      ObserverRegistry.register(Cls)
+      const registry = new ObserverRegistry({}, makeContainer({ MockObserver: { enabled: true } }), null)
+      expect(Cls).toHaveBeenCalledTimes(1)
+      registry.destroy()
+    })
+
+    it('defers to static isEnabled(cfg) when defined on the class', () => {
+      const { Cls } = makeObserverClass()
+      Cls.isEnabled = jest.fn(() => false)
+      ObserverRegistry.register(Cls)
+      new ObserverRegistry({}, makeContainer(), null) // eslint-disable-line no-new
+      expect(Cls.isEnabled).toHaveBeenCalled()
+      expect(Cls).not.toHaveBeenCalled()
+    })
+  })
+
   describe('constructor', () => {
     it('passes samplerRegistry to each observer', () => {
       const { Cls } = makeObserverClass()

--- a/packages/clappr-telemetry/src/observers/observer_registry.test.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.test.js
@@ -6,12 +6,12 @@ const makeContainer = (cfg = {}) => ({
   trigger: jest.fn()
 })
 
-const makeObserverClass = (overrides = {}) => {
+const makeObserverClass = (name = 'MockObserver', overrides = {}) => {
   const instance = { bind: jest.fn(), destroy: jest.fn(), ...overrides }
   const Cls = jest.fn(() => instance)
   Cls.prototype.bind = instance.bind
   Cls.prototype.destroy = instance.destroy
-  Object.defineProperty(Cls, 'name', { value: 'MockObserver', configurable: true })
+  Object.defineProperty(Cls, 'name', { get: () => name, configurable: true })
   return { Cls, instance }
 }
 
@@ -27,8 +27,8 @@ describe('ObserverRegistry', () => {
       const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {})
       const Bad = jest.fn()
       Bad.prototype.destroy = jest.fn()
-      Object.defineProperty(Bad, 'name', { value: 'Bad', configurable: true })
-      ObserverRegistry.register(Bad)
+      Object.defineProperty(Bad, 'name', { get: () => 'Bad', configurable: true })
+      expect(ObserverRegistry.register(Bad)).toBe(false)
       expect(warnSpy).toHaveBeenCalled()
       warnSpy.mockRestore()
     })
@@ -37,16 +37,27 @@ describe('ObserverRegistry', () => {
       const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {})
       const Bad = jest.fn()
       Bad.prototype.bind = jest.fn()
-      Object.defineProperty(Bad, 'name', { value: 'Bad', configurable: true })
-      ObserverRegistry.register(Bad)
+      Object.defineProperty(Bad, 'name', { get: () => 'Bad', configurable: true })
+      expect(ObserverRegistry.register(Bad)).toBe(false)
       expect(warnSpy).toHaveBeenCalled()
       warnSpy.mockRestore()
     })
 
-    it('registers a valid observer class', () => {
+    it('skips and warns when the class relies on the auto-assigned name (no static get name())', () => {
+      const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {})
+      class NoNameGetter {
+        bind() {}
+        destroy() {}
+      }
+      expect(ObserverRegistry.register(NoNameGetter)).toBe(false)
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    it('registers a valid observer class and returns true', () => {
       const { Cls, instance } = makeObserverClass()
-      ObserverRegistry.register(Cls)
-      const registry = new ObserverRegistry({}, makeContainer(), null)
+      expect(ObserverRegistry.register(Cls)).toBe(true)
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [Cls] }), null)
       registry.bind()
       expect(instance.bind).toHaveBeenCalledTimes(1)
     })
@@ -55,7 +66,7 @@ describe('ObserverRegistry', () => {
       const { Cls } = makeObserverClass()
       ObserverRegistry.register(Cls)
       ObserverRegistry.register(Cls)
-      const registry = new ObserverRegistry({}, makeContainer(), null)
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [Cls] }), null)
       registry.bind()
       expect(Cls).toHaveBeenCalledTimes(1)
     })
@@ -66,17 +77,17 @@ describe('ObserverRegistry', () => {
       const { Cls } = makeObserverClass()
       ObserverRegistry.register(Cls)
       ObserverRegistry.unregister(Cls)
-      const registry = new ObserverRegistry({}, makeContainer(), null)
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [Cls] }), null)
       registry.destroy()
       expect(Cls).not.toHaveBeenCalled()
     })
   })
 
   describe('bind()', () => {
-    it('calls bind() on all registered observers', () => {
+    it('calls bind() on all registered observers listed in cfg.observers', () => {
       const { Cls, instance } = makeObserverClass()
       ObserverRegistry.register(Cls)
-      const registry = new ObserverRegistry({}, makeContainer(), null)
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [Cls] }), null)
       registry.bind()
       expect(instance.bind).toHaveBeenCalledTimes(1)
     })
@@ -86,7 +97,7 @@ describe('ObserverRegistry', () => {
     it('calls destroy() on all observers', () => {
       const { Cls, instance } = makeObserverClass()
       ObserverRegistry.register(Cls)
-      const registry = new ObserverRegistry({}, makeContainer(), null)
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [Cls] }), null)
       registry.destroy()
       expect(instance.destroy).toHaveBeenCalledTimes(1)
     })
@@ -94,14 +105,14 @@ describe('ObserverRegistry', () => {
     it('is safe to call multiple times', () => {
       const { Cls } = makeObserverClass()
       ObserverRegistry.register(Cls)
-      const registry = new ObserverRegistry({}, makeContainer(), null)
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [Cls] }), null)
       expect(() => { registry.destroy(); registry.destroy() }).not.toThrow()
     })
 
     it('is safe to call without bind', () => {
       const { Cls } = makeObserverClass()
       ObserverRegistry.register(Cls)
-      const registry = new ObserverRegistry({}, makeContainer(), null)
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [Cls] }), null)
       expect(() => registry.destroy()).not.toThrow()
     })
   })
@@ -110,7 +121,7 @@ describe('ObserverRegistry', () => {
     it('does not instantiate when cfg[name].enabled is false', () => {
       const { Cls } = makeObserverClass()
       ObserverRegistry.register(Cls)
-      const registry = new ObserverRegistry({}, makeContainer({ MockObserver: { enabled: false } }), null)
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [Cls], MockObserver: { enabled: false } }), null)
       expect(Cls).not.toHaveBeenCalled()
       registry.destroy()
     })
@@ -118,7 +129,7 @@ describe('ObserverRegistry', () => {
     it('instantiates when no enabled flag is set', () => {
       const { Cls } = makeObserverClass()
       ObserverRegistry.register(Cls)
-      const registry = new ObserverRegistry({}, makeContainer(), null)
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [Cls] }), null)
       expect(Cls).toHaveBeenCalledTimes(1)
       registry.destroy()
     })
@@ -126,7 +137,7 @@ describe('ObserverRegistry', () => {
     it('instantiates when cfg[name].enabled is true', () => {
       const { Cls } = makeObserverClass()
       ObserverRegistry.register(Cls)
-      const registry = new ObserverRegistry({}, makeContainer({ MockObserver: { enabled: true } }), null)
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [Cls], MockObserver: { enabled: true } }), null)
       expect(Cls).toHaveBeenCalledTimes(1)
       registry.destroy()
     })
@@ -135,7 +146,7 @@ describe('ObserverRegistry', () => {
       const { Cls } = makeObserverClass()
       Cls.isEnabled = jest.fn(() => false)
       ObserverRegistry.register(Cls)
-      new ObserverRegistry({}, makeContainer(), null) // eslint-disable-line no-new
+      new ObserverRegistry({}, makeContainer({ observers: [Cls] }), null) // eslint-disable-line no-new
       expect(Cls.isEnabled).toHaveBeenCalled()
       expect(Cls).not.toHaveBeenCalled()
     })
@@ -144,7 +155,7 @@ describe('ObserverRegistry', () => {
       const { Cls } = makeObserverClass()
       Cls.isEnabled = jest.fn(() => true)
       ObserverRegistry.register(Cls)
-      const registry = new ObserverRegistry({}, makeContainer({ MockObserver: { enabled: false } }), null)
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [Cls], MockObserver: { enabled: false } }), null)
       expect(Cls.isEnabled).toHaveBeenCalled()
       expect(Cls).not.toHaveBeenCalled()
       registry.destroy()
@@ -163,12 +174,37 @@ describe('ObserverRegistry', () => {
     })
   })
 
+  describe('isolation between instances', () => {
+    it('only instantiates observers listed in this container own cfg.observers, even if others are globally registered', () => {
+      const { Cls: OwnObserver, instance: ownInstance } = makeObserverClass('own')
+      const { Cls: OtherObserver, instance: otherInstance } = makeObserverClass('other')
+      ObserverRegistry.register(OwnObserver)
+      ObserverRegistry.register(OtherObserver) // registered globally, e.g. by another player instance
+
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [OwnObserver] }), null)
+      registry.bind()
+
+      expect(ownInstance.bind).toHaveBeenCalledTimes(1)
+      expect(otherInstance.bind).not.toHaveBeenCalled()
+
+      registry.destroy()
+      ObserverRegistry.unregister(OtherObserver)
+    })
+
+    it('does not instantiate an observer present in cfg.observers but never registered', () => {
+      const { Cls } = makeObserverClass('unregistered')
+      const registry = new ObserverRegistry({}, makeContainer({ observers: [Cls] }), null)
+      expect(Cls).not.toHaveBeenCalled()
+      registry.destroy()
+    })
+  })
+
   describe('constructor', () => {
     it('passes samplerRegistry to each observer', () => {
       const { Cls } = makeObserverClass()
       ObserverRegistry.register(Cls)
       const fakeSamplerRegistry = { snapshot: jest.fn() }
-      new ObserverRegistry({}, makeContainer(), fakeSamplerRegistry) // eslint-disable-line no-new
+      new ObserverRegistry({}, makeContainer({ observers: [Cls] }), fakeSamplerRegistry) // eslint-disable-line no-new
       expect(Cls).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),

--- a/packages/clappr-telemetry/src/observers/observer_registry.test.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.test.js
@@ -1,156 +1,125 @@
 import ObserverRegistry from './observer_registry'
-import VideoEventObserver from './video_event_observer'
 import { Log } from '@clappr/core'
-
-jest.mock('./video_event_observer', () => {
-  const mock = jest.fn()
-  mock.isEnabled = jest.fn(() => true)
-  return { __esModule: true, default: mock }
-})
 
 const makeContainer = (cfg = {}) => ({
   options: { telemetry: { ...cfg } },
   trigger: jest.fn()
 })
 
+const makeObserverClass = (overrides = {}) => {
+  const instance = { bind: jest.fn(), destroy: jest.fn(), ...overrides }
+  const Cls = jest.fn(() => instance)
+  Cls.prototype.bind = instance.bind
+  Cls.prototype.destroy = instance.destroy
+  Object.defineProperty(Cls, 'name', { value: 'MockObserver', configurable: true })
+  return { Cls, instance }
+}
+
 describe('ObserverRegistry', () => {
-  let mockVideoObserverInstance
-
-  beforeEach(() => {
-    jest.clearAllMocks()
-    mockVideoObserverInstance = { bind: jest.fn(), destroy: jest.fn() }
-    VideoEventObserver.mockImplementation(() => mockVideoObserverInstance)
-  })
-
-  describe('bind()', () => {
-    it('calls bind() on all registered observers', () => {
-      const registry = new ObserverRegistry({}, makeContainer(), null)
-      registry.bind()
-      expect(mockVideoObserverInstance.bind).toHaveBeenCalledTimes(1)
-    })
-  })
-
-  describe('destroy()', () => {
-    it('calls destroy() on all observers', () => {
-      const registry = new ObserverRegistry({}, makeContainer(), null)
-      registry.destroy()
-      expect(mockVideoObserverInstance.destroy).toHaveBeenCalledTimes(1)
-    })
-
-    it('is safe to call multiple times', () => {
-      const registry = new ObserverRegistry({}, makeContainer(), null)
-      expect(() => {
-        registry.destroy()
-        registry.destroy()
-      }).not.toThrow()
-    })
-
-    it('is safe to call without bind', () => {
-      const registry = new ObserverRegistry({}, makeContainer(), null)
-      expect(() => registry.destroy()).not.toThrow()
-    })
+  afterEach(() => {
+    ObserverRegistry.unregister({ name: 'MockObserver' })
   })
 
   describe('register()', () => {
-    afterEach(() => {
-      ObserverRegistry.unregister('custom')
-    })
-
-    it('skips registration and warns when ObserverClass is missing required methods', () => {
+    it('skips and warns when bind() is missing', () => {
       const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {})
-      ObserverRegistry.register('custom', class {})
+      const Bad = jest.fn()
+      Bad.prototype.destroy = jest.fn()
+      Object.defineProperty(Bad, 'name', { value: 'Bad', configurable: true })
+      ObserverRegistry.register(Bad)
       expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
     })
 
-    it('skips registration and warns when static isEnabled() is missing', () => {
+    it('skips and warns when destroy() is missing', () => {
       const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {})
-      const CustomObserver = jest.fn()
-      CustomObserver.prototype.bind = jest.fn()
-      CustomObserver.prototype.destroy = jest.fn()
-
-      ObserverRegistry.register('custom', CustomObserver)
+      const Bad = jest.fn()
+      Bad.prototype.bind = jest.fn()
+      Object.defineProperty(Bad, 'name', { value: 'Bad', configurable: true })
+      ObserverRegistry.register(Bad)
       expect(warnSpy).toHaveBeenCalled()
-      expect(warnSpy.mock.calls[0].join(' ')).toContain('static isEnabled()')
+      warnSpy.mockRestore()
     })
 
-    it('includes a registered external observer and calls bind() on it', () => {
-      const customInstance = { bind: jest.fn(), destroy: jest.fn() }
-      const CustomObserver = jest.fn(() => customInstance)
-      CustomObserver.isEnabled = jest.fn(() => true)
-      CustomObserver.prototype.bind = jest.fn()
-      CustomObserver.prototype.destroy = jest.fn()
-
-      ObserverRegistry.register('custom', CustomObserver)
-
+    it('registers a valid observer class', () => {
+      const { Cls, instance } = makeObserverClass()
+      ObserverRegistry.register(Cls)
       const registry = new ObserverRegistry({}, makeContainer(), null)
       registry.bind()
-
-      expect(customInstance.bind).toHaveBeenCalledTimes(1)
+      expect(instance.bind).toHaveBeenCalledTimes(1)
     })
 
-    it('passes samplerRegistry to each observer constructor', () => {
-      const fakeSamplerRegistry = { snapshot: jest.fn() }
-      const registry = new ObserverRegistry({}, makeContainer(), fakeSamplerRegistry)
-      registry.destroy()
-      expect(VideoEventObserver).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        fakeSamplerRegistry
-      )
-    })
-  })
-
-  describe('observer filtering via isEnabled()', () => {
-    afterEach(() => {
-      ObserverRegistry.unregister('custom')
-    })
-
-    it('excludes observers whose isEnabled returns false', () => {
-      VideoEventObserver.isEnabled.mockReturnValue(false)
-
-      const registry = new ObserverRegistry({}, makeContainer(), null)
-      registry.destroy()
-      expect(VideoEventObserver).not.toHaveBeenCalled()
-      VideoEventObserver.isEnabled.mockReturnValue(true)
-    })
-
-    it('includes observers whose isEnabled returns true', () => {
-      VideoEventObserver.isEnabled.mockReturnValue(true)
-
+    it('deduplicates — registering the same class twice only instantiates once', () => {
+      const { Cls, instance } = makeObserverClass()
+      ObserverRegistry.register(Cls)
+      ObserverRegistry.register(Cls)
       const registry = new ObserverRegistry({}, makeContainer(), null)
       registry.bind()
-      expect(VideoEventObserver).toHaveBeenCalled()
-    })
-
-    it('excludes a registered external observer when isEnabled returns false', () => {
-      const customInstance = { bind: jest.fn(), destroy: jest.fn() }
-      const CustomObserver = jest.fn(() => customInstance)
-      CustomObserver.isEnabled = jest.fn(() => false)
-      CustomObserver.prototype.bind = jest.fn()
-      CustomObserver.prototype.destroy = jest.fn()
-
-      ObserverRegistry.register('custom', CustomObserver)
-
-      const registry = new ObserverRegistry({}, makeContainer(), null)
-      registry.bind()
-      expect(CustomObserver).not.toHaveBeenCalled()
+      expect(Cls).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('unregister()', () => {
     it('removes a previously registered observer', () => {
-      const customInstance = { bind: jest.fn(), destroy: jest.fn() }
-      const CustomObserver = jest.fn(() => customInstance)
-      CustomObserver.isEnabled = jest.fn(() => true)
-      CustomObserver.prototype.bind = jest.fn()
-      CustomObserver.prototype.destroy = jest.fn()
-
-      ObserverRegistry.register('custom', CustomObserver)
-      ObserverRegistry.unregister('custom')
-
+      const { Cls, instance } = makeObserverClass()
+      ObserverRegistry.register(Cls)
+      ObserverRegistry.unregister(Cls)
       const registry = new ObserverRegistry({}, makeContainer(), null)
       registry.destroy()
-      expect(CustomObserver).not.toHaveBeenCalled()
+      expect(Cls).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('bind()', () => {
+    it('calls bind() on all registered observers', () => {
+      const { Cls, instance } = makeObserverClass()
+      ObserverRegistry.register(Cls)
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      registry.bind()
+      expect(instance.bind).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('destroy()', () => {
+    it('calls destroy() on all observers', () => {
+      const { Cls, instance } = makeObserverClass()
+      ObserverRegistry.register(Cls)
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      registry.destroy()
+      expect(instance.destroy).toHaveBeenCalledTimes(1)
+    })
+
+    it('is safe to call multiple times', () => {
+      const { Cls } = makeObserverClass()
+      ObserverRegistry.register(Cls)
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      expect(() => { registry.destroy(); registry.destroy() }).not.toThrow()
+    })
+
+    it('is safe to call without bind', () => {
+      const { Cls } = makeObserverClass()
+      ObserverRegistry.register(Cls)
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      expect(() => registry.destroy()).not.toThrow()
+    })
+  })
+
+  describe('constructor', () => {
+    it('passes samplerRegistry to each observer', () => {
+      const { Cls } = makeObserverClass()
+      ObserverRegistry.register(Cls)
+      const fakeSamplerRegistry = { snapshot: jest.fn() }
+      new ObserverRegistry({}, makeContainer(), fakeSamplerRegistry)
+      expect(Cls).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        fakeSamplerRegistry
+      )
+    })
+
+    it('starts with an empty registry — no observers instantiated by default', () => {
+      const registry = new ObserverRegistry({}, makeContainer(), null)
+      expect(registry._observers).toHaveLength(0)
     })
   })
 })

--- a/packages/clappr-telemetry/src/observers/observer_registry.test.js
+++ b/packages/clappr-telemetry/src/observers/observer_registry.test.js
@@ -52,7 +52,7 @@ describe('ObserverRegistry', () => {
     })
 
     it('deduplicates — registering the same class twice only instantiates once', () => {
-      const { Cls, instance } = makeObserverClass()
+      const { Cls } = makeObserverClass()
       ObserverRegistry.register(Cls)
       ObserverRegistry.register(Cls)
       const registry = new ObserverRegistry({}, makeContainer(), null)
@@ -63,7 +63,7 @@ describe('ObserverRegistry', () => {
 
   describe('unregister()', () => {
     it('removes a previously registered observer', () => {
-      const { Cls, instance } = makeObserverClass()
+      const { Cls } = makeObserverClass()
       ObserverRegistry.register(Cls)
       ObserverRegistry.unregister(Cls)
       const registry = new ObserverRegistry({}, makeContainer(), null)
@@ -154,8 +154,8 @@ describe('ObserverRegistry', () => {
   describe('ref counting', () => {
     it('is reference-counted — class removed only after all registrations are released', () => {
       const { Cls } = makeObserverClass()
-      ObserverRegistry.register(Cls)  // refCount → 1
-      ObserverRegistry.register(Cls)  // refCount → 2
+      ObserverRegistry.register(Cls) // refCount → 1
+      ObserverRegistry.register(Cls) // refCount → 2
       ObserverRegistry.unregister(Cls) // refCount → 1 — still registered
       expect(ObserverRegistry.has(Cls)).toBe(true)
       ObserverRegistry.unregister(Cls) // refCount → 0 — removed
@@ -168,7 +168,7 @@ describe('ObserverRegistry', () => {
       const { Cls } = makeObserverClass()
       ObserverRegistry.register(Cls)
       const fakeSamplerRegistry = { snapshot: jest.fn() }
-      new ObserverRegistry({}, makeContainer(), fakeSamplerRegistry)
+      new ObserverRegistry({}, makeContainer(), fakeSamplerRegistry) // eslint-disable-line no-new
       expect(Cls).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),

--- a/packages/clappr-telemetry/src/observers/video_event_observer.js
+++ b/packages/clappr-telemetry/src/observers/video_event_observer.js
@@ -12,9 +12,7 @@ import { EVENT_TYPES, TELEMETRY_SOURCES, DEFAULT_VIDEO_EVENTS } from '../utils/c
  * `DEFAULT_VIDEO_EVENTS` and can be narrowed with `telemetry.videoState.videoEvents`.
  */
 export default class VideoEventObserver {
-  static isEnabled(cfg) {
-    return cfg?.videoState?.enabled === true
-  }
+  static get name() { return 'videoState' }
 
   constructor(playback, container, samplerRegistry = null) {
     this._playback = playback

--- a/packages/clappr-telemetry/src/observers/video_event_observer.test.js
+++ b/packages/clappr-telemetry/src/observers/video_event_observer.test.js
@@ -33,24 +33,6 @@ describe('VideoEventObserver', () => {
     observer = new VideoEventObserver(playback, container)
   })
 
-  describe('static isEnabled()', () => {
-    it('returns true when videoState.enabled is true', () => {
-      expect(VideoEventObserver.isEnabled({ videoState: { enabled: true } })).toBe(true)
-    })
-
-    it('returns false when videoState.enabled is false', () => {
-      expect(VideoEventObserver.isEnabled({ videoState: { enabled: false } })).toBe(false)
-    })
-
-    it('returns false when videoState is undefined', () => {
-      expect(VideoEventObserver.isEnabled({})).toBe(false)
-    })
-
-    it('returns false when cfg is undefined', () => {
-      expect(VideoEventObserver.isEnabled(undefined)).toBe(false)
-    })
-  })
-
   describe('constructor', () => {
     it('uses DEFAULT_VIDEO_EVENTS when not configured', () => {
       expect(observer._videoEvents).toEqual(DEFAULT_VIDEO_EVENTS)

--- a/packages/clappr-telemetry/src/samplers/buffer_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/buffer_sampler.js
@@ -6,15 +6,10 @@ import { getBufferAhead, getBufferedRanges, round1 } from '../utils/helpers'
  * Reads the buffer state directly from the `<video>` element on each `collect()` call.
  *
  * **Configuration** via `container.options.telemetry.bufferSample`:
- * - `enabled`       {boolean} — opt-in, must be `true` to activate (default: false)
  * - `includeRanges` {boolean} — whether to include buffered ranges in the payload (default: true)
  */
 export default class BufferSampler {
-  static get name() { return 'buffer-sampler' }
-
-  static isEnabled(cfg) {
-    return cfg?.bufferSample?.enabled === true
-  }
+  static get name() { return 'buffer' }
 
   constructor(playback, container) {
     this._playback = playback

--- a/packages/clappr-telemetry/src/samplers/buffer_sampler.test.js
+++ b/packages/clappr-telemetry/src/samplers/buffer_sampler.test.js
@@ -23,22 +23,8 @@ describe('BufferSampler', () => {
     sampler = new BufferSampler(playback, container)
   })
 
-  describe('isEnabled()', () => {
-    it('returns false by default', () => {
-      expect(BufferSampler.isEnabled({})).toBe(false)
-    })
-
-    it('returns true when bufferSample.enabled is true', () => {
-      expect(BufferSampler.isEnabled({ bufferSample: { enabled: true } })).toBe(true)
-    })
-
-    it('returns false when bufferSample.enabled is false', () => {
-      expect(BufferSampler.isEnabled({ bufferSample: { enabled: false } })).toBe(false)
-    })
-
-    it('returns false when cfg is null', () => {
-      expect(BufferSampler.isEnabled(null)).toBe(false)
-    })
+  it('exposes a static name used as payload key', () => {
+    expect(BufferSampler.name).toBe('buffer')
   })
 
   describe('collect()', () => {

--- a/packages/clappr-telemetry/src/samplers/decoding_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/decoding_sampler.js
@@ -4,20 +4,12 @@
  * Uses `HTMLVideoElement.getVideoPlaybackQuality()`, which returns cumulative
  * counters since playback started. The sampler keeps the previous sample state
  * to compute per-interval deltas.
- *
- * **Configuration** via `container.options.telemetry.decodingSample.enabled: true`
  */
 
 import { round1, round4 } from '../utils/helpers'
 
 export default class DecodingSampler {
-  static get name() {
-    return 'decoding-sampler'
-  }
-
-  static isEnabled(cfg) {
-    return cfg?.decodingSample?.enabled === true
-  }
+  static get name() { return 'decoding' }
 
   constructor(playback, _container) {
     this._playback = playback

--- a/packages/clappr-telemetry/src/samplers/decoding_sampler.test.js
+++ b/packages/clappr-telemetry/src/samplers/decoding_sampler.test.js
@@ -17,22 +17,8 @@ describe('DecodingSampler', () => {
     jest.restoreAllMocks()
   })
 
-  describe('isEnabled()', () => {
-    it('returns false by default', () => {
-      expect(DecodingSampler.isEnabled({})).toBe(false)
-    })
-
-    it('returns true when decodingSample.enabled is true', () => {
-      expect(DecodingSampler.isEnabled({ decodingSample: { enabled: true } })).toBe(true)
-    })
-
-    it('returns false when decodingSample.enabled is false', () => {
-      expect(DecodingSampler.isEnabled({ decodingSample: { enabled: false } })).toBe(false)
-    })
-
-    it('returns false when cfg is null', () => {
-      expect(DecodingSampler.isEnabled(null)).toBe(false)
-    })
+  it('exposes a static name used as payload key', () => {
+    expect(DecodingSampler.name).toBe('decoding')
   })
 
   describe('collect()', () => {

--- a/packages/clappr-telemetry/src/samplers/network_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/network_sampler.js
@@ -55,10 +55,6 @@ function _classifyNetworkAdequacy(mbps, bitrateKbps) {
 export default class NetworkSampler {
   static get name() { return 'network' }
 
-  static isEnabled(cfg) {
-    return cfg?.networkSample?.enabled === true
-  }
-
   constructor(_playback, container) {
     this._destroyed = false
     this._container = container

--- a/packages/clappr-telemetry/src/samplers/network_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/network_sampler.js
@@ -53,9 +53,7 @@ function _classifyNetworkAdequacy(mbps, bitrateKbps) {
 }
 
 export default class NetworkSampler {
-  static get name() {
-    return 'network-sampler'
-  }
+  static get name() { return 'network' }
 
   static isEnabled(cfg) {
     return cfg?.networkSample?.enabled === true

--- a/packages/clappr-telemetry/src/samplers/network_sampler.test.js
+++ b/packages/clappr-telemetry/src/samplers/network_sampler.test.js
@@ -23,24 +23,6 @@ describe('NetworkSampler', () => {
     sampler = new NetworkSampler(null, container)
   })
 
-  describe('isEnabled()', () => {
-    it('returns true when networkSample.enabled is true', () => {
-      expect(NetworkSampler.isEnabled({ networkSample: { enabled: true } })).toBe(true)
-    })
-
-    it('returns false when networkSample.enabled is false', () => {
-      expect(NetworkSampler.isEnabled({ networkSample: { enabled: false } })).toBe(false)
-    })
-
-    it('returns false when networkSample is absent', () => {
-      expect(NetworkSampler.isEnabled({})).toBe(false)
-    })
-
-    it('returns false when cfg is null', () => {
-      expect(NetworkSampler.isEnabled(null)).toBe(false)
-    })
-  })
-
   describe('constructor', () => {
     it('registers listener on CONTAINER_TELEMETRY_TRACE', () => {
       expect(container.on).toHaveBeenCalledWith(

--- a/packages/clappr-telemetry/src/samplers/playback_state_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/playback_state_sampler.js
@@ -5,10 +5,6 @@ import { EVENT_TYPES } from '../utils/constants'
 export default class PlaybackStateSampler {
   static get name() { return 'playbackState' }
 
-  static isEnabled(cfg) {
-    return cfg?.playbackStateSample?.enabled === true
-  }
-
   constructor(playback, container) {
     this._playback = playback
     this._container = container

--- a/packages/clappr-telemetry/src/samplers/playback_state_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/playback_state_sampler.js
@@ -3,7 +3,7 @@ import { round1 } from '../utils/helpers'
 import { EVENT_TYPES } from '../utils/constants'
 
 export default class PlaybackStateSampler {
-  static get name() { return 'playback-state-sampler' }
+  static get name() { return 'playbackState' }
 
   static isEnabled(cfg) {
     return cfg?.playbackStateSample?.enabled === true

--- a/packages/clappr-telemetry/src/samplers/playback_state_sampler.test.js
+++ b/packages/clappr-telemetry/src/samplers/playback_state_sampler.test.js
@@ -32,24 +32,6 @@ describe('PlaybackStateSampler', () => {
     sampler = new PlaybackStateSampler(playback, container)
   })
 
-  describe('isEnabled()', () => {
-    it('returns false by default', () => {
-      expect(PlaybackStateSampler.isEnabled({})).toBe(false)
-    })
-
-    it('returns true when playbackStateSample.enabled is true', () => {
-      expect(PlaybackStateSampler.isEnabled({ playbackStateSample: { enabled: true } })).toBe(true)
-    })
-
-    it('returns false when playbackStateSample.enabled is false', () => {
-      expect(PlaybackStateSampler.isEnabled({ playbackStateSample: { enabled: false } })).toBe(false)
-    })
-
-    it('returns false when cfg is null', () => {
-      expect(PlaybackStateSampler.isEnabled(null)).toBe(false)
-    })
-  })
-
   describe('collect()', () => {
     it('returns networkState, paused, playbackRate, currentTime and null bitrate fields', () => {
       expect(sampler.collect()).toEqual({

--- a/packages/clappr-telemetry/src/samplers/playback_timing_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/playback_timing_sampler.js
@@ -2,7 +2,7 @@ import { Events } from '@clappr/core'
 import { EVENT_TYPES } from '../utils/constants'
 
 export default class PlaybackTimingSampler {
-  static get name() { return 'timing-sampler' }
+  static get name() { return 'timing' }
 
   static isEnabled(cfg) {
     return cfg?.timingSample?.enabled === true

--- a/packages/clappr-telemetry/src/samplers/playback_timing_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/playback_timing_sampler.js
@@ -4,10 +4,6 @@ import { EVENT_TYPES } from '../utils/constants'
 export default class PlaybackTimingSampler {
   static get name() { return 'timing' }
 
-  static isEnabled(cfg) {
-    return cfg?.timingSample?.enabled === true
-  }
-
   constructor(playback, container) {
     this._playback = playback
     this._container = container

--- a/packages/clappr-telemetry/src/samplers/playback_timing_sampler.test.js
+++ b/packages/clappr-telemetry/src/samplers/playback_timing_sampler.test.js
@@ -33,24 +33,6 @@ describe('PlaybackTimingSampler', () => {
     jest.useRealTimers()
   })
 
-  describe('isEnabled()', () => {
-    it('returns true when timingSample.enabled is true', () => {
-      expect(PlaybackTimingSampler.isEnabled({ timingSample: { enabled: true } })).toBe(true)
-    })
-
-    it('returns false when timingSample.enabled is false', () => {
-      expect(PlaybackTimingSampler.isEnabled({ timingSample: { enabled: false } })).toBe(false)
-    })
-
-    it('returns false when timingSample is absent', () => {
-      expect(PlaybackTimingSampler.isEnabled({})).toBe(false)
-    })
-
-    it('returns false when cfg is null', () => {
-      expect(PlaybackTimingSampler.isEnabled(null)).toBe(false)
-    })
-  })
-
   describe('constructor', () => {
     it('registers listeners on playback for all required events', () => {
       expect(playback.on).toHaveBeenCalledWith(Events.PLAYBACK_PLAY_INTENT, expect.any(Function))

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.js
@@ -1,10 +1,11 @@
 import { Log } from '@clappr/core'
-import { emitTelemetry } from '../utils'
+import { emitTelemetry, isComponentEnabled } from '../utils'
 import { EVENT_TYPES } from '../utils/constants'
 
 const DISABLED_INTERVAL = 0
 
 const _registry = new Map()
+const _refCounts = new Map()
 
 /**
  * Drives all active samplers from a single `setInterval`.
@@ -22,7 +23,8 @@ export default class SamplerRegistry {
 
   /**
    * Registers a sampler class. The sampler's `static get name()` is used as
-   * the key in the `mse.sample` payload.
+   * the key in the `mse.sample` payload. Reference-counted — safe to call
+   * multiple times (e.g. from concurrent player instances).
    *
    * @param {Function} SamplerClass - Class with `static get name()`, `collect()`, and `destroy()`
    */
@@ -38,16 +40,30 @@ export default class SamplerRegistry {
       Log.warn('[SamplerRegistry]', `missing ${missing.join(', ')} — skipping`)
       return
     }
-    _registry.set(SamplerClass.name, SamplerClass)
+    const name = SamplerClass.name
+    if (_registry.has(name) && _registry.get(name) !== SamplerClass) {
+      Log.warn('[SamplerRegistry]', `name collision on '${name}' — overwriting existing class`)
+    }
+    _registry.set(name, SamplerClass)
+    _refCounts.set(name, (_refCounts.get(name) || 0) + 1)
   }
 
   /**
    * Removes a previously registered sampler from the global registry.
+   * Reference-counted — the class is only removed when all registrations are released.
    *
    * @param {Function} SamplerClass - The class reference used when registering
    */
   static unregister(SamplerClass) {
-    if (SamplerClass?.name) _registry.delete(SamplerClass.name)
+    if (!SamplerClass?.name) return
+    const name = SamplerClass.name
+    const count = (_refCounts.get(name) || 0) - 1
+    if (count <= 0) {
+      _registry.delete(name)
+      _refCounts.delete(name)
+    } else {
+      _refCounts.set(name, count)
+    }
   }
 
   /**
@@ -66,10 +82,7 @@ export default class SamplerRegistry {
     const raw = cfg.sampleIntervalMs
     this._intervalMs = (typeof raw === 'number' && raw > 0) ? raw : DISABLED_INTERVAL
     this._samplers = [..._registry.entries()]
-      .filter(([, S]) => {
-        if (typeof S.isEnabled === 'function') return S.isEnabled(cfg)
-        return cfg[S.name]?.enabled !== false
-      })
+      .filter(([, S]) => isComponentEnabled(S, cfg))
       .map(([key, S]) => [key, new S(playback, container)])
     this._timerId = null
   }

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.js
@@ -16,29 +16,36 @@ const _refCounts = new Map()
  * omitted when the sampler returns `null` (e.g. decoding seed call).
  *
  * **Configuration** via `container.options.telemetry`:
- * - `sampleIntervalMs` {number} — tick frequency in ms (default: 0 — disabled, use snapshot() for on-demand collection)
+ * - `samplers` {Function[]} — sampler classes for this container
+ * - `sampleIntervalMs` {number} — tick frequency in ms (default: 0 — disabled)
+ *
+ * The registry only validates and ref-counts classes; each instance only
+ * instantiates its own container's `telemetry.samplers`.
  */
 export default class SamplerRegistry {
   static get name() { return 'sampler-registry' }
 
+  /** True if `Cls` declares its own `static get name()`, not the auto-assigned one. */
+  static _hasOwnNameGetter(Cls) {
+    return typeof Cls === 'function' &&
+      typeof Object.getOwnPropertyDescriptor(Cls, 'name')?.get === 'function'
+  }
+
   /**
-   * Registers a sampler class. The sampler's `static get name()` is used as
-   * the key in the `mse.sample` payload. Reference-counted — safe to call
-   * multiple times (e.g. from concurrent player instances).
-   *
-   * @param {Function} SamplerClass - Class with `static get name()`, `collect()`, and `destroy()`
+   * Registers a sampler class, keyed by `static get name()`. Ref-counted.
+   * @returns {boolean} false if validation failed
    */
   static register(SamplerClass) {
     const proto = SamplerClass?.prototype
     const missing = [
-      !SamplerClass?.name && 'static get name()',
+      !SamplerRegistry._hasOwnNameGetter(SamplerClass) && 'static get name()',
       typeof proto?.collect !== 'function' && 'collect()',
       typeof proto?.destroy !== 'function' && 'destroy()'
     ].filter(Boolean)
 
     if (missing.length > 0) {
       Log.warn('[SamplerRegistry]', `missing ${missing.join(', ')} — skipping`)
-      return
+      return false
     }
     const name = SamplerClass.name
     if (_registry.has(name) && _registry.get(name) !== SamplerClass) {
@@ -46,6 +53,7 @@ export default class SamplerRegistry {
     }
     _registry.set(name, SamplerClass)
     _refCounts.set(name, (_refCounts.get(name) || 0) + 1)
+    return true
   }
 
   /**
@@ -81,9 +89,10 @@ export default class SamplerRegistry {
     this._container = container
     const raw = cfg.sampleIntervalMs
     this._intervalMs = (typeof raw === 'number' && raw > 0) ? raw : DISABLED_INTERVAL
-    this._samplers = [..._registry.entries()]
-      .filter(([, S]) => isComponentEnabled(S, cfg))
-      .map(([key, S]) => [key, new S(playback, container)])
+    const samplers = cfg.samplers || []
+    this._samplers = samplers
+      .filter(S => S != null && SamplerRegistry.has(S) && isComponentEnabled(S, cfg))
+      .map(S => [S.name, new S(playback, container)])
     this._timerId = null
   }
 

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.js
@@ -1,35 +1,18 @@
 import { Log } from '@clappr/core'
 import { emitTelemetry } from '../utils'
 import { EVENT_TYPES } from '../utils/constants'
-import BufferSampler from './buffer_sampler'
-import DecodingSampler from './decoding_sampler'
-import PlaybackStateSampler from './playback_state_sampler'
-import NetworkSampler from './network_sampler'
-import PlaybackTimingSampler from './playback_timing_sampler'
-import StreamInfoSampler from './stream_info_sampler'
 
 const DISABLED_INTERVAL = 0
 
-const _registry = new Map([
-  ['buffer', BufferSampler],
-  ['decoding', DecodingSampler],
-  ['playbackState', PlaybackStateSampler],
-  ['network', NetworkSampler],
-  ['timing', PlaybackTimingSampler],
-  ['streamInfo', StreamInfoSampler]
-])
+const _registry = new Map()
 
 /**
  * Drives all active samplers from a single `setInterval`.
  *
- * On construction, filters the sampler registry by each sampler's `isEnabled()`
- * and instantiates only those that are enabled. On every tick, calls `collect()`
- * on each active sampler and emits a single `MSE_SAMPLE` event with the results
- * grouped by key (`buffer`, `decoding`). Keys are omitted when the sampler
- * returns `null` (e.g. decoding seed call).
- *
- * The registry is extensible via `SamplerRegistry.register()` — external samplers
- * can be added before the player is instantiated.
+ * Samplers are registered via `SamplerRegistry.register()` and instantiated
+ * on construction. On every tick, calls `collect()` on each sampler and emits
+ * a single `MSE_SAMPLE` event with the results grouped by name. Keys are
+ * omitted when the sampler returns `null` (e.g. decoding seed call).
  *
  * **Configuration** via `container.options.telemetry`:
  * - `sampleIntervalMs` {number} — tick frequency in ms (default: 0 — disabled, use snapshot() for on-demand collection)
@@ -38,38 +21,33 @@ export default class SamplerRegistry {
   static get name() { return 'sampler-registry' }
 
   /**
-   * Registers an external sampler class into the global registry.
-   * Must be called before the player is instantiated.
+   * Registers a sampler class. The sampler's `static get name()` is used as
+   * the key in the `mse.sample` payload.
    *
-   * **Note:** This method modifies a module-level registry shared by all
-   * SamplerRegistry instances. It is intended to be called once during
-   * app bootstrap, before any player is created.
-   *
-   * @param {string} key - Key used in the `mse.sample` payload (e.g. `'metrics'`)
-   * @param {Function} SamplerClass - Class implementing `static isEnabled()`, `collect()`, and `destroy()`
+   * @param {Function} SamplerClass - Class with `static get name()`, `collect()`, and `destroy()`
    */
-  static register(key, SamplerClass) {
-    const proto = SamplerClass.prototype
+  static register(SamplerClass) {
+    const proto = SamplerClass?.prototype
     const missing = [
-      typeof SamplerClass.isEnabled !== 'function' && 'static isEnabled()',
+      typeof SamplerClass.name !== 'string' && 'static get name()',
       typeof proto?.collect !== 'function' && 'collect()',
       typeof proto?.destroy !== 'function' && 'destroy()'
     ].filter(Boolean)
 
     if (missing.length > 0) {
-      Log.warn('[SamplerRegistry]', `${key}: missing ${missing.join(', ')} — skipping`)
+      Log.warn('[SamplerRegistry]', `missing ${missing.join(', ')} — skipping`)
       return
     }
-    _registry.set(key, SamplerClass)
+    _registry.set(SamplerClass.name, SamplerClass)
   }
 
   /**
    * Removes a previously registered sampler from the global registry.
    *
-   * @param {string} key - The key used when registering the sampler
+   * @param {Function} SamplerClass - The class reference used when registering
    */
-  static unregister(key) {
-    _registry.delete(key)
+  static unregister(SamplerClass) {
+    _registry.delete(SamplerClass.name)
   }
 
   constructor(playback, container) {
@@ -78,7 +56,6 @@ export default class SamplerRegistry {
     const raw = cfg.sampleIntervalMs
     this._intervalMs = (typeof raw === 'number' && raw > 0) ? raw : DISABLED_INTERVAL
     this._samplers = [..._registry.entries()]
-      .filter(([, S]) => S.isEnabled(cfg))
       .map(([key, S]) => [key, new S(playback, container)])
     this._timerId = null
   }

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.js
@@ -29,7 +29,7 @@ export default class SamplerRegistry {
   static register(SamplerClass) {
     const proto = SamplerClass?.prototype
     const missing = [
-      typeof SamplerClass.name !== 'string' && 'static get name()',
+      !SamplerClass?.name && 'static get name()',
       typeof proto?.collect !== 'function' && 'collect()',
       typeof proto?.destroy !== 'function' && 'destroy()'
     ].filter(Boolean)
@@ -47,7 +47,17 @@ export default class SamplerRegistry {
    * @param {Function} SamplerClass - The class reference used when registering
    */
   static unregister(SamplerClass) {
-    _registry.delete(SamplerClass.name)
+    if (SamplerClass?.name) _registry.delete(SamplerClass.name)
+  }
+
+  /**
+   * Returns true if a sampler with the given class's name is already registered.
+   *
+   * @param {Function} SamplerClass
+   * @returns {boolean}
+   */
+  static has(SamplerClass) {
+    return _registry.has(SamplerClass?.name)
   }
 
   constructor(playback, container) {

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.js
@@ -66,6 +66,10 @@ export default class SamplerRegistry {
     const raw = cfg.sampleIntervalMs
     this._intervalMs = (typeof raw === 'number' && raw > 0) ? raw : DISABLED_INTERVAL
     this._samplers = [..._registry.entries()]
+      .filter(([, S]) => {
+        if (typeof S.isEnabled === 'function') return S.isEnabled(cfg)
+        return cfg[S.name]?.enabled !== false
+      })
       .map(([key, S]) => [key, new S(playback, container)])
     this._timerId = null
   }

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.test.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.test.js
@@ -7,13 +7,17 @@ import { Log } from '@clappr/core'
 
 jest.mock('./buffer_sampler', () => {
   const mock = jest.fn()
-  mock.isEnabled = jest.fn(() => true)
+  Object.defineProperty(mock, 'name', { value: 'buffer', configurable: true })
+  mock.prototype.collect = jest.fn()
+  mock.prototype.destroy = jest.fn()
   return { __esModule: true, default: mock }
 })
 
 jest.mock('./decoding_sampler', () => {
   const mock = jest.fn()
-  mock.isEnabled = jest.fn(() => true)
+  Object.defineProperty(mock, 'name', { value: 'decoding', configurable: true })
+  mock.prototype.collect = jest.fn()
+  mock.prototype.destroy = jest.fn()
   return { __esModule: true, default: mock }
 })
 
@@ -40,11 +44,14 @@ describe('SamplerRegistry', () => {
 
     BufferSampler.mockImplementation(() => mockBufferInstance)
     DecodingSampler.mockImplementation(() => mockDecodingInstance)
-    BufferSampler.isEnabled.mockReturnValue(true)
-    DecodingSampler.isEnabled.mockReturnValue(true)
+
+    SamplerRegistry.register(BufferSampler)
+    SamplerRegistry.register(DecodingSampler)
   })
 
   afterEach(() => {
+    SamplerRegistry.unregister(BufferSampler)
+    SamplerRegistry.unregister(DecodingSampler)
     jest.useRealTimers()
   })
 
@@ -130,61 +137,54 @@ describe('SamplerRegistry', () => {
 
       expect(emitTelemetry).not.toHaveBeenCalled()
     })
-  })
 
-  describe('sampler filtering via isEnabled()', () => {
-    it('excludes disabled samplers', () => {
-      BufferSampler.isEnabled.mockReturnValue(false)
-
-      const scheduler = new SamplerRegistry({}, makeContainer())
-      scheduler.bind()
-      jest.advanceTimersByTime(1000)
-
-      const [, , data] = emitTelemetry.mock.calls[0]
-      expect(data).not.toHaveProperty('buffer')
-      expect(data).toHaveProperty('decoding')
-    })
-
-    it('does not emit when all samplers are disabled', () => {
-      BufferSampler.isEnabled.mockReturnValue(false)
-      DecodingSampler.isEnabled.mockReturnValue(false)
+    it('does not emit when no samplers are registered', () => {
+      SamplerRegistry.unregister(BufferSampler)
+      SamplerRegistry.unregister(DecodingSampler)
 
       const scheduler = new SamplerRegistry({}, makeContainer())
       scheduler.bind()
       jest.advanceTimersByTime(1000)
 
       expect(emitTelemetry).not.toHaveBeenCalled()
+
+      SamplerRegistry.register(BufferSampler)
+      SamplerRegistry.register(DecodingSampler)
     })
   })
 
   describe('register()', () => {
-    afterEach(() => {
-      SamplerRegistry.unregister('custom')
+    let CustomSampler
+
+    beforeEach(() => {
+      CustomSampler = jest.fn()
+      Object.defineProperty(CustomSampler, 'name', { value: 'custom', configurable: true })
+      CustomSampler.prototype.collect = jest.fn()
+      CustomSampler.prototype.destroy = jest.fn()
     })
 
-    it('skips registration and warns when SamplerClass is missing required methods', () => {
+    afterEach(() => {
+      SamplerRegistry.unregister(CustomSampler)
+    })
+
+    it('skips registration and warns when required methods are missing', () => {
       const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {})
-      SamplerRegistry.register('custom', class {})
+      class NoMethods {}
+      SamplerRegistry.register(NoMethods)
 
       const scheduler = new SamplerRegistry({}, makeContainer())
       scheduler.bind()
       jest.advanceTimersByTime(1000)
 
-      const [, , data] = emitTelemetry.mock.calls[0]
-      expect(data).not.toHaveProperty('custom')
       expect(warnSpy).toHaveBeenCalled()
-
       scheduler.destroy()
     })
 
     it('includes a registered external sampler in the tick', () => {
       const customInstance = { collect: jest.fn(() => ({ foo: 'bar' })), destroy: jest.fn() }
-      const CustomSampler = jest.fn(() => customInstance)
-      CustomSampler.isEnabled = jest.fn(() => true)
-      CustomSampler.prototype.collect = jest.fn()
-      CustomSampler.prototype.destroy = jest.fn()
+      CustomSampler.mockImplementation(() => customInstance)
 
-      SamplerRegistry.register('custom', CustomSampler)
+      SamplerRegistry.register(CustomSampler)
 
       const scheduler = new SamplerRegistry({}, makeContainer())
       scheduler.bind()
@@ -197,22 +197,37 @@ describe('SamplerRegistry', () => {
       scheduler.destroy()
     })
 
-    it('excludes a registered external sampler when isEnabled returns false', () => {
-      const CustomSampler = jest.fn()
-      CustomSampler.isEnabled = jest.fn(() => false)
-      CustomSampler.prototype.collect = jest.fn()
-      CustomSampler.prototype.destroy = jest.fn()
+    it('overwrites a previously registered sampler with the same name', () => {
+      const NewSampler = jest.fn()
+      Object.defineProperty(NewSampler, 'name', { value: 'custom', configurable: true })
+      NewSampler.prototype.collect = jest.fn()
+      NewSampler.prototype.destroy = jest.fn()
 
-      SamplerRegistry.register('custom', CustomSampler)
+      SamplerRegistry.register(CustomSampler)
+      SamplerRegistry.register(NewSampler)
+
+      new SamplerRegistry({}, makeContainer()) // eslint-disable-line no-new
+
+      expect(NewSampler).toHaveBeenCalled()
+      expect(CustomSampler).not.toHaveBeenCalled()
+
+      SamplerRegistry.unregister(NewSampler)
+    })
+  })
+
+  describe('unregister()', () => {
+    it('removes the sampler so it is no longer instantiated', () => {
+      SamplerRegistry.unregister(BufferSampler)
 
       const scheduler = new SamplerRegistry({}, makeContainer())
       scheduler.bind()
       jest.advanceTimersByTime(1000)
 
-      expect(emitTelemetry).toHaveBeenCalled()
       const [, , data] = emitTelemetry.mock.calls[0]
-      expect(data).not.toHaveProperty('custom')
+      expect(data).not.toHaveProperty('buffer')
+      expect(data).toHaveProperty('decoding')
 
+      SamplerRegistry.register(BufferSampler)
       scheduler.destroy()
     })
   })

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.test.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.test.js
@@ -268,6 +268,39 @@ describe('SamplerRegistry', () => {
 
       SamplerRegistry.unregister(CustomSampler)
     })
+
+    it('does not instantiate when isEnabled returns true but cfg[name].enabled is false', () => {
+      const CustomSampler = jest.fn()
+      Object.defineProperty(CustomSampler, 'name', { value: 'custom', configurable: true })
+      CustomSampler.prototype.collect = jest.fn()
+      CustomSampler.prototype.destroy = jest.fn()
+      CustomSampler.isEnabled = jest.fn(() => true)
+
+      SamplerRegistry.register(CustomSampler)
+      const registry = new SamplerRegistry({}, makeContainer({ custom: { enabled: false } }))
+
+      expect(CustomSampler.isEnabled).toHaveBeenCalled()
+      expect(CustomSampler).not.toHaveBeenCalled()
+
+      SamplerRegistry.unregister(CustomSampler)
+      registry.destroy()
+    })
+  })
+
+  describe('ref counting', () => {
+    it('is reference-counted — class removed only after all registrations are released', () => {
+      const CustomSampler = jest.fn()
+      Object.defineProperty(CustomSampler, 'name', { value: 'counted', configurable: true })
+      CustomSampler.prototype.collect = jest.fn()
+      CustomSampler.prototype.destroy = jest.fn()
+
+      SamplerRegistry.register(CustomSampler)  // refCount → 1
+      SamplerRegistry.register(CustomSampler)  // refCount → 2
+      SamplerRegistry.unregister(CustomSampler) // refCount → 1 — still registered
+      expect(SamplerRegistry.has(CustomSampler)).toBe(true)
+      SamplerRegistry.unregister(CustomSampler) // refCount → 0 — removed
+      expect(SamplerRegistry.has(CustomSampler)).toBe(false)
+    })
   })
 
   describe('snapshot()', () => {

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.test.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.test.js
@@ -7,7 +7,7 @@ import { Log } from '@clappr/core'
 
 jest.mock('./buffer_sampler', () => {
   const mock = jest.fn()
-  Object.defineProperty(mock, 'name', { value: 'buffer', configurable: true })
+  Object.defineProperty(mock, 'name', { get: () => 'buffer', configurable: true })
   mock.prototype.collect = jest.fn()
   mock.prototype.destroy = jest.fn()
   return { __esModule: true, default: mock }
@@ -15,7 +15,7 @@ jest.mock('./buffer_sampler', () => {
 
 jest.mock('./decoding_sampler', () => {
   const mock = jest.fn()
-  Object.defineProperty(mock, 'name', { value: 'decoding', configurable: true })
+  Object.defineProperty(mock, 'name', { get: () => 'decoding', configurable: true })
   mock.prototype.collect = jest.fn()
   mock.prototype.destroy = jest.fn()
   return { __esModule: true, default: mock }
@@ -27,7 +27,7 @@ jest.mock('../utils', () => ({
 }))
 
 const makeContainer = (cfg = {}) => ({
-  options: { telemetry: { sampleIntervalMs: 1000, ...cfg } },
+  options: { telemetry: { sampleIntervalMs: 1000, samplers: [BufferSampler, DecodingSampler], ...cfg } },
   trigger: jest.fn()
 })
 
@@ -138,18 +138,12 @@ describe('SamplerRegistry', () => {
       expect(emitTelemetry).not.toHaveBeenCalled()
     })
 
-    it('does not emit when no samplers are registered', () => {
-      SamplerRegistry.unregister(BufferSampler)
-      SamplerRegistry.unregister(DecodingSampler)
-
-      const scheduler = new SamplerRegistry({}, makeContainer())
+    it('does not emit when cfg.samplers is empty', () => {
+      const scheduler = new SamplerRegistry({}, makeContainer({ samplers: [] }))
       scheduler.bind()
       jest.advanceTimersByTime(1000)
 
       expect(emitTelemetry).not.toHaveBeenCalled()
-
-      SamplerRegistry.register(BufferSampler)
-      SamplerRegistry.register(DecodingSampler)
     })
   })
 
@@ -158,7 +152,7 @@ describe('SamplerRegistry', () => {
 
     beforeEach(() => {
       CustomSampler = jest.fn()
-      Object.defineProperty(CustomSampler, 'name', { value: 'custom', configurable: true })
+      Object.defineProperty(CustomSampler, 'name', { get: () => 'custom', configurable: true })
       CustomSampler.prototype.collect = jest.fn()
       CustomSampler.prototype.destroy = jest.fn()
     })
@@ -170,23 +164,29 @@ describe('SamplerRegistry', () => {
     it('skips registration and warns when required methods are missing', () => {
       const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {})
       class NoMethods {}
-      SamplerRegistry.register(NoMethods)
-
-      const scheduler = new SamplerRegistry({}, makeContainer())
-      scheduler.bind()
-      jest.advanceTimersByTime(1000)
-
+      expect(SamplerRegistry.register(NoMethods)).toBe(false)
       expect(warnSpy).toHaveBeenCalled()
-      scheduler.destroy()
+      warnSpy.mockRestore()
     })
 
-    it('includes a registered external sampler in the tick', () => {
+    it('warns and returns false when the class relies on the auto-assigned name (no static get name())', () => {
+      const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {})
+      class NoNameGetter {
+        collect() {}
+        destroy() {}
+      }
+      expect(SamplerRegistry.register(NoNameGetter)).toBe(false)
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    it('returns true and includes a registered external sampler in the tick', () => {
       const customInstance = { collect: jest.fn(() => ({ foo: 'bar' })), destroy: jest.fn() }
       CustomSampler.mockImplementation(() => customInstance)
 
-      SamplerRegistry.register(CustomSampler)
+      expect(SamplerRegistry.register(CustomSampler)).toBe(true)
 
-      const scheduler = new SamplerRegistry({}, makeContainer())
+      const scheduler = new SamplerRegistry({}, makeContainer({ samplers: [CustomSampler] }))
       scheduler.bind()
       jest.advanceTimersByTime(1000)
 
@@ -197,19 +197,19 @@ describe('SamplerRegistry', () => {
       scheduler.destroy()
     })
 
-    it('overwrites a previously registered sampler with the same name', () => {
+    it('instantiates the exact class from its own cfg.samplers, unaffected by a name collision overwrite elsewhere', () => {
       const NewSampler = jest.fn()
-      Object.defineProperty(NewSampler, 'name', { value: 'custom', configurable: true })
+      Object.defineProperty(NewSampler, 'name', { get: () => 'custom', configurable: true })
       NewSampler.prototype.collect = jest.fn()
       NewSampler.prototype.destroy = jest.fn()
 
-      SamplerRegistry.register(CustomSampler)
-      SamplerRegistry.register(NewSampler)
+      SamplerRegistry.register(CustomSampler) // this container's own class
+      SamplerRegistry.register(NewSampler) // registered elsewhere, same name — overwrites the registry map entry
 
-      new SamplerRegistry({}, makeContainer()) // eslint-disable-line no-new
+      new SamplerRegistry({}, makeContainer({ samplers: [CustomSampler] })) // eslint-disable-line no-new
 
-      expect(NewSampler).toHaveBeenCalled()
-      expect(CustomSampler).not.toHaveBeenCalled()
+      expect(CustomSampler).toHaveBeenCalled()
+      expect(NewSampler).not.toHaveBeenCalled()
 
       SamplerRegistry.unregister(NewSampler)
     })
@@ -232,6 +232,40 @@ describe('SamplerRegistry', () => {
     })
   })
 
+  describe('isolation between instances', () => {
+    it('only instantiates samplers listed in this container own cfg.samplers, even if others are globally registered', () => {
+      const CustomSampler = jest.fn()
+      Object.defineProperty(CustomSampler, 'name', { get: () => 'custom', configurable: true })
+      CustomSampler.prototype.collect = jest.fn()
+      CustomSampler.prototype.destroy = jest.fn()
+      SamplerRegistry.register(CustomSampler) // registered globally, e.g. by another player instance
+
+      const scheduler = new SamplerRegistry({}, makeContainer({ samplers: [BufferSampler] }))
+      scheduler.bind()
+      jest.advanceTimersByTime(1000)
+
+      const [, , data] = emitTelemetry.mock.calls[0]
+      expect(data).toHaveProperty('buffer')
+      expect(data).not.toHaveProperty('decoding')
+      expect(data).not.toHaveProperty('custom')
+      expect(CustomSampler).not.toHaveBeenCalled()
+
+      scheduler.destroy()
+      SamplerRegistry.unregister(CustomSampler)
+    })
+
+    it('does not instantiate a sampler present in cfg.samplers but never registered', () => {
+      const Unregistered = jest.fn()
+      Object.defineProperty(Unregistered, 'name', { get: () => 'unregistered', configurable: true })
+      Unregistered.prototype.collect = jest.fn()
+      Unregistered.prototype.destroy = jest.fn()
+
+      const scheduler = new SamplerRegistry({}, makeContainer({ samplers: [Unregistered] }))
+      expect(Unregistered).not.toHaveBeenCalled()
+      scheduler.destroy()
+    })
+  })
+
   describe('isEnabled filtering', () => {
     it('does not instantiate a sampler when cfg[name].enabled is false', () => {
       const registry = new SamplerRegistry({}, makeContainer({ buffer: { enabled: false } }))
@@ -240,7 +274,7 @@ describe('SamplerRegistry', () => {
       registry.destroy()
     })
 
-    it('instantiates all samplers when no enabled flag is set', () => {
+    it('instantiates all samplers in cfg.samplers when no enabled flag is set', () => {
       const registry = new SamplerRegistry({}, makeContainer())
       expect(BufferSampler).toHaveBeenCalledTimes(1)
       expect(DecodingSampler).toHaveBeenCalledTimes(1)
@@ -255,13 +289,13 @@ describe('SamplerRegistry', () => {
 
     it('defers to static isEnabled(cfg) when defined on the class', () => {
       const CustomSampler = jest.fn()
-      Object.defineProperty(CustomSampler, 'name', { value: 'custom', configurable: true })
+      Object.defineProperty(CustomSampler, 'name', { get: () => 'custom', configurable: true })
       CustomSampler.prototype.collect = jest.fn()
       CustomSampler.prototype.destroy = jest.fn()
       CustomSampler.isEnabled = jest.fn(() => false)
 
       SamplerRegistry.register(CustomSampler)
-      new SamplerRegistry({}, makeContainer()) // eslint-disable-line no-new
+      new SamplerRegistry({}, makeContainer({ samplers: [CustomSampler] })) // eslint-disable-line no-new
 
       expect(CustomSampler.isEnabled).toHaveBeenCalled()
       expect(CustomSampler).not.toHaveBeenCalled()
@@ -271,13 +305,13 @@ describe('SamplerRegistry', () => {
 
     it('does not instantiate when isEnabled returns true but cfg[name].enabled is false', () => {
       const CustomSampler = jest.fn()
-      Object.defineProperty(CustomSampler, 'name', { value: 'custom', configurable: true })
+      Object.defineProperty(CustomSampler, 'name', { get: () => 'custom', configurable: true })
       CustomSampler.prototype.collect = jest.fn()
       CustomSampler.prototype.destroy = jest.fn()
       CustomSampler.isEnabled = jest.fn(() => true)
 
       SamplerRegistry.register(CustomSampler)
-      const registry = new SamplerRegistry({}, makeContainer({ custom: { enabled: false } }))
+      const registry = new SamplerRegistry({}, makeContainer({ samplers: [CustomSampler], custom: { enabled: false } }))
 
       expect(CustomSampler.isEnabled).toHaveBeenCalled()
       expect(CustomSampler).not.toHaveBeenCalled()
@@ -290,7 +324,7 @@ describe('SamplerRegistry', () => {
   describe('ref counting', () => {
     it('is reference-counted — class removed only after all registrations are released', () => {
       const CustomSampler = jest.fn()
-      Object.defineProperty(CustomSampler, 'name', { value: 'counted', configurable: true })
+      Object.defineProperty(CustomSampler, 'name', { get: () => 'counted', configurable: true })
       CustomSampler.prototype.collect = jest.fn()
       CustomSampler.prototype.destroy = jest.fn()
 

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.test.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.test.js
@@ -294,8 +294,8 @@ describe('SamplerRegistry', () => {
       CustomSampler.prototype.collect = jest.fn()
       CustomSampler.prototype.destroy = jest.fn()
 
-      SamplerRegistry.register(CustomSampler)  // refCount → 1
-      SamplerRegistry.register(CustomSampler)  // refCount → 2
+      SamplerRegistry.register(CustomSampler) // refCount → 1
+      SamplerRegistry.register(CustomSampler) // refCount → 2
       SamplerRegistry.unregister(CustomSampler) // refCount → 1 — still registered
       expect(SamplerRegistry.has(CustomSampler)).toBe(true)
       SamplerRegistry.unregister(CustomSampler) // refCount → 0 — removed

--- a/packages/clappr-telemetry/src/samplers/sampler_registry.test.js
+++ b/packages/clappr-telemetry/src/samplers/sampler_registry.test.js
@@ -232,6 +232,44 @@ describe('SamplerRegistry', () => {
     })
   })
 
+  describe('isEnabled filtering', () => {
+    it('does not instantiate a sampler when cfg[name].enabled is false', () => {
+      const registry = new SamplerRegistry({}, makeContainer({ buffer: { enabled: false } }))
+      expect(BufferSampler).not.toHaveBeenCalled()
+      expect(DecodingSampler).toHaveBeenCalledTimes(1)
+      registry.destroy()
+    })
+
+    it('instantiates all samplers when no enabled flag is set', () => {
+      const registry = new SamplerRegistry({}, makeContainer())
+      expect(BufferSampler).toHaveBeenCalledTimes(1)
+      expect(DecodingSampler).toHaveBeenCalledTimes(1)
+      registry.destroy()
+    })
+
+    it('instantiates when cfg[name].enabled is true', () => {
+      const registry = new SamplerRegistry({}, makeContainer({ buffer: { enabled: true } }))
+      expect(BufferSampler).toHaveBeenCalledTimes(1)
+      registry.destroy()
+    })
+
+    it('defers to static isEnabled(cfg) when defined on the class', () => {
+      const CustomSampler = jest.fn()
+      Object.defineProperty(CustomSampler, 'name', { value: 'custom', configurable: true })
+      CustomSampler.prototype.collect = jest.fn()
+      CustomSampler.prototype.destroy = jest.fn()
+      CustomSampler.isEnabled = jest.fn(() => false)
+
+      SamplerRegistry.register(CustomSampler)
+      new SamplerRegistry({}, makeContainer()) // eslint-disable-line no-new
+
+      expect(CustomSampler.isEnabled).toHaveBeenCalled()
+      expect(CustomSampler).not.toHaveBeenCalled()
+
+      SamplerRegistry.unregister(CustomSampler)
+    })
+  })
+
   describe('snapshot()', () => {
     it('returns collected data keyed by sampler name', () => {
       const scheduler = new SamplerRegistry({}, makeContainer())

--- a/packages/clappr-telemetry/src/samplers/stream_info_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/stream_info_sampler.js
@@ -3,7 +3,6 @@ import { EVENT_TYPES } from '../utils/constants'
 
 export default class StreamInfoSampler {
   static get name() { return 'streamInfo' }
-  static isEnabled(cfg) { return cfg?.streamInfoSample?.enabled === true }
 
   constructor(_playback, container) {
     this._destroyed = false

--- a/packages/clappr-telemetry/src/samplers/stream_info_sampler.js
+++ b/packages/clappr-telemetry/src/samplers/stream_info_sampler.js
@@ -2,7 +2,7 @@ import { Events } from '@clappr/core'
 import { EVENT_TYPES } from '../utils/constants'
 
 export default class StreamInfoSampler {
-  static get name() { return 'stream-info-sampler' }
+  static get name() { return 'streamInfo' }
   static isEnabled(cfg) { return cfg?.streamInfoSample?.enabled === true }
 
   constructor(_playback, container) {

--- a/packages/clappr-telemetry/src/samplers/stream_info_sampler.test.js
+++ b/packages/clappr-telemetry/src/samplers/stream_info_sampler.test.js
@@ -31,24 +31,6 @@ describe('StreamInfoSampler', () => {
     sampler = new StreamInfoSampler(null, container)
   })
 
-  describe('isEnabled()', () => {
-    it('returns true when streamInfoSample.enabled is true', () => {
-      expect(StreamInfoSampler.isEnabled({ streamInfoSample: { enabled: true } })).toBe(true)
-    })
-
-    it('returns false when streamInfoSample.enabled is false', () => {
-      expect(StreamInfoSampler.isEnabled({ streamInfoSample: { enabled: false } })).toBe(false)
-    })
-
-    it('returns false when streamInfoSample is absent', () => {
-      expect(StreamInfoSampler.isEnabled({})).toBe(false)
-    })
-
-    it('returns false when cfg is null', () => {
-      expect(StreamInfoSampler.isEnabled(null)).toBe(false)
-    })
-  })
-
   describe('constructor', () => {
     it('registers listener on CONTAINER_TELEMETRY_TRACE', () => {
       expect(container.on).toHaveBeenCalledWith(

--- a/packages/clappr-telemetry/src/telemetry_plugin.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.js
@@ -1,5 +1,5 @@
 import { ContainerPlugin, Log, Events } from '@clappr/core'
-import { findNetworkAdapter } from './adapters'
+import { NetworkAdapters } from './adapters'
 import { SamplerRegistry } from './samplers'
 import { ObserverRegistry } from './observers'
 
@@ -24,6 +24,8 @@ export default class TelemetryPlugin extends ContainerPlugin {
    */
   static get SamplerRegistry() { return SamplerRegistry }
   static get ObserverRegistry() { return ObserverRegistry }
+
+  static get NetworkAdapters() { return NetworkAdapters }
 
   constructor(container) {
     super(container)
@@ -73,7 +75,7 @@ export default class TelemetryPlugin extends ContainerPlugin {
     this.observerRegistry.bind()
 
     if (cfg.network?.enabled === true) {
-      const AdapterClass = findNetworkAdapter(playback)
+      const AdapterClass = NetworkAdapters.find(playback)
 
       if (!AdapterClass) {
         Log.warn(`[TelemetryPlugin] No network adapter for playback: ${playback.name || playback.constructor.name || 'unknown'}`)

--- a/packages/clappr-telemetry/src/telemetry_plugin.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.js
@@ -28,6 +28,7 @@ export default class TelemetryPlugin extends ContainerPlugin {
     this.observerRegistry = null
     this._configAdapters = []
     this._configSamplers = []
+    this._configObservers = []
   }
 
   get name() {
@@ -58,7 +59,7 @@ export default class TelemetryPlugin extends ContainerPlugin {
 
   onPlaybackRead(playback) {
     const cfg = this.container.options?.telemetry
-    if (!cfg) return
+    if (!cfg || cfg.enabled === false) return
 
     this._configSamplers.forEach(S => SamplerRegistry.unregister(S))
     const samplers = cfg.samplers || []
@@ -75,6 +76,11 @@ export default class TelemetryPlugin extends ContainerPlugin {
     if (this.samplerRegistry) this.samplerRegistry.destroy()
     this.samplerRegistry = new SamplerRegistry(playback, this.container)
     this.samplerRegistry.bind()
+
+    this._configObservers.forEach(O => ObserverRegistry.unregister(O))
+    const observers = cfg.observers || []
+    observers.forEach(O => ObserverRegistry.register(O))
+    this._configObservers = observers
 
     if (this.observerRegistry) this.observerRegistry.destroy()
     this.observerRegistry = new ObserverRegistry(playback, this.container, this.samplerRegistry)
@@ -95,6 +101,8 @@ export default class TelemetryPlugin extends ContainerPlugin {
     this._configAdapters = []
     this._configSamplers.forEach(S => SamplerRegistry.unregister(S))
     this._configSamplers = []
+    this._configObservers.forEach(O => ObserverRegistry.unregister(O))
+    this._configObservers = []
     if (this.adapter) {
       this.adapter.destroy()
       this.adapter = null

--- a/packages/clappr-telemetry/src/telemetry_plugin.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.js
@@ -86,7 +86,7 @@ export default class TelemetryPlugin extends ContainerPlugin {
     this.observerRegistry = new ObserverRegistry(playback, this.container, this.samplerRegistry)
     this.observerRegistry.bind()
 
-    const AdapterClass = NetworkAdapters.find(playback)
+    const AdapterClass = NetworkAdapters.find(playback, cfg)
     if (AdapterClass) {
       if (this.adapter) this.adapter.destroy()
       this.adapter = new AdapterClass(playback, this.container)

--- a/packages/clappr-telemetry/src/telemetry_plugin.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.js
@@ -16,12 +16,6 @@ Events.register('CONTAINER_TELEMETRY_TRACE')
  * Integrates with container's telemetry bus to forward network and playback metrics.
  */
 export default class TelemetryPlugin extends ContainerPlugin {
-  /**
-   * UMD access point for `SamplerRegistry.register()`.
-   * The UMD build exposes only the plugin class as the global, so named exports
-   * are not reachable. This static getter bridges that gap for script-tag consumers.
-   * ESM consumers should import `SamplerRegistry` directly from the package.
-   */
   static get SamplerRegistry() { return SamplerRegistry }
   static get ObserverRegistry() { return ObserverRegistry }
 
@@ -32,6 +26,8 @@ export default class TelemetryPlugin extends ContainerPlugin {
     this.adapter = null
     this.samplerRegistry = null
     this.observerRegistry = null
+    this._configAdapters = []
+    this._configSamplers = []
   }
 
   get name() {
@@ -44,7 +40,7 @@ export default class TelemetryPlugin extends ContainerPlugin {
 
   /**
    * Returns a snapshot of all active samplers at the current moment.
-   * Returns an empty object if the scheduler is not yet initialized.
+   * Returns an empty object if the registry is not yet initialized.
    *
    * @returns {Object} Sampler data keyed by sampler name (e.g. `{ buffer: {...}, decoding: {...} }`)
    */
@@ -64,6 +60,16 @@ export default class TelemetryPlugin extends ContainerPlugin {
     const cfg = this.container.options?.telemetry
     if (!cfg) return
 
+    this._configSamplers.forEach(S => SamplerRegistry.unregister(S))
+    const samplers = cfg.samplers || []
+    samplers.forEach(S => SamplerRegistry.register(S))
+    this._configSamplers = samplers
+
+    this._configAdapters.forEach(A => NetworkAdapters.unregister(A))
+    const adapters = cfg.adapters || []
+    adapters.forEach(A => NetworkAdapters.register(A))
+    this._configAdapters = adapters
+
     // Samplers must be bound before the adapter so events emitted during
     // adapter.bind() (e.g. STREAM_INFO on Shaka's attachFilters) are captured.
     if (this.samplerRegistry) this.samplerRegistry.destroy()
@@ -74,20 +80,21 @@ export default class TelemetryPlugin extends ContainerPlugin {
     this.observerRegistry = new ObserverRegistry(playback, this.container, this.samplerRegistry)
     this.observerRegistry.bind()
 
-    if (cfg.network?.enabled === true) {
-      const AdapterClass = NetworkAdapters.find(playback)
-
-      if (!AdapterClass) {
-        Log.warn(`[TelemetryPlugin] No network adapter for playback: ${playback.name || playback.constructor.name || 'unknown'}`)
-      } else {
-        if (this.adapter) this.adapter.destroy()
-        this.adapter = new AdapterClass(playback, this.container)
-        this.adapter.bind()
-      }
+    const AdapterClass = NetworkAdapters.find(playback)
+    if (AdapterClass) {
+      if (this.adapter) this.adapter.destroy()
+      this.adapter = new AdapterClass(playback, this.container)
+      this.adapter.bind()
+    } else if (adapters.length > 0) {
+      Log.warn(`[TelemetryPlugin] No network adapter for playback: ${playback.name || playback.constructor.name || 'unknown'}`)
     }
   }
 
   destroy() {
+    this._configAdapters.forEach(A => NetworkAdapters.unregister(A))
+    this._configAdapters = []
+    this._configSamplers.forEach(S => SamplerRegistry.unregister(S))
+    this._configSamplers = []
     if (this.adapter) {
       this.adapter.destroy()
       this.adapter = null

--- a/packages/clappr-telemetry/src/telemetry_plugin.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.js
@@ -63,13 +63,13 @@ export default class TelemetryPlugin extends ContainerPlugin {
 
     this._configSamplers.forEach(S => SamplerRegistry.unregister(S))
     const samplers = cfg.samplers || []
+    this._configSamplers = samplers.filter(S => S != null && !SamplerRegistry.has(S))
     samplers.forEach(S => SamplerRegistry.register(S))
-    this._configSamplers = samplers
 
     this._configAdapters.forEach(A => NetworkAdapters.unregister(A))
     const adapters = cfg.adapters || []
+    this._configAdapters = adapters.filter(A => A != null && !NetworkAdapters.has(A))
     adapters.forEach(A => NetworkAdapters.register(A))
-    this._configAdapters = adapters
 
     // Samplers must be bound before the adapter so events emitted during
     // adapter.bind() (e.g. STREAM_INFO on Shaka's attachFilters) are captured.
@@ -79,8 +79,8 @@ export default class TelemetryPlugin extends ContainerPlugin {
 
     this._configObservers.forEach(O => ObserverRegistry.unregister(O))
     const observers = cfg.observers || []
+    this._configObservers = observers.filter(O => O != null && !ObserverRegistry.has(O))
     observers.forEach(O => ObserverRegistry.register(O))
-    this._configObservers = observers
 
     if (this.observerRegistry) this.observerRegistry.destroy()
     this.observerRegistry = new ObserverRegistry(playback, this.container, this.samplerRegistry)
@@ -91,7 +91,7 @@ export default class TelemetryPlugin extends ContainerPlugin {
       if (this.adapter) this.adapter.destroy()
       this.adapter = new AdapterClass(playback, this.container)
       this.adapter.bind()
-    } else if (adapters.length > 0) {
+    } else if (NetworkAdapters.size > 0) {
       Log.warn(`[TelemetryPlugin] No network adapter for playback: ${playback.name || playback.constructor.name || 'unknown'}`)
     }
   }

--- a/packages/clappr-telemetry/src/telemetry_plugin.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.js
@@ -61,14 +61,16 @@ export default class TelemetryPlugin extends ContainerPlugin {
     const cfg = this.container.options?.telemetry
     if (!cfg || cfg.enabled === false) return
 
+    // Unregister previously tracked config classes (ref-counted — global registry
+    // only removes them when the last player holding a ref calls unregister).
     this._configSamplers.forEach(S => SamplerRegistry.unregister(S))
     const samplers = cfg.samplers || []
-    this._configSamplers = samplers.filter(S => S != null && !SamplerRegistry.has(S))
+    this._configSamplers = samplers.filter(S => S != null)
     samplers.forEach(S => SamplerRegistry.register(S))
 
     this._configAdapters.forEach(A => NetworkAdapters.unregister(A))
     const adapters = cfg.adapters || []
-    this._configAdapters = adapters.filter(A => A != null && !NetworkAdapters.has(A))
+    this._configAdapters = adapters.filter(A => A != null)
     adapters.forEach(A => NetworkAdapters.register(A))
 
     // Samplers must be bound before the adapter so events emitted during
@@ -79,7 +81,7 @@ export default class TelemetryPlugin extends ContainerPlugin {
 
     this._configObservers.forEach(O => ObserverRegistry.unregister(O))
     const observers = cfg.observers || []
-    this._configObservers = observers.filter(O => O != null && !ObserverRegistry.has(O))
+    this._configObservers = observers.filter(O => O != null)
     observers.forEach(O => ObserverRegistry.register(O))
 
     if (this.observerRegistry) this.observerRegistry.destroy()
@@ -91,7 +93,7 @@ export default class TelemetryPlugin extends ContainerPlugin {
       if (this.adapter) this.adapter.destroy()
       this.adapter = new AdapterClass(playback, this.container)
       this.adapter.bind()
-    } else if (NetworkAdapters.size > 0) {
+    } else if (adapters.length > 0) {
       Log.warn(`[TelemetryPlugin] No network adapter for playback: ${playback.name || playback.constructor.name || 'unknown'}`)
     }
   }

--- a/packages/clappr-telemetry/src/telemetry_plugin.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.js
@@ -85,9 +85,15 @@ export default class TelemetryPlugin extends ContainerPlugin {
     this.observerRegistry = new ObserverRegistry(playback, this.container, this.samplerRegistry)
     this.observerRegistry.bind()
 
+    // Always tear down the previous adapter first — otherwise switching to a
+    // playback/source with no matching adapter would leave the old one bound
+    // to a stale playback instance.
+    if (this.adapter) {
+      this.adapter.destroy()
+      this.adapter = null
+    }
     const AdapterClass = NetworkAdapters.find(playback, cfg)
     if (AdapterClass) {
-      if (this.adapter) this.adapter.destroy()
       this.adapter = new AdapterClass(playback, this.container)
       this.adapter.bind()
     } else if (adapters.length > 0) {

--- a/packages/clappr-telemetry/src/telemetry_plugin.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.js
@@ -61,17 +61,15 @@ export default class TelemetryPlugin extends ContainerPlugin {
     const cfg = this.container.options?.telemetry
     if (!cfg || cfg.enabled === false) return
 
-    // Unregister previously tracked config classes (ref-counted — global registry
-    // only removes them when the last player holding a ref calls unregister).
+    // Only track classes that actually registered — these registries are keyed
+    // by name, so unregistering a rejected class could remove an unrelated one.
     this._configSamplers.forEach(S => SamplerRegistry.unregister(S))
-    const samplers = cfg.samplers || []
-    this._configSamplers = samplers.filter(S => S != null)
-    samplers.forEach(S => SamplerRegistry.register(S))
+    const samplers = (cfg.samplers || []).filter(S => S != null)
+    this._configSamplers = samplers.filter(S => SamplerRegistry.register(S))
 
     this._configAdapters.forEach(A => NetworkAdapters.unregister(A))
-    const adapters = cfg.adapters || []
-    this._configAdapters = adapters.filter(A => A != null)
-    adapters.forEach(A => NetworkAdapters.register(A))
+    const adapters = (cfg.adapters || []).filter(A => A != null)
+    this._configAdapters = adapters.filter(A => NetworkAdapters.register(A))
 
     // Samplers must be bound before the adapter so events emitted during
     // adapter.bind() (e.g. STREAM_INFO on Shaka's attachFilters) are captured.
@@ -80,9 +78,8 @@ export default class TelemetryPlugin extends ContainerPlugin {
     this.samplerRegistry.bind()
 
     this._configObservers.forEach(O => ObserverRegistry.unregister(O))
-    const observers = cfg.observers || []
-    this._configObservers = observers.filter(O => O != null)
-    observers.forEach(O => ObserverRegistry.register(O))
+    const observers = (cfg.observers || []).filter(O => O != null)
+    this._configObservers = observers.filter(O => ObserverRegistry.register(O))
 
     if (this.observerRegistry) this.observerRegistry.destroy()
     this.observerRegistry = new ObserverRegistry(playback, this.container, this.samplerRegistry)

--- a/packages/clappr-telemetry/src/telemetry_plugin.test.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.test.js
@@ -238,7 +238,7 @@ describe('TelemetryPlugin', () => {
 
   it.each([
     ['telemetry config is absent', undefined],
-    ['enabled is false',           { enabled: false }],
+    ['enabled is false', { enabled: false }]
   ])('returns early and skips all setup when %s', (_, telemetry) => {
     mockContainer.options.telemetry = telemetry
 

--- a/packages/clappr-telemetry/src/telemetry_plugin.test.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.test.js
@@ -147,6 +147,12 @@ describe('TelemetryPlugin', () => {
     expect(plugin.adapter).toBeNull()
   })
 
+  it('passes telemetry config to NetworkAdapters.find', () => {
+    plugin.onPlaybackRead(mockPlayback)
+
+    expect(NetworkAdapters.find).toHaveBeenCalledWith(mockPlayback, mockContainer.options.telemetry)
+  })
+
   it('should not throw on destroy when adapter is null', () => {
     plugin.adapter = null
     expect(() => plugin.destroy()).not.toThrow()

--- a/packages/clappr-telemetry/src/telemetry_plugin.test.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.test.js
@@ -224,8 +224,11 @@ describe('TelemetryPlugin', () => {
     expect(NetworkAdapters.register).not.toHaveBeenCalled()
   })
 
-  it('returns early and skips all setup when enabled is false', () => {
-    mockContainer.options.telemetry.enabled = false
+  it.each([
+    ['telemetry config is absent', undefined],
+    ['enabled is false',           { enabled: false }],
+  ])('returns early and skips all setup when %s', (_, telemetry) => {
+    mockContainer.options.telemetry = telemetry
 
     plugin.onPlaybackRead(mockPlayback)
 

--- a/packages/clappr-telemetry/src/telemetry_plugin.test.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.test.js
@@ -194,6 +194,21 @@ describe('TelemetryPlugin', () => {
     expect(plugin.adapter).toBe(newAdapter)
   })
 
+  it('should destroy previous adapter when a subsequent onPlaybackRead finds no matching adapter', () => {
+    const oldAdapter = { bind: jest.fn(), destroy: jest.fn() }
+    const OldClass = jest.fn(() => oldAdapter)
+
+    NetworkAdapters.find.mockReturnValueOnce(OldClass)
+    plugin.onPlaybackRead(mockPlayback)
+    expect(plugin.adapter).toBe(oldAdapter)
+
+    NetworkAdapters.find.mockReturnValueOnce(null)
+    plugin.onPlaybackRead(mockPlayback)
+
+    expect(oldAdapter.destroy).toHaveBeenCalled()
+    expect(plugin.adapter).toBeNull()
+  })
+
   it('should log warning when adapters are provided but none matches the playback engine', () => {
     jest.spyOn(Log, 'warn').mockImplementation(() => {})
     const MockAdapterClass = jest.fn()

--- a/packages/clappr-telemetry/src/telemetry_plugin.test.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.test.js
@@ -5,12 +5,14 @@ import MockSamplerRegistryClass from './samplers/sampler_registry'
 import MockObserverRegistryClass from './observers/observer_registry'
 
 jest.mock('./adapters', () => ({
-  NetworkAdapters: { find: jest.fn(), register: jest.fn() }
+  NetworkAdapters: { find: jest.fn(), register: jest.fn(), unregister: jest.fn(), has: jest.fn(() => false), size: 0 }
 }))
 
 jest.mock('./samplers/sampler_registry', () => {
   const mock = jest.fn()
   mock.register = jest.fn()
+  mock.unregister = jest.fn()
+  mock.has = jest.fn(() => false)
   return { __esModule: true, default: mock }
 })
 
@@ -18,10 +20,13 @@ jest.mock('./samplers', () => ({
   SamplerRegistry: jest.requireMock('./samplers/sampler_registry').default
 }))
 
-jest.mock('./observers/observer_registry', () => ({
-  __esModule: true,
-  default: jest.fn()
-}))
+jest.mock('./observers/observer_registry', () => {
+  const mock = jest.fn()
+  mock.register = jest.fn()
+  mock.unregister = jest.fn()
+  mock.has = jest.fn(() => false)
+  return { __esModule: true, default: mock }
+})
 
 let mockSamplerRegistry
 let mockObserverRegistry
@@ -36,6 +41,7 @@ describe('TelemetryPlugin', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     NetworkAdapters.find.mockReturnValue(null)
+    NetworkAdapters.size = 0
     mockSamplerRegistry = { bind: jest.fn(), destroy: jest.fn(), snapshot: jest.fn(() => ({})) }
     MockSamplerRegistryClass.mockImplementation(() => mockSamplerRegistry)
     mockObserverRegistry = { bind: jest.fn(), destroy: jest.fn() }
@@ -187,6 +193,7 @@ describe('TelemetryPlugin', () => {
     const MockAdapterClass = jest.fn()
     mockContainer.options.telemetry.adapters = [MockAdapterClass]
     NetworkAdapters.find.mockReturnValueOnce(null)
+    NetworkAdapters.size = 1
 
     plugin.onPlaybackRead(mockPlayback)
 

--- a/packages/clappr-telemetry/src/telemetry_plugin.test.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.test.js
@@ -199,7 +199,6 @@ describe('TelemetryPlugin', () => {
     const MockAdapterClass = jest.fn()
     mockContainer.options.telemetry.adapters = [MockAdapterClass]
     NetworkAdapters.find.mockReturnValueOnce(null)
-    NetworkAdapters.size = 1
 
     plugin.onPlaybackRead(mockPlayback)
 
@@ -323,6 +322,17 @@ describe('TelemetryPlugin', () => {
       plugin.onPlaybackRead(mockPlayback)
 
       expect(registerSpy).not.toHaveBeenCalled()
+    })
+
+    it('calls unregister on destroy for samplers that were pre-registered in the global registry', () => {
+      const SamplerA = jest.fn()
+      MockSamplerRegistryClass.has.mockReturnValue(true)
+      mockContainer.options.telemetry.samplers = [SamplerA]
+
+      plugin.onPlaybackRead(mockPlayback)
+      plugin.destroy()
+
+      expect(MockSamplerRegistryClass.unregister).toHaveBeenCalledWith(SamplerA)
     })
   })
 

--- a/packages/clappr-telemetry/src/telemetry_plugin.test.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.test.js
@@ -1,11 +1,11 @@
 import { Log, Events } from '@clappr/core'
 import TelemetryPlugin from './telemetry_plugin'
-import { findNetworkAdapter } from './adapters'
+import { NetworkAdapters } from './adapters'
 import MockSamplerRegistryClass from './samplers/sampler_registry'
 import MockObserverRegistryClass from './observers/observer_registry'
 
 jest.mock('./adapters', () => ({
-  findNetworkAdapter: jest.fn()
+  NetworkAdapters: { find: jest.fn() }
 }))
 
 jest.mock('./samplers/sampler_registry', () => ({
@@ -30,7 +30,7 @@ describe('TelemetryPlugin', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    findNetworkAdapter.mockReturnValue(null)
+    NetworkAdapters.find.mockReturnValue(null)
     mockSamplerRegistry = { bind: jest.fn(), destroy: jest.fn() }
     MockSamplerRegistryClass.mockImplementation(() => mockSamplerRegistry)
     mockObserverRegistry = { bind: jest.fn(), destroy: jest.fn() }
@@ -58,6 +58,10 @@ describe('TelemetryPlugin', () => {
 
   it('should have name property', () => {
     expect(plugin.name).toBe('telemetry')
+  })
+
+  it('exposes NetworkAdapters as a static getter', () => {
+    expect(TelemetryPlugin.NetworkAdapters).toBe(NetworkAdapters)
   })
 
   it('should register listener on CONTAINER_READY event during bindEvents', () => {
@@ -103,7 +107,7 @@ describe('TelemetryPlugin', () => {
   it('should instantiate and bind the adapter when playback is available', () => {
     const mockAdapter = { bind: jest.fn() }
     const MockAdapterClass = jest.fn(() => mockAdapter)
-    findNetworkAdapter.mockReturnValue(MockAdapterClass)
+    NetworkAdapters.find.mockReturnValue(MockAdapterClass)
 
     plugin.onPlaybackRead(mockPlayback)
 
@@ -136,8 +140,8 @@ describe('TelemetryPlugin', () => {
     expect(disabledPlugin.adapter).toBeNull()
   })
 
-  it('should not instantiate adapter when findNetworkAdapter returns null', () => {
-    findNetworkAdapter.mockReturnValueOnce(null)
+  it('should not instantiate adapter when NetworkAdapters.find returns null', () => {
+    NetworkAdapters.find.mockReturnValueOnce(null)
 
     plugin.onPlaybackRead(mockPlayback)
 
@@ -146,7 +150,7 @@ describe('TelemetryPlugin', () => {
 
   it('should log warning when no adapter is found for playback engine', () => {
     jest.spyOn(Log, 'warn').mockImplementation(() => {})
-    findNetworkAdapter.mockReturnValueOnce(null)
+    NetworkAdapters.find.mockReturnValueOnce(null)
 
     plugin.onPlaybackRead(mockPlayback)
 
@@ -161,21 +165,21 @@ describe('TelemetryPlugin', () => {
     const OldClass = jest.fn(() => oldAdapter)
     const NewClass = jest.fn(() => newAdapter)
 
-    findNetworkAdapter.mockReturnValueOnce(OldClass)
+    NetworkAdapters.find.mockReturnValueOnce(OldClass)
     plugin.onPlaybackRead(mockPlayback)
     expect(plugin.adapter).toBe(oldAdapter)
 
-    findNetworkAdapter.mockReturnValueOnce(NewClass)
+    NetworkAdapters.find.mockReturnValueOnce(NewClass)
     plugin.onPlaybackRead(mockPlayback)
 
     expect(oldAdapter.destroy).toHaveBeenCalled()
     expect(plugin.adapter).toBe(newAdapter)
   })
 
-  it('should instantiate HlsNetworkAdapter when findNetworkAdapter returns it', () => {
+  it('should instantiate HlsNetworkAdapter when NetworkAdapters.find returns it', () => {
     const mockAdapter = { bind: jest.fn() }
     const MockHlsClass = jest.fn(() => mockAdapter)
-    findNetworkAdapter.mockReturnValueOnce(MockHlsClass)
+    NetworkAdapters.find.mockReturnValueOnce(MockHlsClass)
 
     plugin.onPlaybackRead({ name: 'hls' })
 

--- a/packages/clappr-telemetry/src/telemetry_plugin.test.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.test.js
@@ -5,12 +5,12 @@ import MockSamplerRegistryClass from './samplers/sampler_registry'
 import MockObserverRegistryClass from './observers/observer_registry'
 
 jest.mock('./adapters', () => ({
-  NetworkAdapters: { find: jest.fn(), register: jest.fn(), unregister: jest.fn(), has: jest.fn(() => false), size: 0 }
+  NetworkAdapters: { find: jest.fn(), register: jest.fn(() => true), unregister: jest.fn(), has: jest.fn(() => false), size: 0 }
 }))
 
 jest.mock('./samplers/sampler_registry', () => {
   const mock = jest.fn()
-  mock.register = jest.fn()
+  mock.register = jest.fn(() => true)
   mock.unregister = jest.fn()
   mock.has = jest.fn(() => false)
   return { __esModule: true, default: mock }
@@ -22,7 +22,7 @@ jest.mock('./samplers', () => ({
 
 jest.mock('./observers/observer_registry', () => {
   const mock = jest.fn()
-  mock.register = jest.fn()
+  mock.register = jest.fn(() => true)
   mock.unregister = jest.fn()
   mock.has = jest.fn(() => false)
   return { __esModule: true, default: mock }
@@ -236,6 +236,17 @@ describe('TelemetryPlugin', () => {
     expect(NetworkAdapters.register).not.toHaveBeenCalled()
   })
 
+  it('does not unregister an adapter that failed registration (avoids removing an unrelated class on destroy)', () => {
+    const InvalidAdapter = jest.fn()
+    NetworkAdapters.register.mockReturnValueOnce(false)
+    mockContainer.options.telemetry.adapters = [InvalidAdapter]
+
+    plugin.onPlaybackRead(mockPlayback)
+    plugin.destroy()
+
+    expect(NetworkAdapters.unregister).not.toHaveBeenCalledWith(InvalidAdapter)
+  })
+
   it.each([
     ['telemetry config is absent', undefined],
     ['enabled is false', { enabled: false }]
@@ -303,25 +314,22 @@ describe('TelemetryPlugin', () => {
     })
 
     it('registers samplers from telemetry.samplers config before instantiating SamplerRegistry', () => {
-      const SamplerRegistry = MockSamplerRegistryClass
-      const registerSpy = jest.spyOn(SamplerRegistry, 'register').mockImplementation(() => {})
       const SamplerA = jest.fn()
       const SamplerB = jest.fn()
       mockContainer.options.telemetry.samplers = [SamplerA, SamplerB]
 
       plugin.onPlaybackRead(mockPlayback)
 
-      expect(registerSpy).toHaveBeenCalledWith(SamplerA)
-      expect(registerSpy).toHaveBeenCalledWith(SamplerB)
+      expect(MockSamplerRegistryClass.register).toHaveBeenCalledWith(SamplerA)
+      expect(MockSamplerRegistryClass.register).toHaveBeenCalledWith(SamplerB)
     })
 
     it('does not call SamplerRegistry.register when samplers config is absent', () => {
-      const registerSpy = jest.spyOn(MockSamplerRegistryClass, 'register').mockImplementation(() => {})
       delete mockContainer.options.telemetry.samplers
 
       plugin.onPlaybackRead(mockPlayback)
 
-      expect(registerSpy).not.toHaveBeenCalled()
+      expect(MockSamplerRegistryClass.register).not.toHaveBeenCalled()
     })
 
     it('calls unregister on destroy for samplers that were pre-registered in the global registry', () => {
@@ -333,6 +341,17 @@ describe('TelemetryPlugin', () => {
       plugin.destroy()
 
       expect(MockSamplerRegistryClass.unregister).toHaveBeenCalledWith(SamplerA)
+    })
+
+    it('does not unregister a sampler that failed registration (avoids removing an unrelated class sharing its name)', () => {
+      const InvalidSampler = jest.fn()
+      MockSamplerRegistryClass.register.mockReturnValueOnce(false)
+      mockContainer.options.telemetry.samplers = [InvalidSampler]
+
+      plugin.onPlaybackRead(mockPlayback)
+      plugin.destroy()
+
+      expect(MockSamplerRegistryClass.unregister).not.toHaveBeenCalledWith(InvalidSampler)
     })
   })
 
@@ -363,6 +382,17 @@ describe('TelemetryPlugin', () => {
     it('should not throw on destroy when observerRegistry is null', () => {
       plugin.observerRegistry = null
       expect(() => plugin.destroy()).not.toThrow()
+    })
+
+    it('does not unregister an observer that failed registration (avoids removing an unrelated class sharing its name)', () => {
+      const InvalidObserver = jest.fn()
+      MockObserverRegistryClass.register.mockReturnValueOnce(false)
+      mockContainer.options.telemetry.observers = [InvalidObserver]
+
+      plugin.onPlaybackRead(mockPlayback)
+      plugin.destroy()
+
+      expect(MockObserverRegistryClass.unregister).not.toHaveBeenCalledWith(InvalidObserver)
     })
   })
 })

--- a/packages/clappr-telemetry/src/telemetry_plugin.test.js
+++ b/packages/clappr-telemetry/src/telemetry_plugin.test.js
@@ -5,12 +5,17 @@ import MockSamplerRegistryClass from './samplers/sampler_registry'
 import MockObserverRegistryClass from './observers/observer_registry'
 
 jest.mock('./adapters', () => ({
-  NetworkAdapters: { find: jest.fn() }
+  NetworkAdapters: { find: jest.fn(), register: jest.fn() }
 }))
 
-jest.mock('./samplers/sampler_registry', () => ({
-  __esModule: true,
-  default: jest.fn()
+jest.mock('./samplers/sampler_registry', () => {
+  const mock = jest.fn()
+  mock.register = jest.fn()
+  return { __esModule: true, default: mock }
+})
+
+jest.mock('./samplers', () => ({
+  SamplerRegistry: jest.requireMock('./samplers/sampler_registry').default
 }))
 
 jest.mock('./observers/observer_registry', () => ({
@@ -31,7 +36,7 @@ describe('TelemetryPlugin', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     NetworkAdapters.find.mockReturnValue(null)
-    mockSamplerRegistry = { bind: jest.fn(), destroy: jest.fn() }
+    mockSamplerRegistry = { bind: jest.fn(), destroy: jest.fn(), snapshot: jest.fn(() => ({})) }
     MockSamplerRegistryClass.mockImplementation(() => mockSamplerRegistry)
     mockObserverRegistry = { bind: jest.fn(), destroy: jest.fn() }
     MockObserverRegistryClass.mockImplementation(() => mockObserverRegistry)
@@ -41,7 +46,7 @@ describe('TelemetryPlugin', () => {
       on: jest.fn(),
       off: jest.fn(),
       playback: null,
-      options: { telemetry: { network: { enabled: true } } }
+      options: { telemetry: {} }
     }
     plugin = new TelemetryPlugin(mockContainer)
   })
@@ -128,64 +133,12 @@ describe('TelemetryPlugin', () => {
     expect(p.adapter).toBeNull()
   })
 
-  it('should not instantiate adapter when telemetry is disabled', () => {
-    const disabledContainer = {
-      on: jest.fn(),
-      off: jest.fn(),
-      playback: null,
-      options: { telemetry: { network: { enabled: false } } }
-    }
-    const disabledPlugin = new TelemetryPlugin(disabledContainer)
-    disabledPlugin.onPlaybackRead(mockPlayback)
-    expect(disabledPlugin.adapter).toBeNull()
-  })
-
   it('should not instantiate adapter when NetworkAdapters.find returns null', () => {
     NetworkAdapters.find.mockReturnValueOnce(null)
 
     plugin.onPlaybackRead(mockPlayback)
 
     expect(plugin.adapter).toBeNull()
-  })
-
-  it('should log warning when no adapter is found for playback engine', () => {
-    jest.spyOn(Log, 'warn').mockImplementation(() => {})
-    NetworkAdapters.find.mockReturnValueOnce(null)
-
-    plugin.onPlaybackRead(mockPlayback)
-
-    expect(Log.warn).toHaveBeenCalledWith(
-      '[TelemetryPlugin] No network adapter for playback: dash_shaka_playback'
-    )
-  })
-
-  it('should destroy previous adapter when onPlaybackRead is called again', () => {
-    const oldAdapter = { bind: jest.fn(), destroy: jest.fn() }
-    const newAdapter = { bind: jest.fn(), destroy: jest.fn() }
-    const OldClass = jest.fn(() => oldAdapter)
-    const NewClass = jest.fn(() => newAdapter)
-
-    NetworkAdapters.find.mockReturnValueOnce(OldClass)
-    plugin.onPlaybackRead(mockPlayback)
-    expect(plugin.adapter).toBe(oldAdapter)
-
-    NetworkAdapters.find.mockReturnValueOnce(NewClass)
-    plugin.onPlaybackRead(mockPlayback)
-
-    expect(oldAdapter.destroy).toHaveBeenCalled()
-    expect(plugin.adapter).toBe(newAdapter)
-  })
-
-  it('should instantiate HlsNetworkAdapter when NetworkAdapters.find returns it', () => {
-    const mockAdapter = { bind: jest.fn() }
-    const MockHlsClass = jest.fn(() => mockAdapter)
-    NetworkAdapters.find.mockReturnValueOnce(MockHlsClass)
-
-    plugin.onPlaybackRead({ name: 'hls' })
-
-    expect(MockHlsClass).toHaveBeenCalledWith({ name: 'hls' }, mockContainer)
-    expect(mockAdapter.bind).toHaveBeenCalled()
-    expect(plugin.adapter).toBe(mockAdapter)
   })
 
   it('should not throw on destroy when adapter is null', () => {
@@ -212,22 +165,93 @@ describe('TelemetryPlugin', () => {
     expect(parentDestroy).toHaveBeenCalled()
   })
 
+  it('should destroy previous adapter when onPlaybackRead is called again', () => {
+    const oldAdapter = { bind: jest.fn(), destroy: jest.fn() }
+    const newAdapter = { bind: jest.fn(), destroy: jest.fn() }
+    const OldClass = jest.fn(() => oldAdapter)
+    const NewClass = jest.fn(() => newAdapter)
+
+    NetworkAdapters.find.mockReturnValueOnce(OldClass)
+    plugin.onPlaybackRead(mockPlayback)
+    expect(plugin.adapter).toBe(oldAdapter)
+
+    NetworkAdapters.find.mockReturnValueOnce(NewClass)
+    plugin.onPlaybackRead(mockPlayback)
+
+    expect(oldAdapter.destroy).toHaveBeenCalled()
+    expect(plugin.adapter).toBe(newAdapter)
+  })
+
+  it('should log warning when adapters are provided but none matches the playback engine', () => {
+    jest.spyOn(Log, 'warn').mockImplementation(() => {})
+    const MockAdapterClass = jest.fn()
+    mockContainer.options.telemetry.adapters = [MockAdapterClass]
+    NetworkAdapters.find.mockReturnValueOnce(null)
+
+    plugin.onPlaybackRead(mockPlayback)
+
+    expect(Log.warn).toHaveBeenCalledWith(
+      '[TelemetryPlugin] No network adapter for playback: dash_shaka_playback'
+    )
+  })
+
+  it('should not log warning when no adapters are provided', () => {
+    jest.spyOn(Log, 'warn').mockImplementation(() => {})
+    mockContainer.options.telemetry.adapters = []
+    NetworkAdapters.find.mockReturnValueOnce(null)
+
+    plugin.onPlaybackRead(mockPlayback)
+
+    expect(Log.warn).not.toHaveBeenCalled()
+  })
+
+  it('registers adapters from telemetry.adapters config', () => {
+    const AdapterA = jest.fn()
+    const AdapterB = jest.fn()
+    mockContainer.options.telemetry.adapters = [AdapterA, AdapterB]
+
+    plugin.onPlaybackRead(mockPlayback)
+
+    expect(NetworkAdapters.register).toHaveBeenCalledWith(AdapterA)
+    expect(NetworkAdapters.register).toHaveBeenCalledWith(AdapterB)
+  })
+
+  it('does not call NetworkAdapters.register when adapters config is absent', () => {
+    delete mockContainer.options.telemetry.adapters
+
+    plugin.onPlaybackRead(mockPlayback)
+
+    expect(NetworkAdapters.register).not.toHaveBeenCalled()
+  })
+
+  it('returns early and skips all setup when enabled is false', () => {
+    mockContainer.options.telemetry.enabled = false
+
+    plugin.onPlaybackRead(mockPlayback)
+
+    expect(NetworkAdapters.register).not.toHaveBeenCalled()
+    expect(NetworkAdapters.find).not.toHaveBeenCalled()
+    expect(MockSamplerRegistryClass).not.toHaveBeenCalled()
+    expect(plugin.adapter).toBeNull()
+    expect(plugin.samplerRegistry).toBeNull()
+  })
+
   describe('snapshot getter', () => {
-    it('delegates to samplerScheduler.snapshot()', () => {
+    it('delegates to samplerRegistry.snapshot()', () => {
       mockSamplerRegistry.snapshot = jest.fn(() => ({ buffer: { bufferAhead: 10 } }))
       plugin.onPlaybackRead(mockPlayback)
       expect(plugin.snapshot).toEqual({ buffer: { bufferAhead: 10 } })
       expect(mockSamplerRegistry.snapshot).toHaveBeenCalled()
     })
 
-    it('returns empty object when samplerScheduler is null', () => {
+    it('returns empty object when samplerRegistry is null', () => {
       plugin.samplerRegistry = null
       expect(plugin.snapshot).toEqual({})
     })
   })
 
   describe('SamplerRegistry lifecycle', () => {
-    it('should instantiate and bind samplerScheduler on onPlaybackRead', () => {
+    it('should instantiate and bind samplerRegistry on onPlaybackRead', () => {
       plugin.onPlaybackRead(mockPlayback)
 
       expect(MockSamplerRegistryClass).toHaveBeenCalledWith(mockPlayback, mockContainer)
@@ -235,14 +259,14 @@ describe('TelemetryPlugin', () => {
       expect(plugin.samplerRegistry).toBe(mockSamplerRegistry)
     })
 
-    it('should destroy previous samplerScheduler on re-bind', () => {
+    it('should destroy previous samplerRegistry on re-bind', () => {
       plugin.onPlaybackRead(mockPlayback)
       plugin.onPlaybackRead(mockPlayback)
 
       expect(mockSamplerRegistry.destroy).toHaveBeenCalledTimes(1)
     })
 
-    it('should destroy samplerScheduler on plugin destroy', () => {
+    it('should destroy samplerRegistry on plugin destroy', () => {
       plugin.onPlaybackRead(mockPlayback)
       plugin.destroy()
 
@@ -250,21 +274,39 @@ describe('TelemetryPlugin', () => {
       expect(plugin.samplerRegistry).toBeNull()
     })
 
-    it('should not throw on destroy when samplerScheduler is null', () => {
+    it('should not throw on destroy when samplerRegistry is null', () => {
       plugin.samplerRegistry = null
       expect(() => plugin.destroy()).not.toThrow()
     })
 
-    it('should instantiate samplerScheduler even when network adapter is disabled', () => {
-      const c = {
-        on: jest.fn(), off: jest.fn(), playback: null,
-        options: { telemetry: { network: { enabled: false } } }
-      }
-      const p = new TelemetryPlugin(c)
-      p.onPlaybackRead(mockPlayback)
+    it('should instantiate samplerRegistry even when no adapter matches', () => {
+      NetworkAdapters.find.mockReturnValue(null)
+      plugin.onPlaybackRead(mockPlayback)
 
-      expect(p.samplerRegistry).toBe(mockSamplerRegistry)
-      expect(p.adapter).toBeNull()
+      expect(plugin.samplerRegistry).toBe(mockSamplerRegistry)
+      expect(plugin.adapter).toBeNull()
+    })
+
+    it('registers samplers from telemetry.samplers config before instantiating SamplerRegistry', () => {
+      const SamplerRegistry = MockSamplerRegistryClass
+      const registerSpy = jest.spyOn(SamplerRegistry, 'register').mockImplementation(() => {})
+      const SamplerA = jest.fn()
+      const SamplerB = jest.fn()
+      mockContainer.options.telemetry.samplers = [SamplerA, SamplerB]
+
+      plugin.onPlaybackRead(mockPlayback)
+
+      expect(registerSpy).toHaveBeenCalledWith(SamplerA)
+      expect(registerSpy).toHaveBeenCalledWith(SamplerB)
+    })
+
+    it('does not call SamplerRegistry.register when samplers config is absent', () => {
+      const registerSpy = jest.spyOn(MockSamplerRegistryClass, 'register').mockImplementation(() => {})
+      delete mockContainer.options.telemetry.samplers
+
+      plugin.onPlaybackRead(mockPlayback)
+
+      expect(registerSpy).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/clappr-telemetry/src/utils/index.js
+++ b/packages/clappr-telemetry/src/utils/index.js
@@ -10,3 +10,18 @@ export {
   parseVideoCodec,
   parseAudioCodec
 } from './helpers'
+
+/**
+ * Checks whether a registry component class should be instantiated.
+ * Both conditions must pass (AND — not exclusive):
+ *   1. static isEnabled(cfg) — if defined, must return truthy
+ *   2. cfg[Cls.name]?.enabled — must not be explicitly false
+ *
+ * @param {Function} Cls - Registry class
+ * @param {Object} cfg - Telemetry config (container.options.telemetry)
+ * @returns {boolean}
+ */
+export const isComponentEnabled = (Cls, cfg) => {
+  if (typeof Cls.isEnabled === 'function' && !Cls.isEnabled(cfg)) return false
+  return cfg[Cls.name]?.enabled !== false
+}


### PR DESCRIPTION
### Motivação

A arquitetura anterior amarrava o plugin de telemetria ao HLS.js e ao Shaka, adapters eram fixos no código, samplers pré-registrados globalmente, e não havia como excluir coletores específicos sem fazer fork do pacote. Isso tornava o plugin inviável para qualquer engine de playback fora dos dois built-ins.

### O que mudou

**Registries começam vazios — você traz o que precisa**

Os três subsistemas agora seguem o mesmo padrão de registro explícito:

```js
telemetry: {
  adapters:  [ShakaNetworkAdapter, HlsNetworkAdapter],
  samplers:  [BufferSampler, DecodingSampler, PlaybackStateSampler,
              NetworkSampler, PlaybackTimingSampler, StreamInfoSampler],
  observers: [VideoEventObserver],
  sampleIntervalMs: 1000,
}
```

Nenhum adapter, sampler ou observer é ativado sem ser explicitamente incluído.

**`NetworkAdapters`** — substitui a função hardcoded `findNetworkAdapter()` por um registry estático. Adapters customizados podem ser registrados via `NetworkAdapters.register(MeuAdapter)` antes da instanciação do player.

**`SamplerRegistry`** — mesmo padrão. Registry começa vazio; os samplers built-in são opt-in. O registry agora inclui seis samplers built-in: `BufferSampler`, `DecodingSampler`, `PlaybackStateSampler`, `NetworkSampler`, `PlaybackTimingSampler` e `StreamInfoSampler`.

**`ObserverRegistry`** — alinhado com a mesma arquitetura. `VideoEventObserver` deixa de ser pré-registrado e passa a ser opt-in.

**Lifecycle via config** — adapters, samplers e observers passados no config são registrados automaticamente no `CONTAINER_READY` e removidos no `destroy()`, sem vazamentos entre instâncias.

**Opt-out granular** — quando componentes são pré-registrados globalmente, use `<name>.enabled: false` para desativá-los por instância sem afetar outras:

```js
telemetry: {
  samplers: [BufferSampler, DecodingSampler, NetworkSampler],
  decoding: { enabled: false }, // desativa por instância
}
```

**Chaves do snapshot** normalizadas para camelCase: `buffer`, `decoding`, `playbackState`, `network`, `timing`, `streamInfo`.

**Snapshot on-demand** — o plugin expõe um getter `snapshot` para leitura imediata dos dados sem esperar o próximo tick e sem emitir evento:

```js
const data = player.getPlugin('telemetry').snapshot
```

**Build UMD** agora expõe todas as classes como propriedades estáticas de `ClapprTelemetry` (ex: `ClapprTelemetry.NetworkAdapters`, `ClapprTelemetry.SamplerRegistry`).

**Demo page** atualizada com templates por engine (HLS, Shaka, Widevine, HTML5), cada um carregando apenas o adapter e os samplers relevantes.

---

## feat(telemetry): extensible registry pattern for adapters, samplers and observers

### Motivation

The previous architecture had the telemetry plugin tightly coupled to HLS.js and Shaka — adapters were hardcoded, samplers were pre-registered globally, and there was no way to opt out of specific collectors without forking the package. This made the plugin impractical for any playback engine outside the two built-ins.

### What changed

**Registries start empty — you bring what you need**

All three subsystems now follow the same explicit registration pattern:

```js
telemetry: {
  adapters:  [ShakaNetworkAdapter, HlsNetworkAdapter],
  samplers:  [BufferSampler, DecodingSampler, PlaybackStateSampler,
              NetworkSampler, PlaybackTimingSampler, StreamInfoSampler],
  observers: [VideoEventObserver],
  sampleIntervalMs: 1000,
}
```

No adapter, sampler or observer runs unless explicitly included.

**`NetworkAdapters`** — replaces the hardcoded `findNetworkAdapter()` function with a static registry. Custom adapters can be registered via `NetworkAdapters.register(MyAdapter)` before the player is instantiated.

**`SamplerRegistry`** — same pattern. Registry starts empty; built-in samplers are opt-in. Six built-in samplers are now available: `BufferSampler`, `DecodingSampler`, `PlaybackStateSampler`, `NetworkSampler`, `PlaybackTimingSampler`, and `StreamInfoSampler`.

**`ObserverRegistry`** — aligned with the same architecture. `VideoEventObserver` is no longer pre-registered.

**Config-driven lifecycle** — adapters, samplers and observers passed via config are automatically registered on `CONTAINER_READY` and unregistered on `destroy()`, with no registry leaks between player instances.

**Granular opt-out** — when components are pre-registered globally (e.g. in a shared SDK setup), use `<name>.enabled: false` to disable specific ones per player instance without affecting others:

```js
telemetry: {
  samplers: [BufferSampler, DecodingSampler, NetworkSampler],
  decoding: { enabled: false }, // disabled for this instance only
}
```

**Snapshot keys** normalized to camelCase: `buffer`, `decoding`, `playbackState`, `network`, `timing`, `streamInfo`.

**On-demand snapshot** — the plugin exposes a `snapshot` getter for immediate sampler data without waiting for the next tick and without emitting any event:

```js
const data = player.getPlugin('telemetry').snapshot
```

**UMD build** now exposes all classes as static properties of `ClapprTelemetry` (e.g. `ClapprTelemetry.NetworkAdapters`, `ClapprTelemetry.SamplerRegistry`).

**Demo page** updated with per-engine templates (HLS, Shaka, Widevine, HTML5), each loading only the relevant adapter and samplers.
