### PR TITLE
ci: add draft GitHub release notes after package publish

### DIFF
--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -28,6 +28,16 @@ Use Yarn with Lerna.
 - `lerna run <command> --scope=<package-name>` - Run command in specific package
 - `lerna publish` - Publish packages (independent versioning)
 
+# Release notes
+
+After a successful `Release` workflow (or via Actions → **Generate release notes**), CI creates a **draft** GitHub Release anchored on `@clappr/player@*`.
+
+Optional repo secret for prose Highlights:
+
+- `COPILOT_GITHUB_TOKEN` — fine-grained PAT with **Copilot Requests: Read** (token owner needs an active Copilot license). Without it, the draft still ships with a mechanical Highlights fallback.
+- Style guide: `.github/release-notes-instructions.md`
+- Logic: `.github/scripts/generate-release-notes.sh`
+
 # Running Projects
 
 ## Player Development

--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -32,6 +32,8 @@ Use Yarn with Lerna.
 
 After a successful `Release` workflow (or via Actions → **Generate release notes**), CI creates a **draft** GitHub Release anchored on `@clappr/player@*`.
 
+This is intentional: `@clappr/player` is the public umbrella announcement. A publish that bumps only `@clappr/core` (or another package) without a new player tag does **not** create a GitHub Release — npm + package CHANGELOGs remain the source of truth for those.
+
 Optional repo secret for prose Highlights:
 
 - `COPILOT_GITHUB_TOKEN` — fine-grained PAT with **Copilot Requests: Read** (token owner needs an active Copilot license). Without it, the draft still ships with a mechanical Highlights fallback.

