### PR TITLE
docs(core): document remaining playback events and Container's role

### DIFF
--- a/packages/clappr-core/src/base/events/events.js
+++ b/packages/clappr-core/src/base/events/events.js
@@ -521,9 +521,17 @@ Events.PLAYBACK_PLAYBACKSTATE = 'playback:playbackstate'
  * @param {boolean} state true if dvr enabled
  */
 Events.PLAYBACK_DVR = 'playback:dvr'
-// TODO doc
+/**
+ * Fired when the playback requests the media control to be disabled.
+ *
+ * @event PLAYBACK_MEDIACONTROL_DISABLE
+ */
 Events.PLAYBACK_MEDIACONTROL_DISABLE = 'playback:mediacontrol:disable'
-// TODO doc
+/**
+ * Fired when the playback requests the media control to be enabled.
+ *
+ * @event PLAYBACK_MEDIACONTROL_ENABLE
+ */
 Events.PLAYBACK_MEDIACONTROL_ENABLE = 'playback:mediacontrol:enable'
 /**
  * Fired when the media for a playback ends.
@@ -580,9 +588,21 @@ Events.PLAYBACK_STOP = 'playback:stop'
  * @param {String} name Playback name
  */
 Events.PLAYBACK_ERROR = 'playback:error'
-// TODO doc
+/**
+ * Fired when the playback has stats data to report.
+ *
+ * @event PLAYBACK_STATS_ADD
+ * @param {Object} stats Data
+ * stats object, its shape depends on the playback implementation
+ */
 Events.PLAYBACK_STATS_ADD = 'playback:stats:add'
-// TODO doc
+/**
+ * Fired when a media fragment/segment has finished loading.
+ *
+ * @event PLAYBACK_FRAGMENT_LOADED
+ * @param {Object} data Data
+ * fragment metadata, its shape depends on the playback implementation
+ */
 Events.PLAYBACK_FRAGMENT_LOADED = 'playback:fragment:loaded'
 /**
  *  Fired when a fragment has been appended into buffer
@@ -592,7 +612,13 @@ Events.PLAYBACK_FRAGMENT_LOADED = 'playback:fragment:loaded'
  *
  */
 Events.PLAYBACK_FRAGMENT_BUFFERED = 'playback:fragment:buffered'
-// TODO doc
+/**
+ * Fired when the playback switches to a different quality level.
+ *
+ * @event PLAYBACK_LEVEL_SWITCH
+ * @param {Object} data Data
+ * level switch metadata, its shape depends on the playback implementation
+ */
 Events.PLAYBACK_LEVEL_SWITCH = 'playback:level:switch'
 /**
  * Fired when subtitle is available on playback for display

--- a/packages/clappr-core/src/components/container/container.js
+++ b/packages/clappr-core/src/components/container/container.js
@@ -15,8 +15,10 @@ import ContainerStyle from './public/style.scss'
 import $ from 'clappr-zepto'
 
 /**
- * An abstraction to represent a container for a given playback
- * TODO: describe its responsabilities
+ * An abstraction to represent a container for a given playback.
+ * It wraps a playback instance, forwards its events, and exposes
+ * playback controls (play, pause, seek, volume, fullscreen, etc.)
+ * to the rest of the player.
  * @class Container
  * @constructor
  * @extends UIObject


### PR DESCRIPTION
## Summary
- Five `Events.PLAYBACK_*` constants (`PLAYBACK_MEDIACONTROL_DISABLE`, `PLAYBACK_MEDIACONTROL_ENABLE`, `PLAYBACK_STATS_ADD`, `PLAYBACK_FRAGMENT_LOADED`, `PLAYBACK_LEVEL_SWITCH`) only had a `// TODO doc` placeholder instead of JSDoc. Filled them in following the style of the other documented events, based on how each event is actually used in `container.js`, `html5_video.js`, `hls.js`, `stats.js`, and `clappr-dash-shaka-playback.js`.
- `Container`'s class doc had a `TODO: describe its responsabilities` placeholder (also a typo for "responsibilities"). Replaced it with an actual description of what `Container` does.

## Why
Shallow pass over the codebase looking for something small and low-risk to fix; these `TODO doc` gaps were the easiest concrete win — pure documentation, no behavior change.

## Test plan
- [x] `yarn lint` passes
- [x] `yarn jest` for `events` and `container` test suites pass (77/77)
- [x] No source logic touched, only comments/JSDoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for playback events, including media controls, fragment loading, statistics, and quality-level switching.
  * Clarified the role of the playback container, including event forwarding and playback control access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->