### PR TITLE
fix(ci): fix repository URLs for npm provenance + publish_only recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
     branches: [main]
     types: [completed]
   workflow_dispatch:
+    inputs:
+      publish_only:
+        description: 'Skip versioning; publish current package.json versions (recovery after a failed publish)'
+        type: boolean
+        default: false
 
 jobs:
   release:
@@ -53,13 +58,21 @@ jobs:
 
       - name: Resolve packages to publish
         id: changed
+        env:
+          PUBLISH_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_only }}
         run: |
           git fetch --tags
           set +e
-          # Keep lerna notices on stderr out of OUTPUT — mixing 2>&1 breaks jq.
           ERR_FILE=$(mktemp)
-          OUTPUT=$(npx lerna changed --include-merged-tags --json 2>"$ERR_FILE")
-          EXIT_CODE=$?
+          if [ "$PUBLISH_ONLY" = "true" ]; then
+            # Recovery: versions/tags already on main; publish public packages as-is.
+            OUTPUT=$(npx lerna list --json 2>"$ERR_FILE")
+            EXIT_CODE=$?
+          else
+            # Keep lerna notices on stderr out of OUTPUT — mixing 2>&1 breaks jq.
+            OUTPUT=$(npx lerna changed --include-merged-tags --json 2>"$ERR_FILE")
+            EXIT_CODE=$?
+          fi
           set -e
           ERR=$(cat "$ERR_FILE")
           rm -f "$ERR_FILE"
@@ -67,15 +80,16 @@ jobs:
             echo "$ERR"
           fi
 
-          if echo "$ERR$OUTPUT" | grep -q "No changed packages found"; then
+          if [ "$PUBLISH_ONLY" != "true" ] && echo "$ERR$OUTPUT" | grep -q "No changed packages found"; then
             echo "packages=[]" >> "$GITHUB_OUTPUT"
             echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "publish_only=false" >> "$GITHUB_OUTPUT"
             echo "No packages to publish"
             exit 0
           fi
 
           if [ $EXIT_CODE -ne 0 ]; then
-            echo "Error running lerna changed (exit code: $EXIT_CODE):"
+            echo "Error resolving packages (exit code: $EXIT_CODE):"
             echo "$ERR"
             echo "$OUTPUT"
             exit 1
@@ -84,14 +98,15 @@ jobs:
           PKGS=$(echo "$OUTPUT" | jq -c '[.[] | select(.private == false) | .name]')
           echo "packages=$PKGS" >> "$GITHUB_OUTPUT"
           echo "count=$(echo "$PKGS" | jq 'length')" >> "$GITHUB_OUTPUT"
+          echo "publish_only=$PUBLISH_ONLY" >> "$GITHUB_OUTPUT"
           echo "Packages to publish: $PKGS"
 
       - name: Version and tag
-        if: steps.changed.outputs.count != '0'
+        if: steps.changed.outputs.count != '0' && steps.changed.outputs.publish_only != 'true'
         run: npx lerna version --include-merged-tags --no-push --yes
 
       - name: Push commit, then tags
-        if: steps.changed.outputs.count != '0'
+        if: steps.changed.outputs.count != '0' && steps.changed.outputs.publish_only != 'true'
         run: |
           # Fail here if branch protection rejects the bot — before any tags leave the runner
           git push origin HEAD:main
@@ -125,4 +140,4 @@ jobs:
 
           Run: $RUN_URL
 
-          Check the failing step before re-running. Recovery is manual via \`workflow_dispatch\`."
+          Check the failing step before re-running. Recovery is manual via \`workflow_dispatch\` (use publish_only if versions/tags already landed)."

--- a/packages/clappr-core/package.json
+++ b/packages/clappr-core/package.json
@@ -30,7 +30,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:clappr/clappr-core.git"
+    "url": "https://github.com/clappr/clappr.git",
+    "directory": "packages/clappr-core"
   },
   "author": "Globo.com",
   "license": "BSD-3-Clause",

--- a/packages/clappr-plugins/package.json
+++ b/packages/clappr-plugins/package.json
@@ -28,7 +28,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:clappr/clappr-plugins.git"
+    "url": "https://github.com/clappr/clappr.git",
+    "directory": "packages/clappr-plugins"
   },
   "author": "Globo.com",
   "license": "BSD-3-Clause",

--- a/packages/dash-shaka-playback/package.json
+++ b/packages/dash-shaka-playback/package.json
@@ -5,7 +5,8 @@
   "main": "./dist/dash-shaka-playback.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:clappr/dash-shaka-playback.git"
+    "url": "https://github.com/clappr/clappr.git",
+    "directory": "packages/dash-shaka-playback"
   },
   "scripts": {
     "build": "webpack",

--- a/packages/hlsjs-playback/package.json
+++ b/packages/hlsjs-playback/package.json
@@ -27,7 +27,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:clappr/hlsjs-playback.git"
+    "url": "https://github.com/clappr/clappr.git",
+    "directory": "packages/hlsjs-playback"
   },
   "author": "Globo.com",
   "license": "BSD-3-Clause",

--- a/packages/html5-tvs-playback/package.json
+++ b/packages/html5-tvs-playback/package.json
@@ -27,7 +27,7 @@
   "module": "./dist/clappr-html5-tvs-playback.esm.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:clappr/clappr.git",
+    "url": "https://github.com/clappr/clappr.git",
     "directory": "packages/html5-tvs-playback"
   },
   "scripts": {

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -24,7 +24,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:clappr/clappr.git"
+    "url": "https://github.com/clappr/clappr.git",
+    "directory": "packages/player"
   },
   "author": "Globo.com",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Release after #2462 got past versioning and **pushed `chore: publish` to `main`** (Bug 3 fixed), then failed on npm publish:

```
E422 … package.json: "repository.url" is "git+ssh://git@github.com/clappr/clappr-core.git",
expected to match "https://github.com/clappr/clappr" from provenance
```

[Failed run](https://github.com/clappr/clappr/actions/runs/30468668961). Versions/tags are on `main` (`@clappr/core@0.14.0`, etc.) but **npm still has the old versions**.

## Changes

- Point all public packages’ `repository` at `https://github.com/clappr/clappr.git` + `directory`
- Add `workflow_dispatch` input `publish_only` to publish current versions without re-running `lerna version`

## After merge (recovery)

1. Merge this PR (approve required).
2. When CI finishes, a Release run will start automatically because `package.json` changed — **cancel that run** so it does not bump again past the already-tagged versions.
3. Actions → Release → **Run workflow** → enable **publish_only** → Run.
4. Confirm npm versions and provenance badges.

## Test plan

- [ ] `publish_only` run publishes `@clappr/core@0.14.0`, `@clappr/plugins@0.9.0`, `@clappr/player@0.12.0`, `@clappr/hlsjs-playback@1.9.5`, `dash-shaka-playback@3.7.0`, `@clappr/clappr-html5-tvs-playback@0.4.0`
- [ ] No orphan: `chore: publish` already on `main`
- [ ] Provenance OK (no E422)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef3daa81-70fe-4c0d-9b0d-a31eabb1cee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef3daa81-70fe-4c0d-9b0d-a31eabb1cee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