--- a/.github/release-notes-instructions.md
+++ b/.github/release-notes-instructions.md
@@ -1,0 +1,42 @@
+# Release Notes Style Guide
+
+Generate **only** the Highlights section body for Clappr package releases.
+Do not invent a title, version table, or changelog links — the workflow adds those.
+
+## What to include
+
+User-facing changes only:
+
+- Bug fixes that affect playback, UI, or public APIs
+- New player/playback/plugin behavior visible to integrators
+- Public API additions or changes that consumers should know about
+
+Write for people who consume `@clappr/player` and related packages, not for maintainers.
+
+## What to skip
+
+Do **not** generate entries for:
+
+- CI/CD and GitHub Actions changes
+- Tests, test framework migrations, coverage
+- Internal refactors with no user-visible effect
+- Documentation-only or website/docs site changes
+- Dependency bumps (unless they fix a security issue users must act on)
+- `chore: publish`, `chore(package): bump version`, and similar release housekeeping
+- Repository URL / provenance / tooling-only fixes
+
+## Semver noise
+
+If some minor version bumps in the range come only from tooling, docs, CI, or test work (not player/playback API changes), add **one** bullet at most, for example:
+
+- Some minor version bumps reflect tooling and docs changes, not player API changes
+
+Do not create a separate "Semver caveats" section. Do not list each infra `feat` individually.
+
+## Style
+
+- Present tense: "Fix", "Add", "Restore"
+- Concise bullets (one change per line)
+- No conventional-commit prefixes (`fix:`, `feat(scope):`, etc.)
+- No attribution like `by @author in #123`
+- Prefer the outcome for users ("Fix mute toggle not restoring volume") over the implementation detail

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# Resolve player tags / version table, or render + create/update a draft GitHub Release.
+# Usage:
+#   MODE=auto|manual [PLAYER_TAG=...] ./generate-release-notes.sh resolve
+#   MODE=auto|manual PLAYER_TAG=... RELEASE_ID=... HIGHLIGHTS=... \
+#     VERSIONS_TABLE=... CHANGELOG_LINKS=... ./generate-release-notes.sh render
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-clappr/clappr}"
+MODE="${MODE:-auto}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+emit() {
+  local key="$1"
+  local value="$2"
+  # Multiline-safe GitHub Actions output
+  {
+    echo "${key}<<EOF"
+    echo "${value}"
+    echo "EOF"
+  } >>"$GITHUB_OUTPUT"
+}
+
+player_tags() {
+  git tag --sort=-v:refname --list '@clappr/player@*'
+}
+
+find_release_for_tag() {
+  local tag="$1"
+  # List endpoint includes drafts for actors with push access.
+  # GET /releases/tags/{tag} only returns published releases — do not use it here.
+  # gh api --jq does not accept jq --arg flags; interpolate carefully (tag is ours).
+  gh api --paginate "repos/${REPO}/releases" \
+    --jq ".[] | select(.tag_name == \"${tag}\") | {id: .id, draft: .draft}" \
+    | head -n1
+}
+
+pkg_version_at() {
+  local ref="$1"
+  local path="$2"
+  git show "${ref}:${path}" 2>/dev/null | jq -r '.version // empty'
+}
+
+build_versions_table_and_links() {
+  local base_tag="$1"
+  local player_tag="$2"
+  local table_rows=""
+  local links=""
+  local pkg_json dir name private prev now
+
+  # Discover packages from the tag tree — not the worktree (checkout may lag tags).
+  while IFS= read -r pkg_json; do
+    [ -n "$pkg_json" ] || continue
+    dir="${pkg_json%/package.json}"
+    name="$(git show "${player_tag}:${pkg_json}" | jq -r '.name')"
+    private="$(git show "${player_tag}:${pkg_json}" | jq -r 'if .private == true then "true" else "false" end')"
+    if [ "$private" = "true" ]; then
+      continue
+    fi
+
+    now="$(pkg_version_at "$player_tag" "$pkg_json")"
+    if [ -z "$now" ]; then
+      continue
+    fi
+
+    if [ -n "$base_tag" ] && git cat-file -e "${base_tag}:${pkg_json}" 2>/dev/null; then
+      prev="$(pkg_version_at "$base_tag" "$pkg_json")"
+    else
+      prev=""
+    fi
+
+    if [ -z "$prev" ]; then
+      prev="—"
+    elif [ "$prev" = "$now" ]; then
+      continue
+    fi
+
+    table_rows+="| \`${name}\` | ${prev} | **${now}** |"
+    table_rows+=$'\n'
+    if git cat-file -e "${player_tag}:${dir}/CHANGELOG.md" 2>/dev/null; then
+      links+="- [\`${name}\`](https://github.com/${REPO}/blob/main/${dir}/CHANGELOG.md)"
+      links+=$'\n'
+    fi
+  done < <(git ls-tree -r --name-only "$player_tag" -- packages | awk -F/ 'NF==3 && $3=="package.json" {print}')
+
+  VERSIONS_TABLE_OUT="$table_rows"
+  CHANGELOG_LINKS_OUT="$links"
+}
+
+cmd_resolve() {
+  local player_tag="${PLAYER_TAG:-}"
+  local base_tag=""
+  local release_json release_id is_draft should_run="true" skip_copilot="false"
+  local versions_table="" changelog_links="" title=""
+
+  if [ -z "$player_tag" ]; then
+    player_tag="$(player_tags | head -1 || true)"
+  fi
+
+  if [ -z "$player_tag" ]; then
+    echo "No @clappr/player tag found"
+    emit should_run "false"
+    emit player_tag ""
+    emit base_tag ""
+    emit release_id ""
+    emit skip_copilot "true"
+    emit title ""
+    emit versions_table ""
+    emit changelog_links ""
+    return 0
+  fi
+
+  if ! git rev-parse -q --verify "refs/tags/${player_tag}" >/dev/null; then
+    echo "Tag not found: ${player_tag}" >&2
+    exit 1
+  fi
+
+  release_json="$(find_release_for_tag "$player_tag" || true)"
+  release_id=""
+  is_draft=""
+  if [ -n "$release_json" ]; then
+    # Do not use `// empty` on .draft — in jq, false is falsy so `false // empty` yields empty.
+    release_id="$(echo "$release_json" | jq -r '.id')"
+    is_draft="$(echo "$release_json" | jq -r '.draft')"
+    if [ "$release_id" = "null" ]; then
+      release_id=""
+    fi
+    if [ "$is_draft" = "null" ]; then
+      is_draft=""
+    fi
+  fi
+
+  if [ -n "$release_id" ] && [ "$is_draft" = "false" ]; then
+    echo "Published release already exists for ${player_tag} (id=${release_id}); skipping"
+    should_run="false"
+  elif [ -n "$release_id" ] && [ "$is_draft" = "true" ] && [ "$MODE" = "auto" ]; then
+    echo "Draft already exists for ${player_tag} (id=${release_id}) and MODE=auto; skipping"
+    should_run="false"
+  fi
+
+  base_tag="$(player_tags | awk -v t="$player_tag" '$0 == t { getline; print; exit }')"
+  if [ -z "$base_tag" ]; then
+    echo "No previous @clappr/player tag before ${player_tag}; Copilot step will be skipped"
+    skip_copilot="true"
+  fi
+
+  title="${player_tag##*@}"
+
+  if [ "$should_run" = "true" ]; then
+    build_versions_table_and_links "$base_tag" "$player_tag"
+    versions_table="$VERSIONS_TABLE_OUT"
+    changelog_links="$CHANGELOG_LINKS_OUT"
+  fi
+
+  echo "player_tag=${player_tag}"
+  echo "base_tag=${base_tag:-<none>}"
+  echo "release_id=${release_id:-<none>}"
+  echo "is_draft=${is_draft:-<none>}"
+  echo "should_run=${should_run}"
+  echo "skip_copilot=${skip_copilot}"
+  echo "mode=${MODE}"
+
+  emit should_run "$should_run"
+  emit player_tag "$player_tag"
+  emit base_tag "$base_tag"
+  emit release_id "$release_id"
+  emit skip_copilot "$skip_copilot"
+  emit title "$title"
+  emit versions_table "$versions_table"
+  emit changelog_links "$changelog_links"
+}
+
+cmd_render() {
+  local player_tag="${PLAYER_TAG:?PLAYER_TAG is required}"
+  local title="${TITLE:-${player_tag##*@}}"
+  local release_id="${RELEASE_ID:-}"
+  local highlights="${HIGHLIGHTS:-}"
+  local versions_table="${VERSIONS_TABLE:-}"
+  local changelog_links="${CHANGELOG_LINKS:-}"
+  local body_file
+  body_file="$(mktemp)"
+
+  if [ -z "$(echo "$highlights" | tr -d '[:space:]')" ]; then
+    highlights="- See package changelogs below for details."
+  fi
+
+  {
+    echo "## Published versions"
+    echo
+    if [ -n "$(echo "$versions_table" | tr -d '[:space:]')" ]; then
+      echo "| Package | Previous | Now |"
+      echo "|---|---|---|"
+      # Ensure trailing newline handling is consistent
+      printf '%s\n' "$versions_table" | sed '/^$/d'
+    else
+      echo "_No public package version changes detected between tags._"
+    fi
+    echo
+    echo "## Highlights"
+    echo
+    printf '%s\n' "$highlights"
+    echo
+    echo "## Full changelogs"
+    echo
+    if [ -n "$(echo "$changelog_links" | tr -d '[:space:]')" ]; then
+      printf '%s\n' "$changelog_links" | sed '/^$/d'
+    else
+      echo "- See package CHANGELOG.md files on \`main\`."
+    fi
+  } >"$body_file"
+
+  {
+    echo "### Draft release body preview"
+    echo
+    cat "$body_file"
+  } >>"$GITHUB_STEP_SUMMARY"
+
+  if [ "${DRY_RUN:-}" = "1" ]; then
+    echo "DRY_RUN=1 — not creating/updating GitHub Release"
+    echo "---- body ----"
+    cat "$body_file"
+    rm -f "$body_file"
+    return 0
+  fi
+
+  if [ -n "$release_id" ]; then
+    if [ "$MODE" != "manual" ]; then
+      echo "Release id ${release_id} present but MODE=${MODE}; refusing to update" >&2
+      exit 1
+    fi
+    echo "Updating draft release id=${release_id} for ${player_tag}"
+    # --input expects JSON on stdin; use jq to build the payload safely.
+    jq -n --rawfile body "$body_file" '{body: $body}' \
+      | gh api -X PATCH "repos/${REPO}/releases/${release_id}" --input -
+  else
+    echo "Creating draft release for ${player_tag} (title=${title})"
+    gh release create "$player_tag" \
+      --repo "$REPO" \
+      --draft \
+      --title "$title" \
+      --notes-file "$body_file"
+  fi
+
+  rm -f "$body_file"
+}
+
+main() {
+  local cmd="${1:-}"
+  case "$cmd" in
+    resolve) cmd_resolve ;;
+    render) cmd_render ;;
+    *)
+      echo "Usage: $0 resolve|render" >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -4,6 +4,7 @@
 #   MODE=auto|manual [PLAYER_TAG=...] ./generate-release-notes.sh resolve
 #   MODE=auto|manual PLAYER_TAG=... RELEASE_ID=... HIGHLIGHTS=... \
 #     VERSIONS_TABLE=... CHANGELOG_LINKS=... ./generate-release-notes.sh render
