### PR TITLE
fix(ci): gate draft release notes on npm player publish

### DIFF
--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -31,9 +31,11 @@ Use Yarn with Lerna.
 
 # Release notes
 
-After a successful `Release` workflow (or via Actions → **Generate release notes**), CI creates a **draft** GitHub Release anchored on `@clappr/player@*`.
+After `Release` successfully publishes `@clappr/player` to npm, it calls **Generate release notes**, which creates a **draft** GitHub Release anchored on `@clappr/player@*`. Manual dispatch (Actions → **Generate release notes**) can regenerate/update a draft.
 
-This is intentional: `@clappr/player` is the public umbrella announcement. A publish that bumps only `@clappr/core` (or another package) without a new player tag does **not** create a GitHub Release — npm + package CHANGELOGs remain the source of truth for those.
+This is intentional: `@clappr/player` is the public umbrella announcement. Empty Release runs, non-player-only publishes, and git tags that never reached npm do **not** create a GitHub Release — npm + package CHANGELOGs remain the source of truth for those.
+
+If a draft was opened for a player tag that is not on npm: delete the draft, recover with Release `publish_only`, then re-run **Generate release notes** if needed.
 
 Optional repo secret for prose Highlights:
 

--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -33,7 +33,7 @@ Use Yarn with Lerna.
 
 After `Release` successfully publishes `@clappr/player` to npm, it calls **Generate release notes**, which creates a **draft** GitHub Release anchored on `@clappr/player@*`. Manual dispatch (Actions → **Generate release notes**) can regenerate/update a draft.
 
-This is intentional: `@clappr/player` is the public umbrella announcement. Empty Release runs, non-player-only publishes, and git tags that never reached npm do **not** create a GitHub Release — npm + package CHANGELOGs remain the source of truth for those.
+This is intentional: `@clappr/player` is the public umbrella announcement. Empty Release runs, non-player-only publishes, runs where the player version was already on npm (nothing new published), and git tags that never reached npm do **not** create a GitHub Release — npm + package CHANGELOGs remain the source of truth for those. Manual dispatch is the way to regenerate notes in those cases.
 
 If a draft was opened for a player tag that is not on npm: delete the draft, recover with Release `publish_only`, then re-run **Generate release notes** if needed.
 

--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -33,7 +33,9 @@ Use Yarn with Lerna.
 
 After `Release` successfully publishes `@clappr/player` to npm, it calls **Generate release notes**, which creates a **draft** GitHub Release anchored on `@clappr/player@*`. Manual dispatch (Actions → **Generate release notes**) can regenerate/update a draft.
 
-This is intentional: `@clappr/player` is the public umbrella announcement. Empty Release runs, non-player-only publishes, runs where the player version was already on npm (nothing new published), and git tags that never reached npm do **not** create a GitHub Release — npm + package CHANGELOGs remain the source of truth for those. Manual dispatch is the way to regenerate notes in those cases.
+This is intentional: `@clappr/player` is the public umbrella announcement. Empty Release runs, non-player-only publishes, and runs where the player version was already on npm (nothing new published) do **not** create a GitHub Release — npm + package CHANGELOGs remain the source of truth for those. Manual dispatch is the way to regenerate notes in those cases.
+
+A player version missing from npm is handled differently per path: called by `Release` it **fails** (the publish had already succeeded, so absence is an anomaly worth an issue — a green run would notify nobody); on manual dispatch it skips with a warning, since you aimed at that tag on purpose.
 
 If a draft was opened for a player tag that is not on npm: delete the draft, recover with Release `publish_only`, then re-run **Generate release notes** if needed.
 

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Resolve player tags / version table, or render + create/update a draft GitHub Release.
+# resolve refuses to announce a player tag that is not on npm; Published versions
+# rows are likewise filtered to versions present on the registry.
 # Usage:
 #   MODE=auto|manual [PLAYER_TAG=...] ./generate-release-notes.sh resolve
 #   MODE=auto|manual PLAYER_TAG=... RELEASE_ID=... HIGHLIGHTS=... \
@@ -49,6 +51,13 @@ pkg_version_at() {
   git show "${ref}:${path}" 2>/dev/null | jq -r '.version // empty'
 }
 
