### PR TITLE
fix(zepto): close CodeQL alerts #109–#117 in Zepto fork

### DIFF
--- a/packages/clappr-core/src/main.test.js
+++ b/packages/clappr-core/src/main.test.js
@@ -1,0 +1,38 @@
+import Clappr, { $ as named$ } from './main'
+
+describe('Clappr.$', () => {
+  test('re-exports the Zepto collection constructor', () => {
+    expect(Clappr.$).toBe(named$)
+    expect(typeof Clappr.$).toBe('function')
+  })
+
+  test('parses single-tag and multi-node fragments', () => {
+    const single = Clappr.$('<div/>')
+    expect(single.length).toBe(1)
+    expect(single[0].tagName).toBe('DIV')
+
+    const rows = Clappr.$('<tr><td>x</td></tr>')
+    expect(rows.length).toBe(1)
+    expect(rows[0].tagName).toBe('TR')
+    expect(rows[0].children[0].textContent).toBe('x')
+  })
+
+  test('expands self-closing non-void tags without breaking quoted attrs', () => {
+    const nested = Clappr.$('<div><p class="x"/></div>')
+    expect(nested.find('p').length).toBe(1)
+    expect(nested.find('p').attr('class')).toBe('x')
+
+    const quoted = Clappr.$('<div title="/>"/>')
+    expect(quoted.attr('title')).toBe('/>')
+  })
+
+  test('comment and doctype-prefixed fragments still produce nodes', () => {
+    const commented = Clappr.$('<!-- c --><span>y</span>')
+    expect(commented.length).toBe(2)
+    expect(commented[0].nodeType).toBe(Node.COMMENT_NODE)
+    expect(commented.filter('span').text()).toBe('y')
+
+    const withDoctype = Clappr.$('<!DOCTYPE html><div>z</div>')
+    expect(withDoctype.filter('div').text()).toBe('z')
+  })
+})

--- a/packages/clappr-zepto/src/zepto.js
+++ b/packages/clappr-zepto/src/zepto.js
@@ -948,7 +948,6 @@ window.$ === undefined && (window.$ = Zepto)
       document = window.document,
       key,
       name,
-      rscript = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
       scriptTypeRE = /^(?:text|application)\/javascript/i,
       xmlTypeRE = /^(?:text|application)\/xml/i,
       jsonType = 'application/json',
@@ -1285,9 +1284,17 @@ window.$ === undefined && (window.$ = Zepto)
         callback = options.success
     if (parts.length > 1) options.url = parts[0], selector = parts[1]
     options.success = function(response){
-      self.html(selector ?
-        $('<div>').html(response.replace(rscript, "")).find(selector)
-        : response)
+      // With a selector, parse into a detached container and drop <script>
+      // nodes structurally before finding matches. Without a selector the
+      // response is inserted as-is (same asymmetry as jQuery). This is not
+      // a sanitizer: event-handler attrs and javascript: URLs still pass.
+      if (selector) {
+        var container = $('<div>').html(response)
+        container.find('script').remove()
+        self.html(container.find(selector))
+      } else {
+        self.html(response)
+      }
       callback && callback.apply(self, arguments)
     }
     $.ajax(options)
@@ -1804,10 +1811,13 @@ window.$ === undefined && (window.$ = Zepto)
     return result
   }
 