+#   DRY_RUN=1 ... ./generate-release-notes.sh render   # print body only; no create/update
 set -euo pipefail
 
 REPO="${GITHUB_REPOSITORY:-clappr/clappr}"
@@ -31,7 +32,8 @@ find_release_for_tag() {
   # List endpoint includes drafts for actors with push access.
   # GET /releases/tags/{tag} only returns published releases — do not use it here.
   # gh api --jq does not accept jq --arg flags; interpolate carefully (tag is ours).
-  gh api --paginate "repos/${REPO}/releases" \
+  # per_page=100 keeps the clappr release list on a single page today.
+  gh api --paginate "repos/${REPO}/releases?per_page=100" \
     --jq ".[] | select(.tag_name == \"${tag}\") | {id: .id, draft: .draft}" \
     | head -n1
 }
@@ -50,6 +52,7 @@ build_versions_table_and_links() {
   local pkg_json dir name private prev now
 
   # Discover packages from the tag tree — not the worktree (checkout may lag tags).
+  # NF==3 matches packages/<name>/package.json only (no nested package roots).
   while IFS= read -r pkg_json; do
     [ -n "$pkg_json" ] || continue
     dir="${pkg_json%/package.json}"
@@ -139,7 +142,8 @@ cmd_resolve() {
     should_run="false"
   fi
 
-  base_tag="$(player_tags | awk -v t="$player_tag" '$0 == t { getline; print; exit }')"
+  # When player_tag is the oldest tag, getline hits EOF and must not reprint $0.
+  base_tag="$(player_tags | awk -v t="$player_tag" '$0 == t { if ((getline line) > 0) print line; exit }')"
   if [ -z "$base_tag" ]; then
     echo "No previous @clappr/player tag before ${player_tag}; Copilot step will be skipped"
     skip_copilot="true"
@@ -180,6 +184,7 @@ cmd_render() {
   local changelog_links="${CHANGELOG_LINKS:-}"
   local body_file
   body_file="$(mktemp)"
+  trap 'rm -f "$body_file"' EXIT
 
   if [ -z "$(echo "$highlights" | tr -d '[:space:]')" ]; then
     highlights="- See package changelogs below for details."
@@ -220,7 +225,6 @@ cmd_render() {
     echo "DRY_RUN=1 — not creating/updating GitHub Release"
     echo "---- body ----"
     cat "$body_file"
-    rm -f "$body_file"
     return 0
   fi
 
@@ -231,7 +235,7 @@ cmd_render() {
     fi
     echo "Updating draft release id=${release_id} for ${player_tag}"
     # --input expects JSON on stdin; use jq to build the payload safely.
-    jq -n --rawfile body "$body_file" '{body: $body}' \
+    jq -n --rawfile body "$body_file" --arg name "$title" '{body: $body, name: $name}' \
       | gh api -X PATCH "repos/${REPO}/releases/${release_id}" --input -
   else
     echo "Creating draft release for ${player_tag} (title=${title})"
@@ -241,8 +245,6 @@ cmd_render() {
       --title "$title" \
       --notes-file "$body_file"
   fi
-
-  rm -f "$body_file"
 }
 
 main() {

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -12,6 +12,11 @@ MODE="${MODE:-auto}"
 GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
 GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
 
+# Script-scoped so the EXIT trap can still see the path after cmd_render returns
+# (a `local body_file` would be unbound under `set -u` when the trap fires).
+body_file=""
+trap 'rm -f "$body_file"' EXIT
+
 emit() {
   local key="$1"
   local value="$2"
@@ -182,9 +187,7 @@ cmd_render() {
   local highlights="${HIGHLIGHTS:-}"
   local versions_table="${VERSIONS_TABLE:-}"
   local changelog_links="${CHANGELOG_LINKS:-}"
-  local body_file
   body_file="$(mktemp)"
-  trap 'rm -f "$body_file"' EXIT
 
   if [ -z "$(echo "$highlights" | tr -d '[:space:]')" ]; then
     highlights="- See package changelogs below for details."

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -1,0 +1,78 @@
+# Creates a draft GitHub Release anchored on @clappr/player after a successful
+# Release workflow (or via workflow_dispatch).
+#
+# Prerequisite (optional but recommended for prose Highlights):
+#   Repository secret COPILOT_GITHUB_TOKEN — fine-grained PAT with
+#   "Copilot Requests: Read". The token owner must have an active Copilot
+#   license (individual is fine). Without it, the Copilot step fails open and
+#   the draft is created with a mechanical Highlights fallback.
+name: Generate release notes
+
+on:
+  workflow_run:
+    workflows: ['Release']
+    branches: [main]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      player_tag:
+        description: '@clappr/player tag to announce (default: latest player tag)'
+        required: false
+        type: string
+
+concurrency:
+  group: generate-release-notes
+  cancel-in-progress: false
+
+jobs:
+  notes:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: write
+      pull-requests: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Resolve tags and version table
+        id: resolve
+        env:
+          MODE: ${{ github.event_name == 'workflow_dispatch' && 'manual' || 'auto' }}
+          PLAYER_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.player_tag || '' }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: .github/scripts/generate-release-notes.sh resolve
+
+      - name: Generate highlights
+        id: copilot
+        if: steps.resolve.outputs.should_run == 'true' && steps.resolve.outputs.skip_copilot != 'true'
+        continue-on-error: true
+        uses: github/copilot-release-notes@v1
+        with:
+          base-ref: ${{ steps.resolve.outputs.base_tag }}
+          head-ref: ${{ steps.resolve.outputs.player_tag }}
+          pr-strategy: github-api
+          instructions: .github/release-notes-instructions.md
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+      - name: Create or update draft release
+        if: steps.resolve.outputs.should_run == 'true'
+        env:
+          MODE: ${{ github.event_name == 'workflow_dispatch' && 'manual' || 'auto' }}
+          PLAYER_TAG: ${{ steps.resolve.outputs.player_tag }}
+          TITLE: ${{ steps.resolve.outputs.title }}
+          RELEASE_ID: ${{ steps.resolve.outputs.release_id }}
+          VERSIONS_TABLE: ${{ steps.resolve.outputs.versions_table }}
+          CHANGELOG_LINKS: ${{ steps.resolve.outputs.changelog_links }}
+          HIGHLIGHTS: ${{ steps.copilot.outputs.release-notes }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: .github/scripts/generate-release-notes.sh render

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -61,6 +61,9 @@ jobs:
           pr-strategy: github-api
           instructions: .github/release-notes-instructions.md
         env:
+          # GITHUB_TOKEN is required for pr-strategy: github-api (repo/PR reads).
+          # Actions does not inject it into step env automatically.
+          GITHUB_TOKEN: ${{ github.token }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 
       - name: Create or update draft release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,12 @@ Packages that do **not** publish to npm:
 | `packages/clappr-telemetry/` | `private: true` until the first intentional release |
 | `apps/clappr.io/` | Docs site (`clappr-docs`, already `private: true`) |
 
+### GitHub Release notes
+
+After a successful `Release` workflow (or Actions → **Generate release notes**), CI opens a **draft** GitHub Release anchored on `@clappr/player@*`. That tag is the public umbrella announcement: publishes that bump only other packages (e.g. `@clappr/core` alone) do not create a GitHub Release.
+
+Optional repo secret `COPILOT_GITHUB_TOKEN` (fine-grained PAT with Copilot Requests: Read) enables prose Highlights via Copilot; without it the draft uses a mechanical fallback. See `.github/release-notes-instructions.md` and `.github/scripts/generate-release-notes.sh`.
+
 ## Tooling
 
 ### Package manager


### PR DESCRIPTION
## Summary
- Add `Generate release notes` workflow that runs after a successful `Release` (also `workflow_dispatch`)
- Create a **draft** GitHub Release on `@clappr/player@*`: version table from tag `package.json` diffs, Highlights via `github/copilot-release-notes@v1` (user-facing only), CHANGELOG links
- Idempotent guards: skip if a published release exists; in auto mode skip if a draft already exists (avoids duplicates from the second CI→Release cycle after `chore: publish`); concurrency group; discover packages from the git tag tree

## Test plan
- [ ] Add repo secret `COPILOT_GITHUB_TOKEN` (fine-grained PAT with Copilot Requests: Read) — optional; without it the draft still ships with fallback Highlights
- [ ] Merge and confirm the first auto run skips for `@clappr/player@0.12.1` (already published)
- [ ] On the next player bump: verify a draft appears with Published versions / Highlights / Full changelogs
- [ ] Manually run **Generate release notes** with `player_tag` to regenerate/overwrite a draft
- [ ] Publish the draft in the GitHub UI and confirm it becomes Latest