### PR TITLE
fix(ci): resolve Release publish versions via Lerna JSON

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,9 @@ jobs:
 
       - name: Ensure npm supports trusted publishing
         run: |
-          npm install -g npm@latest
+          # Pin to npm 11: trusted publishing needs a recent npm, but npm 12 stopped
+          # forcing JSON from `npm pkg get` and can surprise CI with other CLI changes.
+          npm install -g npm@^11.5.0
           npm --version
 
       - name: Install dependencies
@@ -116,10 +118,24 @@ jobs:
         if: steps.changed.outputs.count != '0'
         run: |
           failed=()
+          # Versions after lerna version live in package.json; read them via Lerna JSON
+          # instead of `npm pkg get` stdout (npm 12+ is not JSON by default — see #2472).
+          ERR_FILE=$(mktemp)
+          LIST_JSON=$(npx lerna list --json 2>"$ERR_FILE")
+          LIST_EXIT=$?
+          ERR=$(cat "$ERR_FILE")
+          rm -f "$ERR_FILE"
+          if [ -n "$ERR" ]; then
+            echo "$ERR"
+          fi
+          if [ $LIST_EXIT -ne 0 ]; then
+            echo "::error::Could not list package versions (exit code: $LIST_EXIT)"
+            exit 1
+          fi
+
           for pkg in $(echo '${{ steps.changed.outputs.packages }}' | jq -r '.[]'); do
             echo "::group::publish $pkg"
-            # npm pkg get -w returns {"name":"version"} JSON, not a bare string
-            ver=$(npm pkg get version -w "$pkg" | jq -r 'to_entries[0].value')
+            ver=$(echo "$LIST_JSON" | jq -r --arg pkg "$pkg" '.[] | select(.name == $pkg) | .version')
             if [ -z "$ver" ] || [ "$ver" = "null" ]; then
               echo "::error::Could not resolve version for $pkg"
               failed+=("$pkg")


### PR DESCRIPTION
## Summary
- Fixes the Release workflow failure from [#2472](https://github.com/clappr/clappr/issues/2472) / [run 30487857234](https://github.com/clappr/clappr/actions/runs/30487857234): `npm pkg get` piped to `jq` broke under npm 12 (stdout is no longer forced JSON).
- Resolve package versions for publish from `lerna list --json` (package.json after the Lerna bump), matching how the resolve step already uses Lerna JSON.
- Pin global npm to `^11.5.0` instead of `latest` so trusted publishing stays available without pulling npm 12 CLI changes by surprise.

## Test plan
- [ ] Review the Publish step: versions come from `lerna list --json`, stderr kept out of the JSON parse
- [ ] After merge, recover unpublished tags via **Actions → Release → Run workflow** with `publish_only: true` (versions/tags for `0.14.2` / `0.12.2` / etc. are already on `main`)
- [ ] Confirm packages appear on npm (`@clappr/core@0.14.2`, `@clappr/player@0.12.2`, …)
- [ ] Close #2472 once recovery succeeds