### PR TITLE
fix(ci): keep lerna logs out of changed JSON parse

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,18 @@ jobs:
         run: |
           git fetch --tags
           set +e
-          OUTPUT=$(npx lerna changed --include-merged-tags --json 2>&1)
+          # Keep lerna notices on stderr out of OUTPUT — mixing 2>&1 breaks jq.
+          ERR_FILE=$(mktemp)
+          OUTPUT=$(npx lerna changed --include-merged-tags --json 2>"$ERR_FILE")
           EXIT_CODE=$?
           set -e
+          ERR=$(cat "$ERR_FILE")
+          rm -f "$ERR_FILE"
+          if [ -n "$ERR" ]; then
+            echo "$ERR"
+          fi
 
-          if echo "$OUTPUT" | grep -q "No changed packages found"; then
+          if echo "$ERR$OUTPUT" | grep -q "No changed packages found"; then
             echo "packages=[]" >> "$GITHUB_OUTPUT"
             echo "count=0" >> "$GITHUB_OUTPUT"
             echo "No packages to publish"
@@ -69,6 +76,7 @@ jobs:
 
           if [ $EXIT_CODE -ne 0 ]; then
             echo "Error running lerna changed (exit code: $EXIT_CODE):"
+            echo "$ERR"
             echo "$OUTPUT"
             exit 1
           fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The first Release after #2459 failed in **Resolve packages to publish** with `jq: parse error` (exit 5): we captured `lerna changed --json` as `2>&1`, so lerna notice lines polluted the JSON before `jq`.

[Failed run](https://github.com/clappr/clappr/actions/runs/30468383582) — App token / checkout worked; nothing was versioned or published.

## Fix

Capture stdout (JSON) and stderr (logs) separately; still detect “No changed packages found” and surface real errors.

## Test plan

- [ ] Merge → CI → Release
- [ ] Step resolves 6 public packages
- [ ] Version commit lands on `main`; npm versions advance

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef3daa81-70fe-4c0d-9b0d-a31eabb1cee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef3daa81-70fe-4c0d-9b0d-a31eabb1cee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

