### PR TITLE
Extend CI test coverage to all packages with a test script

### DIFF
--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -12,6 +12,7 @@ This project is a monorepo managed by Lerna using Yarn workspaces. Each package 
   - `packages/player/` - Main player bundle (`@clappr/player`)
   - `packages/clappr-core/` - Core player components (`@clappr/core`)
   - `packages/clappr-plugins/` - Main player plugins (`@clappr/plugins`)
+  - `packages/clappr-telemetry/` - Playback telemetry and metrics (`@clappr/telemetry`)
   - `packages/clappr-zepto/` - Zepto.js build for Clappr
   - `packages/dash-shaka-playback/` - DASH playback with Shaka Player
   - `packages/hlsjs-playback/` - HLS playback with hls.js (`@clappr/hlsjs-playback`)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format:check": "prettier --check \"**/*.{js,ts,json,md}\"",
     "release": "lerna version --include-merged-tags --no-push --yes",
     "prepare": "husky",
-    "test": "lerna run test --scope=@clappr/core --scope=@clappr/clappr-html5-tvs-playback",
+    "test": "lerna run test --no-bail",
     "build": "lerna run build --scope=@clappr/player --include-dependencies"
   },
   "volta": {

--- a/packages/clappr-telemetry/package.json
+++ b/packages/clappr-telemetry/package.json
@@ -10,7 +10,7 @@
     "release": "MINIMIZE=true rollup --config --bundleConfigAsCjs",
     "build": "rollup --config --bundleConfigAsCjs",
     "watch": "rollup --config --watch --bundleConfigAsCjs",
-    "test": "jest src/",
+    "test": "jest src/ --coverage --silent",
     "test:coverage": "jest src/ --coverage",
     "test:coverage:open": "open coverage/lcov-report/index.html",
     "test:debug": "node --inspect node_modules/.bin/jest src/ --runInBand",

--- a/packages/clappr-zepto/package.json
+++ b/packages/clappr-zepto/package.json
@@ -6,8 +6,7 @@
   "main": "zepto.min.js",
   "types": "./main.d.ts",
   "scripts": {
-    "build": "./scripts/build-clappr-zepto -c=v1.2.0 -o=./",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "./scripts/build-clappr-zepto -c=v1.2.0 -o=./"
   },
   "repository": {
     "type": "git",

--- a/packages/hlsjs-playback/jest.config.js
+++ b/packages/hlsjs-playback/jest.config.js
@@ -1,6 +1,8 @@
 const ClapprCorePkg = require('@clappr/core/package.json')
 
 module.exports = {
+  // Explicit since jest 27 flipped the default to 'node'; these suites need DOM.
+  testEnvironment: 'jsdom',
   verbose: true,
   transform: {
     '^.+\\.js$': 'babel-jest',

--- a/packages/html5-tvs-playback/jest.config.js
+++ b/packages/html5-tvs-playback/jest.config.js
@@ -1,4 +1,6 @@
 module.exports = {
+  // Explicit since jest 27 flipped the default to 'node'; these suites need DOM.
+  testEnvironment: 'jsdom',
   verbose: true,
   transform: { '^.+\\.js$': 'babel-jest' },
   collectCoverageFrom: ['src/*.js', 'src/**/*.js'],


### PR DESCRIPTION
## Summary

- Root `yarn test` no longer uses a `--scope` allow-list; it now runs `lerna run test --no-bail`, so every workspace package that declares a `test` script is covered on PRs (including `@clappr/hlsjs-playback`, `@clappr/plugins`, and `@clappr/telemetry`).
- Removes the placeholder `"test": "… && exit 1"` script from `clappr-zepto`, which has no `src/` and would otherwise fail an unscoped run. `dash-shaka-playback` stays skipped (no `test` script); `@clappr/player` keeps its harmless echo.
- Aligns `@clappr/telemetry`'s `test` script with the other suites (`--coverage --silent`). It was the only one of the five collecting no coverage. No `coverageThreshold` is configured, so this is observability, not a new gate — it currently reports 94.49% statements / 97.06% lines.
- Pins `testEnvironment: 'jsdom'` explicitly in `hlsjs-playback` and `html5-tvs-playback`. Both relied on the jest 26 default, which jest 27 flipped to `node`, and their suites need DOM (`hls.test.js`, `html5_playback.test.js`, `drm_handler.test.js`). A no-op today; it keeps a future jest bump from silently breaking two suites that now gate publishing.
- Adds `packages/clappr-telemetry/` to the package list in `.github/instructions/project.instructions.md`, which never listed it.

**Blast radius:** Release is gated on the CI workflow conclusion, so a red suite in any package now blocks publishing for all of them. That was already true for `core` and `html5-tvs-playback`; this change widens the gate deliberately. Telemetry (400 tests / 14 suites) is now part of that gate. Recovery remains `workflow_dispatch` + `publish_only` on Release.

**Note on `--no-bail`:** lerna 8 delegates to nx, and with no `nx.json` present lerna injects `test → {dependencies: true, target: test}`. nx marks dependents of a failed task as `skipped` even under `--no-bail` (`task-orchestrator.js`), so "other packages continue" holds for sibling packages but is timing-dependent for anything downstream of `@clappr/core`. The non-zero exit code is unaffected either way, so CI gating is correct regardless.

Closes #2456

Follow-up: publish telemetry once CI coverage lands — #2470

## Test plan

- [x] `yarn test` runs: core, plugins, telemetry, hlsjs-playback, html5-tvs-playback (player echoes; zepto and dash-shaka skipped) — 6 projects, 1065 tests, exit 0
- [x] Confirm a deliberate failing assert still yields non-zero exit with `--no-bail` — verified with two probes (failure in a sibling package, and in `@clappr/core`); both exit 1, remaining suites still ran
- [x] `html5-tvs-playback`'s 90% `coverageThreshold` still passes with the newly included suites
- [x] `@clappr/telemetry`'s `test` script now collects coverage under `--coverage --silent` (94.49% statements / 97.06% lines; no threshold gate)
- [x] CI on this PR is green for the newly included suites
- [x] No changes to `.github/workflows/ci.yml` (still invokes root `yarn test`)