### PR TITLE
fix(ci): parse workspace version JSON when skipping publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,14 @@ jobs:
           failed=()
           for pkg in $(echo '${{ steps.changed.outputs.packages }}' | jq -r '.[]'); do
             echo "::group::publish $pkg"
-            ver=$(npm pkg get version -w "$pkg" | tr -d '"')
+            # npm pkg get -w returns {"name":"version"} JSON, not a bare string
+            ver=$(npm pkg get version -w "$pkg" | jq -r 'to_entries[0].value')
+            if [ -z "$ver" ] || [ "$ver" = "null" ]; then
+              echo "::error::Could not resolve version for $pkg"
+              failed+=("$pkg")
+              echo "::endgroup::"
+              continue
+            fi
             if npm view "$pkg@$ver" version >/dev/null 2>&1; then
               echo "Skipping $pkg@$ver (already on npm)"
               echo "::endgroup::"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

The `publish_only` recovery run ([30469875133](https://github.com/clappr/clappr/actions/runs/30469875133)) **successfully published** the remaining packages (`dash-shaka@3.7.1`, `hlsjs@1.9.6`, `html5-tvs@0.4.1`, `player@0.12.1`). The job still exited red because the skip check mis-parsed `npm pkg get version -w` (returns `{"@clappr/core":"0.14.1"}`), so it tried to republish `core`/`plugins` and counted those as failures.

## Fix

Parse the version with `jq -r 'to_entries[0].value'`.

No need to re-run publish after this merges.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef3daa81-70fe-4c0d-9b0d-a31eabb1cee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef3daa81-70fe-4c0d-9b0d-a31eabb1cee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

