### PR TITLE
fix(telemetry): publish @clappr/telemetry to npm

### DIFF
--- a/packages/clappr-telemetry/README.md
+++ b/packages/clappr-telemetry/README.md
@@ -1,6 +1,6 @@
 # @clappr/telemetry
 
-[![npm version](https://img.shields.io/badge/npm-v0.1.0-cb3837)](https://www.npmjs.com/package/@clappr/telemetry)
+[![npm version](https://img.shields.io/npm/v/@clappr/telemetry.svg?color=cb3837)](https://www.npmjs.com/package/@clappr/telemetry)
 
 A telemetry plugin for [Clappr](https://github.com/clappr/clappr). Collects network, buffer, decoding, playback state, playback timing, and stream info metrics from the player and exposes them through a single unified event on the container bus.
 

--- a/packages/clappr-telemetry/package.json
+++ b/packages/clappr-telemetry/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@clappr/telemetry",
   "version": "0.2.2",
-  "private": true,
   "description": "Telemetry package for Clappr player",
   "main": "./dist/clappr-telemetry.js",
   "module": "./dist/clappr-telemetry.esm.js",


### PR DESCRIPTION
## Summary
- Drops `"private": true` from `packages/clappr-telemetry/package.json` so lerna/Release picks the package up for future publishes.
- Fixes the npm version badge in the package README, which was hardcoded to a stale `v0.1.0`; now points at the dynamic shields.io npm endpoint so it never goes stale again.

## Manual steps already completed (outside this PR)
- `@clappr/telemetry@0.2.2` bootstrap-published manually to npm (OIDC trusted publishing cannot be used for a package's first-ever publish — tracked upstream at [npm/cli#8544](https://github.com/npm/cli/issues/8544)).
- Trusted publisher configured on npmjs.com for `clappr/clappr` → `.github/workflows/release.yml`, action `npm publish`.
- `.github/instructions/project.instructions.md` package list already covers `clappr-telemetry` (landed separately in `5f001ecb`).
- Tarball contents (`files: ["/dist", "/src"]`, includes `*.test.js`) intentionally left as-is for consistency with `@clappr/hlsjs-playback`.

Closes #2470

## Test plan
- [ ] Next green CI run on `main` triggers Release; confirm it publishes any future `@clappr/telemetry` bump via OIDC with provenance (current `0.2.2` will just be skipped as "already on npm").
- [ ] Confirm README badge renders the live npm version after merge.