### PR TITLE
fix(player): use textContent for demo editor hash payload

### DIFF
--- a/packages/player/public/index.html
+++ b/packages/player/public/index.html
@@ -101,7 +101,8 @@ player.attachTo(playerElement);
 
       if (window.location.hash) {
         var editorContent = atob(window.location.hash.slice(1))
-        document.getElementById("editor").innerHTML = editorContent
+        // textContent avoids HTML parsing of shared URL payloads (DOM XSS).
+        document.getElementById("editor").textContent = editorContent
         setTimeout(run, 0)
       } else {
         var playerElement = document.getElementById("player-wrapper");

--- a/packages/player/public/index.plainhtml5.html
+++ b/packages/player/public/index.plainhtml5.html
@@ -101,7 +101,8 @@ player.attachTo(playerElement);
 
       if (window.location.hash) {
         var editorContent = atob(window.location.hash.slice(1))
-        document.getElementById("editor").innerHTML = editorContent
+        // textContent avoids HTML parsing of shared URL payloads (DOM XSS).
+        document.getElementById("editor").textContent = editorContent
         setTimeout(run, 0)
       } else {
         var playerElement = document.getElementById("player-wrapper");


### PR DESCRIPTION
## Summary
- Replace `innerHTML` with `textContent` when loading shared editor payloads from the URL fragment in the player demo pages (`index.html` / `index.plainhtml5.html`).
- Closes the DOM XSS sink flagged by CodeQL (`js/xss` alerts [#8](https://github.com/clappr/clappr/security/code-scanning/8) / [#9](https://github.com/clappr/clappr/security/code-scanning/9)).
- Preserves the intentional playground “share code via URL” + `eval` behavior; only stops HTML parsing of the fragment before Ace initializes.

Fixes #2478

## Test plan
- [ ] Open `packages/player/public/index.html`, edit code, click Run, reload — editor content restores from hash and player runs
- [ ] Repeat on `index.plainhtml5.html`
- [ ] Confirm a hash whose decoded payload is HTML (e.g. `<img src=x onerror=alert(1)>`) no longer executes as HTML (appears as text in the editor)
- [ ] Confirm CodeQL alerts #8 and #9 clear after merge/scan