### PR TITLE
fix(ci): release via lerna version + npm OIDC publish (#2455)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,25 @@ jobs:
       id-token: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # github-actions[bot] cannot be added to bypass_pull_request_allowances;
-          # Core Team fine-grained PAT until a bypassable app is available. See #2460.
-          token: ${{ secrets.RELEASE_TOKEN }}
+          # App must be in main's bypass_pull_request_allowances (built-in
+          # GitHub Actions cannot). See #2455 / #2460.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git
         run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Use Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,13 @@ on:
   workflow_run:
     workflows: ['CI']
     branches: [main]
-    types:
-      - completed
+    types: [completed]
+  workflow_dispatch:
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
       id-token: write
@@ -30,44 +30,82 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           registry-url: https://registry.npmjs.org
           cache: 'yarn'
+
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
-      - name: Check for changes
-        id: check_changes
+      - name: Resolve packages to publish
+        id: changed
         run: |
           git fetch --tags
           set +e
-          OUTPUT=$(lerna changed 2>&1)
+          OUTPUT=$(npx lerna changed --include-merged-tags --json 2>&1)
           EXIT_CODE=$?
           set -e
 
           if echo "$OUTPUT" | grep -q "No changed packages found"; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "packages=[]" >> "$GITHUB_OUTPUT"
+            echo "count=0" >> "$GITHUB_OUTPUT"
             echo "No packages to publish"
-          elif [ $EXIT_CODE -eq 0 ] && [ -n "$OUTPUT" ]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "Found packages to publish:"
-            echo "$OUTPUT"
-          elif [ $EXIT_CODE -eq 0 ] && [ -z "$OUTPUT" ]; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "No packages to publish (empty output)"
-          else
+            exit 0
+          fi
+
+          if [ $EXIT_CODE -ne 0 ]; then
             echo "Error running lerna changed (exit code: $EXIT_CODE):"
             echo "$OUTPUT"
             exit 1
           fi
 
-      - name: Release packages
-        id: release
-        if: steps.check_changes.outputs.has_changes == 'true'
-        run: yarn release
-        continue-on-error: true
+          PKGS=$(echo "$OUTPUT" | jq -c '[.[] | select(.private == false) | .name]')
+          echo "packages=$PKGS" >> "$GITHUB_OUTPUT"
+          echo "count=$(echo "$PKGS" | jq 'length')" >> "$GITHUB_OUTPUT"
+          echo "Packages to publish: $PKGS"
 
-      - name: Publish from git tags
-        if: steps.check_changes.outputs.has_changes == 'true' && steps.release.outcome == 'failure'
-        run: lerna publish from-git --yes
+      - name: Version and tag
+        if: steps.changed.outputs.count != '0'
+        run: npx lerna version --include-merged-tags --no-push --yes
+
+      - name: Push commit, then tags
+        if: steps.changed.outputs.count != '0'
+        run: |
+          # Fail here if branch protection rejects the bot — before any tags leave the runner
+          git push origin HEAD:main
+          git push origin --tags
+
+      - name: Publish to npm
+        if: steps.changed.outputs.count != '0'
+        run: |
+          for pkg in $(echo '${{ steps.changed.outputs.packages }}' | jq -r '.[]'); do
+            echo "::group::publish $pkg"
+            npm publish -w "$pkg" --provenance
+            echo "::endgroup::"
+          done
+
+  notify-failure:
+    needs: release
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open issue for failed release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create --repo ${{ github.repository }} \
+            --title "Release workflow failed on $(date -u +%Y-%m-%d)" \
+            --label bug \
+            --body "The Release workflow failed and no packages were published.
+
+          Run: $RUN_URL
+
+          Check the failing step before re-running. Recovery is manual via \`workflow_dispatch\`."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # github-actions[bot] cannot be added to bypass_pull_request_allowances;
+          # Core Team fine-grained PAT until a bypassable app is available. See #2460.
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Configure git
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Packages that do **not** publish to npm:
 - `yarn workspace <package-name> add <dependency>` — Package-specific dependency
 - `lerna run <command>` — All packages
 - `lerna run <command> --scope=<package-name>` — Single package
-- `yarn release` — Publish (`lerna publish`, independent versioning)
+- `yarn release` — Version packages (`lerna version`); npm publish is done by the Release workflow via OIDC
 
 ### Running projects
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint packages/*/src/ --fix",
     "format": "prettier --write \"**/*.{js,ts,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,ts,json,md}\"",
-    "release": "lerna publish --include-merged-tags --provenance --yes",
+    "release": "lerna version --include-merged-tags --no-push --yes",
     "prepare": "husky",
     "test": "lerna run test --scope=@clappr/core --scope=@clappr/clappr-html5-tvs-playback",
     "build": "lerna run build --scope=@clappr/player --include-dependencies"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Second PR for [#2455](https://github.com/clappr/clappr/issues/2455). Fixes the three release bugs: invalid `--provenance` on `lerna publish`, missing npm auth (OIDC via npm CLI), and orphan-tag failure mode from pushing tags before the version commit lands on `main`.

**Do not merge until the GitHub App setup below is done.** Merging triggers CI → Release and the first real publish in nine months.

## Prerequisites

1. ~~Merge [#2458](https://github.com/clappr/clappr/pull/2458)~~ done
2. ~~Trusted Publishers~~ already configured (`release.yml` / `clappr/clappr`)
3. **Org GitHub App** for release pushes (built-in GitHub Actions cannot be added to bypass):
   - [x] App created (Contents: R/W, Metadata: R)
   - [x] Private key generated; secrets `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY` on the repo
   - [x] App **installed** on `clappr/clappr`
   - [x] App added to `main` → *Allow specified actors to bypass required pull requests*

Follow-up cleanup of any leftover PAT path: [#2460](https://github.com/clappr/clappr/issues/2460).

## Changes

- Root `release` script: `lerna version --include-merged-tags --no-push --yes`
- Rewrite `.github/workflows/release.yml`:
  - `workflow_dispatch` for recovery
  - Node 22 + `npm@latest` (Trusted Publishing needs npm ≥ 11.5.1)
  - `lerna changed --include-merged-tags`, filter `private == false`
  - `lerna version --no-push` → push **commit then tags**
  - Auth via `actions/create-github-app-token` + `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`
  - `npm publish -w <pkg> --provenance` (OIDC; no npm token)
  - Remove `continue-on-error` and the blind `from-git` fallback
  - `notify-failure` opens a `bug` issue on red runs
- Update `AGENTS.md` tooling line for the new release script

## Test plan

- [x] Tags retargeted; private packages excluded after #2458
- [x] App secrets + install + branch-protection bypass in place
- [ ] After merge: Release run publishes; `chore: publish` lands on `main` (not orphaned)
- [ ] Provenance badge on npm package pages

Related: [#2457](https://github.com/clappr/clappr/issues/2457), [#2460](https://github.com/clappr/clappr/issues/2460).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef3daa81-70fe-4c0d-9b0d-a31eabb1cee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef3daa81-70fe-4c0d-9b0d-a31eabb1cee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

