### PR TITLE
fix(ci): skip already-published packages; continue on publish failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,11 +115,25 @@ jobs:
       - name: Publish to npm
         if: steps.changed.outputs.count != '0'
         run: |
+          failed=()
           for pkg in $(echo '${{ steps.changed.outputs.packages }}' | jq -r '.[]'); do
             echo "::group::publish $pkg"
-            npm publish -w "$pkg" --provenance
+            ver=$(npm pkg get version -w "$pkg" | tr -d '"')
+            if npm view "$pkg@$ver" version >/dev/null 2>&1; then
+              echo "Skipping $pkg@$ver (already on npm)"
+              echo "::endgroup::"
+              continue
+            fi
+            if ! npm publish -w "$pkg" --provenance; then
+              echo "::error::Failed to publish $pkg@$ver"
+              failed+=("$pkg@$ver")
+            fi
             echo "::endgroup::"
           done
+          if [ ${#failed[@]} -gt 0 ]; then
+            echo "Publish failures: ${failed[*]}"
+            exit 1
+          fi
 
   notify-failure:
     needs: release


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Status after latest Release ([30469119640](https://github.com/clappr/clappr/actions/runs/30469119640))

Published with provenance:
- `@clappr/core@0.14.1`
- `@clappr/plugins@0.9.1`

Failed (stopped the loop):
- `dash-shaka-playback@3.7.1` → **E404** (typical when Trusted Publisher / publish permission is missing for that package)

Not reached:
- `@clappr/hlsjs-playback@1.9.6`
- `@clappr/clappr-html5-tvs-playback@0.4.1`
- `@clappr/player@0.12.1`

Versions/tags for all of the above are already on `main` (`chore: publish`).

## This PR

- Skip `npm publish` when `$pkg@$ver` already exists on the registry
- Continue publishing remaining packages if one fails; fail the job at the end if any failed

## After merge

1. Confirm Trusted Publisher on **`dash-shaka-playback`** (and the remaining packages):  
   `npm trust list dash-shaka-playback` → `clappr/clappr` + `release.yml` + publish
2. Cancel any automatic Release that would re-bump, then run **workflow_dispatch** with **publish_only=true**
3. Expect: skip core/plugins; publish the four remaining (or fail only dash-shaka if trust is still wrong)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef3daa81-70fe-4c0d-9b0d-a31eabb1cee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef3daa81-70fe-4c0d-9b0d-a31eabb1cee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