+# True when registry.npmjs.org has name@version (avoids announcing git-only tags).
+npm_has_package_version() {
+  local name="$1"
+  local ver="$2"
+  npm view "${name}@${ver}" version >/dev/null 2>&1
+}
+
 build_versions_table_and_links() {
   local base_tag="$1"
   local player_tag="$2"
@@ -69,6 +78,12 @@ build_versions_table_and_links() {
 
     now="$(pkg_version_at "$player_tag" "$pkg_json")"
     if [ -z "$now" ]; then
+      continue
+    fi
+
+    # Only list versions that actually landed on npm (partial publish batches).
+    if ! npm_has_package_version "$name" "$now"; then
+      echo "Skipping ${name}@${now} in Published versions (not on npm)"
       continue
     fi
 
@@ -99,6 +114,7 @@ build_versions_table_and_links() {
 cmd_resolve() {
   local player_tag="${PLAYER_TAG:-}"
   local base_tag=""
+  local player_ver=""
   local release_json release_id is_draft should_run="true" skip_copilot="false"
   local versions_table="" changelog_links="" title=""
 
@@ -124,6 +140,13 @@ cmd_resolve() {
     exit 1
   fi
 
+  # Git tags can land before npm publish succeeds — never draft that case.
+  player_ver="${player_tag##*@}"
+  if ! npm_has_package_version "@clappr/player" "$player_ver"; then
+    echo "@clappr/player@${player_ver} tag exists but is not on npm; skipping draft"
+    should_run="false"
+  fi
+
   release_json="$(find_release_for_tag "$player_tag" || true)"
   release_id=""
   is_draft=""
@@ -139,10 +162,10 @@ cmd_resolve() {
     fi
   fi
 
-  if [ -n "$release_id" ] && [ "$is_draft" = "false" ]; then
+  if [ "$should_run" = "true" ] && [ -n "$release_id" ] && [ "$is_draft" = "false" ]; then
     echo "Published release already exists for ${player_tag} (id=${release_id}); skipping"
     should_run="false"
-  elif [ -n "$release_id" ] && [ "$is_draft" = "true" ] && [ "$MODE" = "auto" ]; then
+  elif [ "$should_run" = "true" ] && [ -n "$release_id" ] && [ "$is_draft" = "true" ] && [ "$MODE" = "auto" ]; then
     echo "Draft already exists for ${player_tag} (id=${release_id}) and MODE=auto; skipping"
     should_run="false"
   fi

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -2,6 +2,8 @@
 # Resolve player tags / version table, or render + create/update a draft GitHub Release.
 # resolve refuses to announce a player tag that is not on npm; Published versions
 # rows are likewise filtered to versions present on the registry.
+# The player gate tolerates publish-to-registry lag via NPM_VIEW_ATTEMPTS (default 3)
+# and NPM_VIEW_RETRY_DELAY (default 10s).
 # Usage:
 #   MODE=auto|manual [PLAYER_TAG=...] ./generate-release-notes.sh resolve
 #   MODE=auto|manual PLAYER_TAG=... RELEASE_ID=... HIGHLIGHTS=... \
@@ -52,10 +54,33 @@ pkg_version_at() {
 }
 
 # True when registry.npmjs.org has name@version (avoids announcing git-only tags).
+# The packument can lag a few seconds behind `npm publish`, so callers that run right
+# after a publish pass attempts > 1. Callers still treat a false return as "absent",
+# so a failure that is not a 404 is warned about loudly before returning.
 npm_has_package_version() {
   local name="$1"
   local ver="$2"
-  npm view "${name}@${ver}" version >/dev/null 2>&1
+  local attempts="${3:-1}"
+  local attempt=1
+  local out=""
+
+  while true; do
+    if out="$(npm view "${name}@${ver}" version --fetch-retries=1 2>&1)"; then
+      return 0
+    fi
+    # Only a clean 404 means "not published yet" and is worth waiting on. npm
+    # already retries network failures itself, so anything else is inconclusive:
+    # warn once and stop rather than stacking more waits on top of npm's.
+    if ! printf '%s' "$out" | grep -q 'E404'; then
+      echo "::warning::npm view ${name}@${ver} failed without a 404: $(printf '%s' "$out" | tr '\n' ' ')"
+      return 1
+    fi
+    if [ "$attempt" -ge "$attempts" ]; then
+      return 1
+    fi
+    attempt=$((attempt + 1))
+    sleep "${NPM_VIEW_RETRY_DELAY:-10}"
+  done
 }
 
 build_versions_table_and_links() {
@@ -81,12 +106,6 @@ build_versions_table_and_links() {
       continue
     fi
 
-    # Only list versions that actually landed on npm (partial publish batches).
-    if ! npm_has_package_version "$name" "$now"; then
-      echo "Skipping ${name}@${now} in Published versions (not on npm)"
-      continue
-    fi
-
     if [ -n "$base_tag" ] && git cat-file -e "${base_tag}:${pkg_json}" 2>/dev/null; then
       prev="$(pkg_version_at "$base_tag" "$pkg_json")"
     else
@@ -96,6 +115,14 @@ build_versions_table_and_links() {
     if [ -z "$prev" ]; then
       prev="—"
     elif [ "$prev" = "$now" ]; then
+      continue
+    fi
+
+    # Only list versions that actually landed on npm (partial publish batches).
+    # Checked last: unchanged packages already dropped out above, so this is one
+    # registry call per table row instead of one per package in the monorepo.
+    if ! npm_has_package_version "$name" "$now"; then
+      echo "Skipping ${name}@${now} in Published versions (not on npm)"
       continue
     fi
 
@@ -140,10 +167,17 @@ cmd_resolve() {
     exit 1
   fi
 
-  # Git tags can land before npm publish succeeds — never draft that case.
+  # Git tags can land before npm publish succeeds — never draft that case. Retries
+  # because Release calls this seconds after publishing, and a suppressed draft is
+  # surfaced (warning + step summary) instead of leaving a silently green run.
   player_ver="${player_tag##*@}"
-  if ! npm_has_package_version "@clappr/player" "$player_ver"; then
-    echo "@clappr/player@${player_ver} tag exists but is not on npm; skipping draft"
+  if ! npm_has_package_version "@clappr/player" "$player_ver" "${NPM_VIEW_ATTEMPTS:-3}"; then
+    echo "::warning::@clappr/player@${player_ver} is tagged in git but not on npm; no draft release created"
+    {
+      echo "### Release notes skipped"
+      echo
+      echo "\`@clappr/player@${player_ver}\` is tagged in git but was not found on npm, so no draft GitHub Release was created."
+    } >>"$GITHUB_STEP_SUMMARY"
     should_run="false"
   fi
 
@@ -162,12 +196,14 @@ cmd_resolve() {
     fi
   fi
 
-  if [ "$should_run" = "true" ] && [ -n "$release_id" ] && [ "$is_draft" = "false" ]; then
-    echo "Published release already exists for ${player_tag} (id=${release_id}); skipping"
-    should_run="false"
-  elif [ "$should_run" = "true" ] && [ -n "$release_id" ] && [ "$is_draft" = "true" ] && [ "$MODE" = "auto" ]; then
-    echo "Draft already exists for ${player_tag} (id=${release_id}) and MODE=auto; skipping"
-    should_run="false"
+  if [ "$should_run" = "true" ] && [ -n "$release_id" ]; then
+    if [ "$is_draft" = "false" ]; then
+      echo "Published release already exists for ${player_tag} (id=${release_id}); skipping"
+      should_run="false"
+    elif [ "$is_draft" = "true" ] && [ "$MODE" = "auto" ]; then
+      echo "Draft already exists for ${player_tag} (id=${release_id}) and MODE=auto; skipping"
+      should_run="false"
+    fi
   fi
 
   # When player_tag is the oldest tag, getline hits EOF and must not reprint $0.

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -4,6 +4,8 @@
 # rows are likewise filtered to versions present on the registry. Both tolerate
 # publish-to-registry lag via REGISTRY_ATTEMPTS (default 3) and REGISTRY_RETRY_DELAY
 # (default 10s), and fail loudly when the registry cannot answer at all.
+# REQUIRE_NPM=1 additionally turns a *confirmed* absence into a failure — set it only
+# when the caller already published the player in this run (see resolve).
 # Usage:
 #   MODE=auto|manual [PLAYER_TAG=...] ./generate-release-notes.sh resolve
 #   MODE=auto|manual PLAYER_TAG=... RELEASE_ID=... HIGHLIGHTS=... \
@@ -17,6 +19,10 @@ GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
 GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
 # Overridable so the registry-unreachable path can be exercised locally.
 NPM_REGISTRY="${NPM_REGISTRY:-https://registry.npmjs.org}"
+# Deliberately not derived from MODE: `auto` is also the default for a bare local
+# run, and MODE answers a different question (may render overwrite a draft?).
+# Off by default so inspecting an orphan tag by hand stays a clean skip.
+REQUIRE_NPM="${REQUIRE_NPM:-0}"
 
 # Script-scoped so the EXIT trap can still see the path after cmd_render returns
 # (a `local body_file` would be unbound under `set -u` when the trap fires).
@@ -199,9 +205,12 @@ cmd_resolve() {
   fi
 
   # Git tags can land before npm publish succeeds — never draft that case. Retries
-  # because Release calls this seconds after publishing. A confirmed absence is a
-  # deliberate skip (warning + step summary); an inconclusive registry is a failure,
-  # so notify-failure opens an issue instead of leaving a silently green run.
+  # because Release calls this seconds after publishing. An inconclusive registry is
+  # always a failure, so notify-failure opens an issue instead of leaving a silently
+  # green run. A confirmed absence is a deliberate skip when a human aimed us at the
+  # tag, but a failure under REQUIRE_NPM: there the caller already published the
+  # player, so "not on npm" contradicts its own precondition — lag or incident, both
+  # need a human, and only a red job notifies anyone.
   player_ver="${player_tag##*@}"
   registry_rc=0
   registry_has_version "@clappr/player" "$player_ver" "${REGISTRY_ATTEMPTS:-3}" || registry_rc=$?
@@ -210,6 +219,10 @@ cmd_resolve() {
     exit 1
   fi
   if [ "$registry_rc" != "0" ]; then
+    if [ "$REQUIRE_NPM" = "1" ]; then
+      echo "::error::Release published @clappr/player@${player_ver} but the registry still reports it absent (attempts: ${REGISTRY_ATTEMPTS:-3}); failing so the notes can be re-run"
+      exit 1
+    fi
     echo "::warning::@clappr/player@${player_ver} is tagged in git but not on npm; no draft release created"
     {
       echo "### Release notes skipped"

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Resolve player tags / version table, or render + create/update a draft GitHub Release.
 # resolve refuses to announce a player tag that is not on npm; Published versions
-# rows are likewise filtered to versions present on the registry.
-# The player gate tolerates publish-to-registry lag via NPM_VIEW_ATTEMPTS (default 3)
-# and NPM_VIEW_RETRY_DELAY (default 10s).
+# rows are likewise filtered to versions present on the registry. Both tolerate
+# publish-to-registry lag via REGISTRY_ATTEMPTS (default 3) and REGISTRY_RETRY_DELAY
+# (default 10s), and fail loudly when the registry cannot answer at all.
 # Usage:
 #   MODE=auto|manual [PLAYER_TAG=...] ./generate-release-notes.sh resolve
 #   MODE=auto|manual PLAYER_TAG=... RELEASE_ID=... HIGHLIGHTS=... \
@@ -15,6 +15,8 @@ REPO="${GITHUB_REPOSITORY:-clappr/clappr}"
 MODE="${MODE:-auto}"
 GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
 GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
+# Overridable so the registry-unreachable path can be exercised locally.
+NPM_REGISTRY="${NPM_REGISTRY:-https://registry.npmjs.org}"
 
 # Script-scoped so the EXIT trap can still see the path after cmd_render returns
 # (a `local body_file` would be unbound under `set -u` when the trap fires).
@@ -53,33 +55,36 @@ pkg_version_at() {
   git show "${ref}:${path}" 2>/dev/null | jq -r '.version // empty'
 }
 
-# True when registry.npmjs.org has name@version (avoids announcing git-only tags).
-# The packument can lag a few seconds behind `npm publish`, so callers that run right
-# after a publish pass attempts > 1. Callers still treat a false return as "absent",
-# so a failure that is not a 404 is warned about loudly before returning.
-npm_has_package_version() {
+# Asks registry.npmjs.org whether name@version exists, so git-only tags are never
+# announced. Three-state on purpose: "we could not find out" must not be silently
+# equivalent to "not published". Queried over HTTP rather than `npm view` because the
+# status code is a stable contract — this workflow has no setup-node, so it would
+# otherwise depend on the runner image's npm keeping E404 in its stderr (see #2472).
+#   0 = present (200)   1 = confirmed absent (404)   2 = inconclusive (anything else)
+# A 404 is retried: the packument can lag seconds behind a publish.
+registry_has_version() {
   local name="$1"
   local ver="$2"
   local attempts="${3:-1}"
   local attempt=1
-  local out=""
+  local code=""
 
   while true; do
-    if out="$(npm view "${name}@${ver}" version --fetch-retries=1 2>&1)"; then
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+      "${NPM_REGISTRY}/${name//\//%2f}/${ver}" || true)"
+
+    if [ "$code" = "200" ]; then
       return 0
     fi
-    # Only a clean 404 means "not published yet" and is worth waiting on. npm
-    # already retries network failures itself, so anything else is inconclusive:
-    # warn once and stop rather than stacking more waits on top of npm's.
-    if ! printf '%s' "$out" | grep -q 'E404'; then
-      echo "::warning::npm view ${name}@${ver} failed without a 404: $(printf '%s' "$out" | tr '\n' ' ')"
-      return 1
-    fi
     if [ "$attempt" -ge "$attempts" ]; then
-      return 1
+      if [ "$code" = "404" ]; then
+        return 1
+      fi
+      echo "::warning::Registry lookup for ${name}@${ver} was inconclusive (HTTP ${code:-none})"
+      return 2
     fi
     attempt=$((attempt + 1))
-    sleep "${NPM_VIEW_RETRY_DELAY:-10}"
+    sleep "${REGISTRY_RETRY_DELAY:-10}"
   done
 }
 
@@ -88,7 +93,8 @@ build_versions_table_and_links() {
   local player_tag="$2"
   local table_rows=""
   local links=""
-  local pkg_json dir name private prev now
+  local skipped=""
+  local pkg_json dir name private prev now rc
 
   # Discover packages from the tag tree — not the worktree (checkout may lag tags).
   # NF==3 matches packages/<name>/package.json only (no nested package roots).
@@ -121,8 +127,19 @@ build_versions_table_and_links() {
     # Only list versions that actually landed on npm (partial publish batches).
     # Checked last: unchanged packages already dropped out above, so this is one
     # registry call per table row instead of one per package in the monorepo.
-    if ! npm_has_package_version "$name" "$now"; then
+    # Same retry budget as the player gate — these siblings were published in the
+    # same run, so they are just as exposed to packument lag, and a row silently
+    # dropped would announce fewer packages than were actually released.
+    rc=0
+    registry_has_version "$name" "$now" "${REGISTRY_ATTEMPTS:-3}" || rc=$?
+    if [ "$rc" = "2" ]; then
+      echo "::error::Could not determine whether ${name}@${now} is on npm; refusing to render a partial table"
+      exit 1
+    fi
+    if [ "$rc" != "0" ]; then
       echo "Skipping ${name}@${now} in Published versions (not on npm)"
+      skipped+="- \`${name}@${now}\`"
+      skipped+=$'\n'
       continue
     fi
 
@@ -136,12 +153,26 @@ build_versions_table_and_links() {
 
   VERSIONS_TABLE_OUT="$table_rows"
   CHANGELOG_LINKS_OUT="$links"
+
+  # A dropped row means the draft understates the release — say so where a human
+  # will see it, not only in the job log.
+  if [ -n "$skipped" ]; then
+    echo "::warning::Some bumped packages were left out of Published versions (not on npm)"
+    {
+      echo "### Packages left out of the release notes"
+      echo
+      echo "Bumped between tags but not found on npm, so they are not listed in the draft:"
+      echo
+      printf '%s\n' "$skipped" | sed '/^$/d'
+    } >>"$GITHUB_STEP_SUMMARY"
+  fi
 }
 
 cmd_resolve() {
   local player_tag="${PLAYER_TAG:-}"
   local base_tag=""
   local player_ver=""
+  local registry_rc=0
   local release_json release_id is_draft should_run="true" skip_copilot="false"
   local versions_table="" changelog_links="" title=""
 
@@ -168,10 +199,17 @@ cmd_resolve() {
   fi
 
   # Git tags can land before npm publish succeeds — never draft that case. Retries
-  # because Release calls this seconds after publishing, and a suppressed draft is
-  # surfaced (warning + step summary) instead of leaving a silently green run.
+  # because Release calls this seconds after publishing. A confirmed absence is a
+  # deliberate skip (warning + step summary); an inconclusive registry is a failure,
+  # so notify-failure opens an issue instead of leaving a silently green run.
   player_ver="${player_tag##*@}"
-  if ! npm_has_package_version "@clappr/player" "$player_ver" "${NPM_VIEW_ATTEMPTS:-3}"; then
+  registry_rc=0
+  registry_has_version "@clappr/player" "$player_ver" "${REGISTRY_ATTEMPTS:-3}" || registry_rc=$?
+  if [ "$registry_rc" = "2" ]; then
+    echo "::error::Could not determine whether @clappr/player@${player_ver} is on npm; failing instead of skipping silently"
+    exit 1
+  fi
+  if [ "$registry_rc" != "0" ]; then
     echo "::warning::@clappr/player@${player_ver} is tagged in git but not on npm; no draft release created"
     {
       echo "### Release notes skipped"

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -1,5 +1,9 @@
-# Creates a draft GitHub Release anchored on @clappr/player after a successful
-# Release workflow (or via workflow_dispatch).
+# Creates a draft GitHub Release anchored on @clappr/player after Release
+# successfully publishes that package (workflow_call), or via workflow_dispatch.
+#
+# Does not run on empty Release successes or non-player publishes — Release
+# only calls this workflow when player_published=true. resolve also requires
+# the player version to exist on npm before creating a draft.
 #
 # Prerequisite (optional but recommended for prose Highlights):
 #   Repository secret COPILOT_GITHUB_TOKEN — fine-grained PAT with
@@ -9,10 +13,13 @@
 name: Generate release notes
 
 on:
-  workflow_run:
-    workflows: ['Release']
-    branches: [main]
-    types: [completed]
+  workflow_call:
+    inputs:
+      player_tag:
+        description: '@clappr/player tag to announce (default: latest player tag)'
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       player_tag:
@@ -27,7 +34,6 @@ concurrency:
 jobs:
   notes:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
       pull-requests: read
@@ -44,8 +50,9 @@ jobs:
       - name: Resolve tags and version table
         id: resolve
         env:
+          # workflow_call from Release = auto; manual dispatch can update drafts.
           MODE: ${{ github.event_name == 'workflow_dispatch' && 'manual' || 'auto' }}
-          PLAYER_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.player_tag || '' }}
+          PLAYER_TAG: ${{ inputs.player_tag || '' }}
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: .github/scripts/generate-release-notes.sh resolve

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: string
         default: 'auto'
+      published_in_run:
+        description: 'Caller published the player in this run, so a missing npm version is an error rather than a skip'
+        required: false
+        type: boolean
+        default: true
     secrets:
       # Must be declared to be passed explicitly by the caller (only `inherit`
       # skips this). Optional: the Copilot step fails open without it.
@@ -67,6 +72,12 @@ jobs:
           # (publish_only recovery) would read as a manual run.
           MODE: ${{ inputs.mode || 'manual' }}
           PLAYER_TAG: ${{ inputs.player_tag || '' }}
+          # Absent on workflow_dispatch, so a hand-aimed orphan tag still just skips.
+          REQUIRE_NPM: ${{ inputs.published_in_run && '1' || '0' }}
+          # The caller published seconds ago, so give packument propagation a wider
+          # budget there (~50s): under REQUIRE_NPM this is what separates "npm was
+          # slow" from a real alarm, and a false alarm costs a bug issue.
+          REGISTRY_ATTEMPTS: ${{ inputs.published_in_run && '6' || '3' }}
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: .github/scripts/generate-release-notes.sh resolve

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -20,6 +20,16 @@ on:
         required: false
         type: string
         default: ''
+      mode:
+        description: 'auto (never touch an existing draft) or manual (may update one)'
+        required: false
+        type: string
+        default: 'auto'
+    secrets:
+      # Must be declared to be passed explicitly by the caller (only `inherit`
+      # skips this). Optional: the Copilot step fails open without it.
+      COPILOT_GITHUB_TOKEN:
+        required: false
   workflow_dispatch:
     inputs:
       player_tag:
@@ -50,8 +60,12 @@ jobs:
       - name: Resolve tags and version table
         id: resolve
         env:
-          # workflow_call from Release = auto; manual dispatch can update drafts.
-          MODE: ${{ github.event_name == 'workflow_dispatch' && 'manual' || 'auto' }}
+          # `mode` exists only under workflow_call, where its default applies (auto);
+          # on workflow_dispatch the key is absent, so this falls back to manual.
+          # Do not derive this from github.event_name — in a called workflow the
+          # github context is the caller's, so Release's own workflow_dispatch
+          # (publish_only recovery) would read as a manual run.
+          MODE: ${{ inputs.mode || 'manual' }}
           PLAYER_TAG: ${{ inputs.player_tag || '' }}
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -76,7 +90,8 @@ jobs:
       - name: Create or update draft release
         if: steps.resolve.outputs.should_run == 'true'
         env:
-          MODE: ${{ github.event_name == 'workflow_dispatch' && 'manual' || 'auto' }}
+          # Same derivation as the resolve step above — see the note there.
+          MODE: ${{ inputs.mode || 'manual' }}
           PLAYER_TAG: ${{ steps.resolve.outputs.player_tag }}
           TITLE: ${{ steps.resolve.outputs.title }}
           RELEASE_ID: ${{ steps.resolve.outputs.release_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    outputs:
+      player_published: ${{ steps.announce.outputs.player_published || 'false' }}
+      player_tag: ${{ steps.announce.outputs.player_tag || '' }}
 
     steps:
       - name: Generate GitHub App token
@@ -157,6 +160,42 @@ jobs:
             echo "Publish failures: ${failed[*]}"
             exit 1
           fi
+
+      # Only announce when this run's publish set included @clappr/player and
+      # Publish to npm succeeded (skip-already-on-npm counts as success).
+      - name: Set release notes outputs
+        id: announce
+        if: steps.changed.outputs.count != '0'
+        env:
+          PACKAGES_JSON: ${{ steps.changed.outputs.packages }}
+        run: |
+          if ! echo "$PACKAGES_JSON" | jq -e 'index("@clappr/player") != null' >/dev/null; then
+            echo "player_published=false" >> "$GITHUB_OUTPUT"
+            echo "player_tag=" >> "$GITHUB_OUTPUT"
+            echo "Player not in publish set; skipping release notes"
+            exit 0
+          fi
+          ver=$(jq -r '.version' packages/player/package.json)
+          if [ -z "$ver" ] || [ "$ver" = "null" ]; then
+            echo "::error::Could not read @clappr/player version from package.json"
+            exit 1
+          fi
+          echo "player_published=true" >> "$GITHUB_OUTPUT"
+          echo "player_tag=@clappr/player@${ver}" >> "$GITHUB_OUTPUT"
+          echo "Will request release notes for @clappr/player@${ver}"
+
+  # Draft GitHub Release only after a successful player publish (not on empty
+  # Release runs or non-player-only publishes).
+  notes:
+    needs: release
+    if: needs.release.outputs.player_published == 'true'
+    permissions:
+      contents: write
+      pull-requests: read
+    secrets: inherit
+    uses: ./.github/workflows/generate-release-notes.yml
+    with:
+      player_tag: ${{ needs.release.outputs.player_tag }}
 
   notify-failure:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,9 @@ jobs:
           # different recovery — do not claim nothing was published when it was.
           if [ "$RELEASE_RESULT" != "success" ]; then
             title="Release workflow failed on $(date -u +%Y-%m-%d)"
-            body="The Release workflow failed and no packages were published.
+            # The publish step publishes package by package, so a failure can leave
+            # part of the batch on npm — check the run rather than assuming either way.
+            body="The Release workflow failed. Some packages may already have been published before the failure — check the \`Publish to npm\` step for what landed.
 
           Run: $RUN_URL
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,9 @@ jobs:
     uses: ./.github/workflows/generate-release-notes.yml
     with:
       player_tag: ${{ needs.release.outputs.player_tag }}
+      # Explicit even though it is the default: this job only exists because the
+      # publish succeeded, so a missing npm version here must fail, not skip.
+      published_in_run: true
 
   # `if: failure()` keeps this running when release fails and notes is skipped —
   # a skipped need does not block a job guarded by a status function.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,9 +118,13 @@ jobs:
           git push origin --tags
 
       - name: Publish to npm
+        id: publish
         if: steps.changed.outputs.count != '0'
         run: |
           failed=()
+          # Records only versions this run actually pushed to npm — the release
+          # notes gate reads it, so "already on npm" skips must not land here.
+          PUBLISHED_FILE=$(mktemp)
           # Versions after lerna version live in package.json; read them via Lerna JSON
           # instead of `npm pkg get` stdout (npm 12+ is not JSON by default — see #2472).
           ERR_FILE=$(mktemp)
@@ -153,52 +157,60 @@ jobs:
             if ! npm publish -w "$pkg" --provenance; then
               echo "::error::Failed to publish $pkg@$ver"
               failed+=("$pkg@$ver")
+            else
+              echo "$pkg@$ver" >> "$PUBLISHED_FILE"
             fi
             echo "::endgroup::"
           done
+          PUBLISHED_JSON=$(jq -R -s -c 'split("\n") | map(select(length > 0))' < "$PUBLISHED_FILE")
+          rm -f "$PUBLISHED_FILE"
+          echo "published=$PUBLISHED_JSON" >> "$GITHUB_OUTPUT"
+          echo "Published in this run: $PUBLISHED_JSON"
           if [ ${#failed[@]} -gt 0 ]; then
             echo "Publish failures: ${failed[*]}"
             exit 1
           fi
 
-      # Only announce when this run's publish set included @clappr/player and
-      # Publish to npm succeeded (skip-already-on-npm counts as success).
+      # Only announce when this run actually published @clappr/player to npm. The
+      # requested set is not enough: publish_only asks for every public package, and
+      # versions already on npm are skipped — neither is a new release to announce.
       - name: Set release notes outputs
         id: announce
         if: steps.changed.outputs.count != '0'
         env:
-          PACKAGES_JSON: ${{ steps.changed.outputs.packages }}
+          PUBLISHED_JSON: ${{ steps.publish.outputs.published }}
         run: |
-          if ! echo "$PACKAGES_JSON" | jq -e 'index("@clappr/player") != null' >/dev/null; then
+          # Tag comes from the same version the publish used, so it cannot drift.
+          tag=$(echo "$PUBLISHED_JSON" | jq -r '.[] | select(startswith("@clappr/player@"))' | head -1)
+          if [ -z "$tag" ]; then
             echo "player_published=false" >> "$GITHUB_OUTPUT"
             echo "player_tag=" >> "$GITHUB_OUTPUT"
-            echo "Player not in publish set; skipping release notes"
+            echo "@clappr/player was not published in this run; skipping release notes"
             exit 0
           fi
-          ver=$(jq -r '.version' packages/player/package.json)
-          if [ -z "$ver" ] || [ "$ver" = "null" ]; then
-            echo "::error::Could not read @clappr/player version from package.json"
-            exit 1
-          fi
           echo "player_published=true" >> "$GITHUB_OUTPUT"
-          echo "player_tag=@clappr/player@${ver}" >> "$GITHUB_OUTPUT"
-          echo "Will request release notes for @clappr/player@${ver}"
+          echo "player_tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Will request release notes for ${tag}"
 
-  # Draft GitHub Release only after a successful player publish (not on empty
-  # Release runs or non-player-only publishes).
+  # Draft GitHub Release only when this run pushed a new player version to npm —
+  # not on empty Release runs, non-player publishes, or versions already on npm.
   notes:
     needs: release
     if: needs.release.outputs.player_published == 'true'
     permissions:
       contents: write
       pull-requests: read
-    secrets: inherit
+    # Only secret the notes workflow uses — no need to hand it the release app key.
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
     uses: ./.github/workflows/generate-release-notes.yml
     with:
       player_tag: ${{ needs.release.outputs.player_tag }}
 
+  # `if: failure()` keeps this running when release fails and notes is skipped —
+  # a skipped need does not block a job guarded by a status function.
   notify-failure:
-    needs: release
+    needs: [release, notes]
     if: failure()
     runs-on: ubuntu-latest
     permissions:
@@ -208,12 +220,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          RELEASE_RESULT: ${{ needs.release.result }}
         run: |
-          gh issue create --repo ${{ github.repository }} \
-            --title "Release workflow failed on $(date -u +%Y-%m-%d)" \
-            --label bug \
-            --body "The Release workflow failed and no packages were published.
+          # Publishing and drafting notes fail for different reasons and need
+          # different recovery — do not claim nothing was published when it was.
+          if [ "$RELEASE_RESULT" != "success" ]; then
+            title="Release workflow failed on $(date -u +%Y-%m-%d)"
+            body="The Release workflow failed and no packages were published.
 
           Run: $RUN_URL
 
           Check the failing step before re-running. Recovery is manual via \`workflow_dispatch\` (use publish_only if versions/tags already landed)."
+          else
+            title="Release notes generation failed on $(date -u +%Y-%m-%d)"
+            body="Packages were published to npm successfully, but the **Generate release notes** job failed, so no draft GitHub Release was created.
+
+          Run: $RUN_URL
+
+          Nothing needs to be re-published. Once the failing step is understood, re-run the notes manually via Actions → **Generate release notes**."
+          fi
+          gh issue create --repo "$REPO" \
+            --title "$title" \
+            --label bug \
+            --body "$body"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,10 @@ After `Release` **successfully publishes `@clappr/player` to npm**, it calls **G
 Notes do **not** run when:
 
 - The Release run published nothing, or only non-player packages (e.g. `@clappr/telemetry` alone)
+- The run did not actually publish the player — the version was already on npm and got skipped (common on `publish_only` recovery)
 - A git tag exists but the player version is not on npm yet (failed/partial publish)
 
-You can also run Actions → **Generate release notes** manually (updates an existing draft). `resolve` still requires the player version on npm.
+You can also run Actions → **Generate release notes** manually (updates an existing draft) — that is the way to regenerate notes in the cases above. `resolve` still requires the player version on npm.
 
 Optional repo secret `COPILOT_GITHUB_TOKEN` (fine-grained PAT with Copilot Requests: Read) enables prose Highlights via Copilot; without it the draft uses a mechanical fallback. See `.github/release-notes-instructions.md` and `.github/scripts/generate-release-notes.sh`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ Notes do **not** run when:
 
 You can also run Actions → **Generate release notes** manually (updates an existing draft) — that is the way to regenerate notes in the cases above. `resolve` still requires the player version on npm.
 
+Not finding a version and not being able to ask are different things: if the npm registry cannot answer, the notes job **fails** (opening a "Release notes generation failed" issue) instead of quietly skipping the draft. Nothing needs re-publishing in that case — just re-run the notes.
+
 Optional repo secret `COPILOT_GITHUB_TOKEN` (fine-grained PAT with Copilot Requests: Read) enables prose Highlights via Copilot; without it the draft uses a mechanical fallback. See `.github/release-notes-instructions.md` and `.github/scripts/generate-release-notes.sh`.
 
 **Cleanup if a draft was created for a git-only player tag** (tag pushed, npm publish failed): delete that draft GitHub Release, recover with Release `workflow_dispatch` + `publish_only`, then run **Generate release notes** manually if needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,18 @@ Packages that do **not** publish to npm:
 
 ### GitHub Release notes
 
-After a successful `Release` workflow (or Actions → **Generate release notes**), CI opens a **draft** GitHub Release anchored on `@clappr/player@*`. That tag is the public umbrella announcement: publishes that bump only other packages (e.g. `@clappr/core` alone) do not create a GitHub Release.
+After `Release` **successfully publishes `@clappr/player` to npm**, it calls **Generate release notes**, which opens a **draft** GitHub Release anchored on `@clappr/player@*`. That tag is the public umbrella announcement.
+
+Notes do **not** run when:
+
+- The Release run published nothing, or only non-player packages (e.g. `@clappr/telemetry` alone)
+- A git tag exists but the player version is not on npm yet (failed/partial publish)
+
+You can also run Actions → **Generate release notes** manually (updates an existing draft). `resolve` still requires the player version on npm.
 
 Optional repo secret `COPILOT_GITHUB_TOKEN` (fine-grained PAT with Copilot Requests: Read) enables prose Highlights via Copilot; without it the draft uses a mechanical fallback. See `.github/release-notes-instructions.md` and `.github/scripts/generate-release-notes.sh`.
+
+**Cleanup if a draft was created for a git-only player tag** (tag pushed, npm publish failed): delete that draft GitHub Release, recover with Release `workflow_dispatch` + `publish_only`, then run **Generate release notes** manually if needed.
 
 ## Tooling
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,11 +50,21 @@ Notes do **not** run when:
 
 - The Release run published nothing, or only non-player packages (e.g. `@clappr/telemetry` alone)
 - The run did not actually publish the player — the version was already on npm and got skipped (common on `publish_only` recovery)
-- A git tag exists but the player version is not on npm yet (failed/partial publish)
 
-You can also run Actions → **Generate release notes** manually (updates an existing draft) — that is the way to regenerate notes in the cases above. `resolve` still requires the player version on npm.
+You can also run Actions → **Generate release notes** manually (updates an existing draft) — that is the way to regenerate notes in the cases above. `resolve` still requires the player version on npm; aimed by hand at a git-only tag it skips with a warning.
 
-Not finding a version and not being able to ask are different things: if the npm registry cannot answer, the notes job **fails** (opening a "Release notes generation failed" issue) instead of quietly skipping the draft. Nothing needs re-publishing in that case — just re-run the notes.
+**When the player version is missing from npm, the two paths differ on purpose:**
+
+| Path | Missing on npm | Why |
+|---|---|---|
+| Called by `Release` (`published_in_run: true`) | **Fails** → "Release notes generation failed" issue | The publish already succeeded, so absence contradicts the caller's own precondition. Whether it is registry lag or a real incident, a green run would notify nobody. |
+| Manual dispatch | Skips with a warning | You aimed at that tag deliberately; failing would be noise. |
+
+The registry gets ~50s (`REGISTRY_ATTEMPTS: 6`) on the Release path before it counts as missing, so the failure means something is wrong rather than npm being slow.
+
+Not finding a version and not being able to ask are also different things: if the npm registry cannot answer at all, the notes job **fails** on both paths instead of quietly skipping the draft (only the Release path opens an issue — `notify-failure` lives in `release.yml`).
+
+Nothing needs re-publishing for any notes failure — "Re-run failed jobs" on the Release run re-runs only the notes job, and no duplicate issue is opened.
 
 Optional repo secret `COPILOT_GITHUB_TOKEN` (fine-grained PAT with Copilot Requests: Read) enables prose Highlights via Copilot; without it the draft uses a mechanical fallback. See `.github/release-notes-instructions.md` and `.github/scripts/generate-release-notes.sh`.
 


### PR DESCRIPTION
## Summary
- Call **Generate release notes** from Release only when `@clappr/player` was in the successful publish set (no more drafts from empty Release runs or non-player publishes).
- Skip drafting when the player tag exists in git but is not on npm; filter **Published versions** to packages actually present on the registry.
- Document recovery for git-only player tags (delete draft → `publish_only` → manual notes).

## Test plan
- [ ] Confirm the misleading `@clappr/player@0.12.2` draft was deleted (already done).
- [ ] Merge and wait for next telemetry-only (or empty) Release: **Generate release notes** job should not run.
- [ ] After a successful player npm publish (or `publish_only` that includes player): notes workflow runs and draft is created only if `@clappr/player@version` is on npm.
- [ ] Manual **Generate release notes** with an unpublished player tag skips (`should_run=false`).