-  // shortcut methods for `.bind(event, fn)` for each event type
+  // shortcut methods for `.bind(event, fn)` for each event type.
+  // Skip names already defined (e.g. ajax $.fn.load) — this fork concatenates
+  // ajax before event, unlike upstream's default `event ajax` order.
   ;('focusin focusout focus blur load resize scroll unload click dblclick '+
   'mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave '+
   'change select keydown keypress keyup error').split(' ').forEach(function(event) {
+    if ($.fn[event]) return
     $.fn[event] = function(callback) {
       return (0 in arguments) ?
         this.bind(event, callback) :

--- a/packages/clappr-zepto/src/zepto.js
+++ b/packages/clappr-zepto/src/zepto.js
@@ -1576,7 +1576,9 @@ window.$ === undefined && (window.$ = Zepto)
       slice = Array.prototype.slice,
       isFunction = $.isFunction,
       isString = function(obj){ return typeof obj == 'string' },
-      handlers = {},
+      // Prototype-less map: handlers['__proto__'] must never resolve to
+      // Object.prototype (CodeQL js/prototype-polluting-assignment).
+      handlers = Object.create(null),
       specialEvents={},
       focusinSupported = 'onfocusin' in window,
       focus = { focus: 'focusin', blur: 'focusout' },
@@ -1585,7 +1587,11 @@ window.$ === undefined && (window.$ = Zepto)
   specialEvents.click = specialEvents.mousedown = specialEvents.mouseup = specialEvents.mousemove = 'MouseEvents'
 
   function zid(element) {
-    return element._zid || (element._zid = _zid++)
+    // Always a number — a forged element._zid string must not become a
+    // dynamic key into handlers.
+    var id = element._zid
+    if (typeof id !== 'number') element._zid = id = _zid++
+    return id
   }
   function findHandlers(element, event, fn, selector) {
     event = parse(event)
@@ -1649,13 +1655,8 @@ window.$ === undefined && (window.$ = Zepto)
     var id = zid(element)
     ;(events || '').split(/\s/).forEach(function(event){
       findHandlers(element, event, fn, selector).forEach(function(handler){
-        // handler.i is the stable index assigned at registration (set.length).
-        // Reject prototype-chain keys and require an own slot; keep delete (not
-        // splice) so later handlers' indices stay valid for off().
-        var i = handler.i
-        if (i !== '__proto__' && i !== 'constructor' && i !== 'prototype' &&
-            Object.prototype.hasOwnProperty.call(handlers[id], i))
-          delete handlers[id][i]
+        // Keep delete (not splice) so handler.i remains a stable index for off().
+        delete handlers[id][handler.i]
       if ('removeEventListener' in element)
         element.removeEventListener(realEvent(handler.e), handler.proxy, eventCapture(handler, capture))
       })

--- a/packages/clappr-zepto/src/zepto.js
+++ b/packages/clappr-zepto/src/zepto.js
@@ -1647,7 +1647,11 @@ window.$ === undefined && (window.$ = Zepto)
     var id = zid(element)
     ;(events || '').split(/\s/).forEach(function(event){
       findHandlers(element, event, fn, selector).forEach(function(handler){
-        delete handlers[id][handler.i]
+        // handler.i is the stable index assigned at registration (set.length).
+        // Guard own-property so a forged key cannot delete Object.prototype
+        // members; keep delete (not splice) so later handlers' indices stay valid.
+        if (Object.prototype.hasOwnProperty.call(handlers[id], handler.i))
+          delete handlers[id][handler.i]
       if ('removeEventListener' in element)
         element.removeEventListener(realEvent(handler.e), handler.proxy, eventCapture(handler, capture))
       })

--- a/packages/clappr-zepto/src/zepto.js
+++ b/packages/clappr-zepto/src/zepto.js
@@ -10,7 +10,7 @@ var Zepto = (function() {
     document = window.document,
     elementDisplay = {}, classCache = {},
     cssNumber = { 'column-count': 1, 'columns': 1, 'font-weight': 1, 'line-height': 1,'opacity': 1, 'z-index': 1, 'zoom': 1 },
-    fragmentRE = /^\s*<(\w+|!)[^>]*>/,
+    fragmentRE = /^\s*<(!|\w+(?!\w))[^>]*>/,
     singleTagRE = /^<(\w+)\s*\/?>(?:<\/\1>|)$/,
     tagExpanderRE = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/ig,
     rootNodeRE = /^(?:body|html)$/i,

--- a/packages/clappr-zepto/src/zepto.js
+++ b/packages/clappr-zepto/src/zepto.js
@@ -152,7 +152,9 @@ var Zepto = (function() {
       // exec() yields null without a match; previously test() && RegExp.$1
       // yielded false. Both fall through to name = '*' below.
       if (name === undefined) name = (match = fragmentRE.exec(html)) && match[1]
-      if (!(name in containers)) name = '*'
+      // Own-property check: `in` walks the prototype (`toString`, etc.) and
+      // would make container a function — childNodes then throws TypeError.
+      if (!Object.prototype.hasOwnProperty.call(containers, name)) name = '*'
 
       container = containers[name]
       container.innerHTML = '' + html

--- a/packages/clappr-zepto/src/zepto.js
+++ b/packages/clappr-zepto/src/zepto.js
@@ -142,14 +142,16 @@ var Zepto = (function() {
   // This function can be overridden in plugins for example to make
   // it compatible with browsers that don't support the DOM fully.
   zepto.fragment = function(html, name, properties) {
-    var dom, nodes, container
+    var dom, nodes, container, match
 
     // A special case optimization for a single tag
-    if (singleTagRE.test(html)) dom = $(document.createElement(RegExp.$1))
+    if ((match = singleTagRE.exec(html))) dom = $(document.createElement(match[1]))
 
     if (!dom) {
       if (html.replace) html = html.replace(tagExpanderRE, "<$1></$2>")
-      if (name === undefined) name = fragmentRE.test(html) && RegExp.$1
+      // exec() yields null without a match; previously test() && RegExp.$1
+      // yielded false. Both fall through to name = '*' below.
+      if (name === undefined) name = (match = fragmentRE.exec(html)) && match[1]
       if (!(name in containers)) name = '*'
 
       container = containers[name]
@@ -188,7 +190,7 @@ var Zepto = (function() {
   // special cases).
   // This method can be overridden in plugins.
   zepto.init = function(selector, context) {
-    var dom
+    var dom, match
     // If nothing given, return an empty Zepto collection
     if (!selector) return zepto.Z()
     // Optimize for string selectors
@@ -197,8 +199,8 @@ var Zepto = (function() {
       // If it's a html fragment, create nodes from it
       // Note: In both Chrome 21 and Firefox 15, DOM error 12
       // is thrown if the fragment doesn't begin with <
-      if (selector[0] == '<' && fragmentRE.test(selector))
-        dom = zepto.fragment(selector, RegExp.$1, context), selector = null
+      if (selector[0] == '<' && (match = fragmentRE.exec(selector)))
+        dom = zepto.fragment(selector, match[1], context), selector = null
       // If there's a context, create a collection on that context first, and select
       // nodes from there
       else if (context !== undefined) return $(context).find(selector)
@@ -216,8 +218,8 @@ var Zepto = (function() {
       else if (isObject(selector))
         dom = [selector], selector = null
       // If it's a html fragment, create nodes from it
-      else if (fragmentRE.test(selector))
-        dom = zepto.fragment(selector.trim(), RegExp.$1, context), selector = null
+      else if ((match = fragmentRE.exec(selector)))
+        dom = zepto.fragment(selector.trim(), match[1], context), selector = null
       // If there's a context, create a collection on that context first, and select
       // nodes from there
       else if (context !== undefined) return $(context).find(selector)

--- a/packages/clappr-zepto/src/zepto.js
+++ b/packages/clappr-zepto/src/zepto.js
@@ -1649,11 +1649,13 @@ window.$ === undefined && (window.$ = Zepto)
     var id = zid(element)
     ;(events || '').split(/\s/).forEach(function(event){
       findHandlers(element, event, fn, selector).forEach(function(handler){
-        // handler.i is the stable index assigned at registration (set.length).
-        // Guard own-property so a forged key cannot delete Object.prototype
-        // members; keep delete (not splice) so later handlers' indices stay valid.
-        if (Object.prototype.hasOwnProperty.call(handlers[id], handler.i))
-          delete handlers[id][handler.i]
+        // handler.i is the stable numeric index assigned at registration
+        // (set.length). Restrict to numbers and own properties so a forged key
+        // cannot touch Object.prototype; keep delete (not splice) so later
+        // handlers' indices stay valid for off().
+        var i = handler.i
+        if (typeof i === 'number' && Object.prototype.hasOwnProperty.call(handlers[id], i))
+          delete handlers[id][i]
       if ('removeEventListener' in element)
         element.removeEventListener(realEvent(handler.e), handler.proxy, eventCapture(handler, capture))
       })

--- a/packages/clappr-zepto/src/zepto.js
+++ b/packages/clappr-zepto/src/zepto.js
@@ -1649,12 +1649,12 @@ window.$ === undefined && (window.$ = Zepto)
     var id = zid(element)
     ;(events || '').split(/\s/).forEach(function(event){
       findHandlers(element, event, fn, selector).forEach(function(handler){
-        // handler.i is the stable numeric index assigned at registration
-        // (set.length). Restrict to numbers and own properties so a forged key
-        // cannot touch Object.prototype; keep delete (not splice) so later
-        // handlers' indices stay valid for off().
+        // handler.i is the stable index assigned at registration (set.length).
+        // Reject prototype-chain keys and require an own slot; keep delete (not
+        // splice) so later handlers' indices stay valid for off().
         var i = handler.i
-        if (typeof i === 'number' && Object.prototype.hasOwnProperty.call(handlers[id], i))
+        if (i !== '__proto__' && i !== 'constructor' && i !== 'prototype' &&
+            Object.prototype.hasOwnProperty.call(handlers[id], i))
           delete handlers[id][i]
       if ('removeEventListener' in element)
         element.removeEventListener(realEvent(handler.e), handler.proxy, eventCapture(handler, capture))

--- a/packages/clappr-zepto/src/zepto.js
+++ b/packages/clappr-zepto/src/zepto.js
@@ -12,7 +12,7 @@ var Zepto = (function() {
     cssNumber = { 'column-count': 1, 'columns': 1, 'font-weight': 1, 'line-height': 1,'opacity': 1, 'z-index': 1, 'zoom': 1 },
     fragmentRE = /^\s*<(!|\w+(?!\w))[^>]*>/,
     singleTagRE = /^<(\w+)\s*\/?>(?:<\/\1>|)$/,
-    tagExpanderRE = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/ig,
+    tagExpanderRE = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)(?![\w:])(?:"[^"]*"|'[^']*'|\/(?!>)|[^>"'\/])*)\/>/ig,
     rootNodeRE = /^(?:body|html)$/i,
     capitalRE = /([A-Z])/g,
 

--- a/packages/clappr-zepto/src/zepto.js
+++ b/packages/clappr-zepto/src/zepto.js
@@ -1062,7 +1062,14 @@ window.$ === undefined && (window.$ = Zepto)
       responseData = arguments
     }
 
-    script.src = options.url.replace(/\?(.+)=\?/, '?$1=' + callbackName)
+    // Rewrite the last `=?` after `?` without a regex (avoids ReDoS on `.+`).
+    // `i > q + 1` preserves the original `.+` requirement of at least one
+    // character between `?` and `=?`.
+    var q = options.url.indexOf('?'),
+        i = q > -1 ? options.url.lastIndexOf('=?') : -1
+    script.src = i > q + 1
+      ? options.url.slice(0, i + 1) + callbackName + options.url.slice(i + 2)
+      : options.url
     document.head.appendChild(script)
 
     if (options.timeout > 0) abortTimeout = setTimeout(function(){

--- a/packages/clappr-zepto/src/zepto.test.js
+++ b/packages/clappr-zepto/src/zepto.test.js
@@ -15,6 +15,12 @@ describe('RegExp.$1 fragment sites', () => {
     expect(nodes[0].childNodes.length).toBe(0)
   })
 
+  test('singleTagRE createElement: <div></div>', () => {
+    const nodes = $('<div></div>')
+    expect(nodes.length).toBe(1)
+    expect(nodes[0].tagName).toBe('DIV')
+  })
+
   test('singleTagRE createElement: <p></p>', () => {
     const nodes = $('<p></p>')
     expect(nodes.length).toBe(1)
@@ -37,6 +43,13 @@ describe('RegExp.$1 fragment sites', () => {
     expect(nodes[0].textContent).toBe('x')
   })
 
+  test('fragmentRE with comment-only fragment', () => {
+    const nodes = $('<!-- c -->')
+    expect(nodes.length).toBe(1)
+    expect(nodes[0].nodeType).toBe(Node.COMMENT_NODE)
+    expect(nodes[0].textContent).toBe(' c ')
+  })
+
   test('fragmentRE with comment-prefixed fragment', () => {
     const nodes = $('<!--c--><div>y</div>')
     expect(nodes.length).toBe(2)
@@ -45,11 +58,38 @@ describe('RegExp.$1 fragment sites', () => {
     expect(nodes[1].textContent).toBe('y')
   })
 
+  test('fragmentRE with doctype-prefixed fragment', () => {
+    const nodes = $('<!DOCTYPE html><div>z</div>')
+    expect(nodes.length).toBeGreaterThanOrEqual(1)
+    expect(nodes.filter('div').length).toBe(1)
+    expect(nodes.filter('div')[0].textContent).toBe('z')
+  })
+
   test('$() entry path uses fragmentRE capture for container tag', () => {
-    const nodes = $('<tr><td>cell</td></tr>')
+    const nodes = $('<tr><td>x</td></tr>')
     expect(nodes.length).toBe(1)
     expect(nodes[0].tagName).toBe('TR')
     expect(nodes[0].children[0].tagName).toBe('TD')
+    expect(nodes[0].children[0].textContent).toBe('x')
+  })
+
+  test('fragment with attributes preserves attr values', () => {
+    const nodes = $('<div id="a" class="b" data-x="1">c</div>')
+    expect(nodes.length).toBe(1)
+    expect(nodes[0].tagName).toBe('DIV')
+    expect(nodes.attr('id')).toBe('a')
+    expect(nodes.attr('class')).toBe('b')
+    expect(nodes.attr('data-x')).toBe('1')
+    expect(nodes.text()).toBe('c')
+  })
+
+  test('fragmentRE no-match falls through to default container', () => {
+    // name = fragmentRE.test(html) && RegExp.$1 yields false without a match;
+    // both false and null (from a future exec() migration) hit name = '*'.
+    const nodes = $.zepto.fragment('plain text', undefined)
+    expect(nodes.length).toBe(1)
+    expect(nodes[0].nodeType).toBe(Node.TEXT_NODE)
+    expect(nodes[0].textContent).toBe('plain text')
   })
 })
 
@@ -76,10 +116,82 @@ describe('html() and tagExpander paths', () => {
     expect(nodes.find('p')[0].tagName).toBe('P')
   })
 
+  test('self-closing tag with attributes expands', () => {
+    const nodes = $('<div><span class="x"/></div>')
+    expect(nodes.find('span').length).toBe(1)
+    expect(nodes.find('span').attr('class')).toBe('x')
+  })
+
   test('malformed fragment still yields a collection', () => {
     const nodes = $('<div><span>unclosed')
     expect(nodes.length).toBe(1)
     expect(nodes[0].tagName).toBe('DIV')
     expect(nodes.find('span').length).toBe(1)
+  })
+})
+
+describe('$.ajaxJSONP', () => {
+  let appendSpy
+  let appended
+
+  beforeEach(() => {
+    appended = []
+    appendSpy = jest.spyOn(document.head, 'appendChild').mockImplementation(node => {
+      appended.push(node)
+      return node
+    })
+  })
+
+  afterEach(() => {
+    appendSpy.mockRestore()
+    Object.keys(window).forEach(key => {
+      if (/^Zepto(TestCb)?\d*$/.test(key) || /^ZeptoTestCb\d+$/.test(key)) {
+        delete window[key]
+      }
+    })
+  })
+
+  // Pass type so ajaxJSONP does not redirect into $.ajax (which adds a cache
+  // buster and would obscure the URL rewrite under test). Direct calls also
+  // skip ajaxSettings merge, so supply the callbacks ajaxBeforeSend/ajaxError use.
+  function jsonpOptions(url, jsonpCallback) {
+    const noop = () => {}
+    return {
+      type: 'GET',
+      url,
+      jsonpCallback,
+      beforeSend: noop,
+      success: noop,
+      error: noop,
+      complete: noop,
+      global: false
+    }
+  }
+
+  test('rewrites ?a=1&callback=? with the generated callback name', () => {
+    $.ajaxJSONP(
+      jsonpOptions('https://example.com/api?a=1&callback=?', 'ZeptoTestCb1')
+    )
+    expect(appended.length).toBe(1)
+    expect(appended[0].src).toBe(
+      'https://example.com/api?a=1&callback=ZeptoTestCb1'
+    )
+  })
+
+  test('with two =? placeholders rewrites the last match', () => {
+    $.ajaxJSONP(
+      jsonpOptions('https://example.com/api?x=?&callback=?', 'ZeptoTestCb2')
+    )
+    expect(appended[0].src).toBe(
+      'https://example.com/api?x=?&callback=ZeptoTestCb2'
+    )
+  })
+
+  test('without =? leaves the url unchanged', () => {
+    $.ajaxJSONP(
+      jsonpOptions('https://example.com/api?callback=fixed', 'ZeptoTestCb3')
+    )
+    expect(appended.length).toBe(1)
+    expect(appended[0].src).toBe('https://example.com/api?callback=fixed')
   })
 })

--- a/packages/clappr-zepto/src/zepto.test.js
+++ b/packages/clappr-zepto/src/zepto.test.js
@@ -149,21 +149,18 @@ describe('html() and tagExpander paths', () => {
     // expander does not match. Old [^>]* swallowed it. Spy replace so we
     // exercise the production tagExpanderRE (jsdom drops both parse outcomes).
     const html = '<div title="unclosed />'
-    const original = String.prototype.replace
-    let expanderResult
-    String.prototype.replace = function (re, repl) {
-      const result = original.apply(this, arguments)
-      if (re && typeof re.source === 'string' && re.source.indexOf('area|br|col') !== -1) {
-        expanderResult = result
-      }
-      return result
-    }
+    const spy = jest.spyOn(String.prototype, 'replace')
     try {
       $.zepto.fragment(html)
+      const idx = spy.mock.calls.findIndex(
+        args => args[0] && typeof args[0].source === 'string' &&
+          args[0].source.indexOf('area|br|col') !== -1
+      )
+      expect(idx).toBeGreaterThanOrEqual(0)
+      expect(spy.mock.results[idx].value).toBe(html)
     } finally {
-      String.prototype.replace = original
+      spy.mockRestore()
     }
-    expect(expanderResult).toBe(html)
   })
 
   test('tagExpanderRE and fragmentRE stay linear on pathological input', () => {

--- a/packages/clappr-zepto/src/zepto.test.js
+++ b/packages/clappr-zepto/src/zepto.test.js
@@ -146,13 +146,24 @@ describe('html() and tagExpander paths', () => {
 
   test('unterminated quote no longer expands self-closing tag', () => {
     // Intentional divergence: lone " cannot be consumed by any branch, so the
-    // expander does not match. Old [^>]* swallowed it.
+    // expander does not match. Old [^>]* swallowed it. Spy replace so we
+    // exercise the production tagExpanderRE (jsdom drops both parse outcomes).
     const html = '<div title="unclosed />'
-    const expanded = html.replace(
-      /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)(?![\w:])(?:"[^"]*"|'[^']*'|\/(?!>)|[^>"'/])*)\/>/ig,
-      '<$1></$2>'
-    )
-    expect(expanded).toBe(html)
+    const original = String.prototype.replace
+    let expanderResult
+    String.prototype.replace = function (re, repl) {
+      const result = original.apply(this, arguments)
+      if (re && typeof re.source === 'string' && re.source.indexOf('area|br|col') !== -1) {
+        expanderResult = result
+      }
+      return result
+    }
+    try {
+      $.zepto.fragment(html)
+    } finally {
+      String.prototype.replace = original
+    }
+    expect(expanderResult).toBe(html)
   })
 
   test('tagExpanderRE and fragmentRE stay linear on pathological input', () => {

--- a/packages/clappr-zepto/src/zepto.test.js
+++ b/packages/clappr-zepto/src/zepto.test.js
@@ -84,8 +84,8 @@ describe('RegExp.$1 fragment sites', () => {
   })
 
   test('fragmentRE no-match falls through to default container', () => {
-    // name = fragmentRE.test(html) && RegExp.$1 yields false without a match;
-    // both false and null (from a future exec() migration) hit name = '*'.
+    // name = fragmentRE.test(html) && RegExp.$1 yielded false without a match;
+    // exec() yields null. Both hit name = '*'.
     const nodes = $.zepto.fragment('plain text', undefined)
     expect(nodes.length).toBe(1)
     expect(nodes[0].nodeType).toBe(Node.TEXT_NODE)

--- a/packages/clappr-zepto/src/zepto.test.js
+++ b/packages/clappr-zepto/src/zepto.test.js
@@ -159,6 +159,54 @@ describe('html() and tagExpander paths', () => {
   })
 })
 
+describe('$.fn.load', () => {
+  let originalAjax
+
+  beforeEach(() => {
+    originalAjax = $.ajax
+  })
+
+  afterEach(() => {
+    $.ajax = originalAjax
+  })
+
+  test('without selector inserts the full response including script nodes', () => {
+    const html = '<p>hi</p><script type="text/plain">keep</script><span>there</span>'
+    $.ajax = jest.fn(options => {
+      options.success(html)
+      return {}
+    })
+    const el = $('<div/>')
+    el.load('/x')
+    expect(el.find('p').length).toBe(1)
+    expect(el.find('span').length).toBe(1)
+    expect(el.find('script').length).toBe(1)
+    expect(el.text()).toContain('hi')
+    expect(el.text()).toContain('there')
+  })
+
+  test('with selector inserts matches and removes script nodes structurally', () => {
+    const html =
+      '<div class="item">keep</div>' +
+      '<script>window.__zeptoLoadSpy=1</script>' +
+      '<div class="other">drop</div>' +
+      '<div class="item"><script type="text/plain">nested</script>ok</div>'
+    $.ajax = jest.fn(options => {
+      expect(options.url).toBe('/x')
+      options.success(html)
+      return {}
+    })
+    const el = $('<div/>')
+    el.load('/x .item')
+    expect(el.find('.item').length).toBe(2)
+    expect(el.find('.other').length).toBe(0)
+    expect(el.find('script').length).toBe(0)
+    expect(el.text()).toContain('keep')
+    expect(el.text()).toContain('ok')
+    expect(window.__zeptoLoadSpy).toBeUndefined()
+  })
+})
+
 describe('$.ajaxJSONP', () => {
   let appendSpy
   let appended

--- a/packages/clappr-zepto/src/zepto.test.js
+++ b/packages/clappr-zepto/src/zepto.test.js
@@ -207,6 +207,20 @@ describe('$.fn.load', () => {
   })
 })
 
+describe('event handler remove', () => {
+  test('off() removes a handler without disturbing later registrations', () => {
+    const el = $('<div/>')
+    const first = jest.fn()
+    const second = jest.fn()
+    el.on('click', first)
+    el.on('click', second)
+    el.off('click', first)
+    el.trigger('click')
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('$.ajaxJSONP', () => {
   let appendSpy
   let appended

--- a/packages/clappr-zepto/src/zepto.test.js
+++ b/packages/clappr-zepto/src/zepto.test.js
@@ -271,4 +271,10 @@ describe('$.ajaxJSONP', () => {
     expect(appended.length).toBe(1)
     expect(appended[0].src).toBe('https://example.com/api?callback=fixed')
   })
+
+  test('requires at least one character between ? and =?', () => {
+    // Original /\?(.+)=\?/ needed `.+`; `i > q + 1` preserves that.
+    $.ajaxJSONP(jsonpOptions('https://example.com/api?=?', 'ZeptoTestCb4'))
+    expect(appended[0].src).toBe('https://example.com/api?=?')
+  })
 })

--- a/packages/clappr-zepto/src/zepto.test.js
+++ b/packages/clappr-zepto/src/zepto.test.js
@@ -149,7 +149,7 @@ describe('html() and tagExpander paths', () => {
     // expander does not match. Old [^>]* swallowed it.
     const html = '<div title="unclosed />'
     const expanded = html.replace(
-      /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)(?![\w:])(?:"[^"]*"|'[^']*'|\/(?!>)|[^>"'\/])*)\/>/ig,
+      /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)(?![\w:])(?:"[^"]*"|'[^']*'|\/(?!>)|[^>"'/])*)\/>/ig,
       '<$1></$2>'
     )
     expect(expanded).toBe(html)

--- a/packages/clappr-zepto/src/zepto.test.js
+++ b/packages/clappr-zepto/src/zepto.test.js
@@ -232,6 +232,20 @@ describe('event handler remove', () => {
     expect(first).not.toHaveBeenCalled()
     expect(second).toHaveBeenCalledTimes(1)
   })
+
+  test('forged element._zid string does not break on/off', () => {
+    const node = document.createElement('div')
+    node._zid = '__proto__'
+    const el = $(node)
+    const fn = jest.fn()
+    el.on('click', fn)
+    el.trigger('click')
+    expect(fn).toHaveBeenCalledTimes(1)
+    el.off('click', fn)
+    el.trigger('click')
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(typeof node._zid).toBe('number')
+  })
 })
 
 describe('$.ajaxJSONP', () => {

--- a/packages/clappr-zepto/src/zepto.test.js
+++ b/packages/clappr-zepto/src/zepto.test.js
@@ -91,6 +91,19 @@ describe('RegExp.$1 fragment sites', () => {
     expect(nodes[0].nodeType).toBe(Node.TEXT_NODE)
     expect(nodes[0].textContent).toBe('plain text')
   })
+
+  test.each(['toString', 'constructor', 'valueOf'])(
+    'prototype-key container name %s falls back to default',
+    name => {
+      // Pass the hostile name directly: previously `name in containers` was
+      // true for Object.prototype keys and threw TypeError on childNodes.
+      expect(() => $.zepto.fragment('<div>x</div>', name)).not.toThrow()
+      const nodes = $.zepto.fragment('<div>x</div>', name)
+      expect(nodes.length).toBe(1)
+      expect(nodes[0].tagName).toBe('DIV')
+      expect(nodes[0].textContent).toBe('x')
+    }
+  )
 })
 
 describe('$.zepto.isZ', () => {

--- a/packages/clappr-zepto/src/zepto.test.js
+++ b/packages/clappr-zepto/src/zepto.test.js
@@ -122,6 +122,35 @@ describe('html() and tagExpander paths', () => {
     expect(nodes.find('span').attr('class')).toBe('x')
   })
 
+  test('self-closing tag with quoted attr containing /> does not break out', () => {
+    // Previously [^>]* crossed the quote and expanded at the /> inside the
+    // attribute value (#111). Quote-aware expansion must leave the attr intact.
+    const nodes = $('<div title="/>"/>')
+    expect(nodes.length).toBe(1)
+    expect(nodes[0].tagName).toBe('DIV')
+    expect(nodes.attr('title')).toBe('/>')
+  })
+
+  test('unterminated quote no longer expands self-closing tag', () => {
+    // Intentional divergence: lone " cannot be consumed by any branch, so the
+    // expander does not match. Old [^>]* swallowed it.
+    const html = '<div title="unclosed />'
+    const expanded = html.replace(
+      /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)(?![\w:])(?:"[^"]*"|'[^']*'|\/(?!>)|[^>"'\/])*)\/>/ig,
+      '<$1></$2>'
+    )
+    expect(expanded).toBe(html)
+  })
+
+  test('tagExpanderRE and fragmentRE stay linear on pathological input', () => {
+    const html = '<' + 'a'.repeat(50000)
+    const start = Date.now()
+    const nodes = $.zepto.fragment(html)
+    const elapsed = Date.now() - start
+    expect(elapsed).toBeLessThan(2000)
+    expect($(nodes).filter('*').length).toBe(0)
+  })
+
   test('malformed fragment still yields a collection', () => {
     const nodes = $('<div><span>unclosed')
     expect(nodes.length).toBe(1)


### PR DESCRIPTION
## Summary
- Fix nine CodeQL alerts in the permanent Zepto fork (`packages/clappr-zepto/src/zepto.js`): ReDoS on `fragmentRE` / `tagExpanderRE` / JSONP URL rewrite, unsafe HTML expansion across quotes, incomplete `rscript` stripping in `$.fn.load`, and prototype-polluting `delete` / `containers` lookup.
- Migrate capture reads from global `RegExp.$1` to local `exec()`, add hand-written coverage in `zepto.test.js`, and exercise the public `Clappr.$` surface in `packages/clappr-core/src/main.test.js` so Lerna bumps `@clappr/core`.
- Closes #2477.

## Intentional divergences
1. `<div title="unclosed />` no longer expands (unterminated quotes) — closes the #111 hole.
2. `<script>` removal in `$.fn.load` (selector path) is structural via DOM `.remove()`, not textual regex.
3. Fragment name capture without a match is now `null` instead of `false` — still falls through to `'*'`.
4. `$('<toString>…')`-style prototype container names no longer throw `TypeError`.

## Not a sanitizer
`$.fn.load` is **not** a sanitizer after this change. `<img onerror>`, `<svg onload>`, and `javascript:` URLs still pass. Scripts created via `innerHTML` already did not execute before this change.

## Other notes
- Fork module order is `ajax` then `event` (upstream default is `event` then `ajax`), so the event `load` shortcut was overwriting ajax `$.fn.load`. Event shortcuts now skip names already defined on `$.fn`.
- Lerna dry-run on this branch confirmed `@clappr/core: 0.14.4 => 0.14.5` (reverted; actual bump happens on release).

## Test plan
- [x] `yarn --cwd packages/clappr-zepto test`
- [x] `yarn lint && yarn test && yarn build`
- [ ] CodeQL on PR: expect alerts #110–#117 closed by code; #109 closed or dismissed with justification (`handler.i = set.length`, `delete` does not create properties)
- [ ] Confirm `@clappr/core` is included in the next release bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML fragment handling, including comment and doctype-prefixed fragments, quote-safe self-closing tags, and complex attribute values.
  * Hardened `Clappr.$`/Zepto fragment parsing to avoid errors and reduce risk from malformed or hostile markup.
  * Improved `ajaxJSONP` URL placeholder rewriting and delimiter handling.
  * Fixed selector-based HTML loading to exclude injected `<script>` nodes; refined `off()` handler removal behavior.
* **Tests**
  * Expanded Jest coverage for fragment parsing, `load`, AJAX JSONP rewriting, and event handler edge cases (including `_zid` hardening).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->