### PR TITLE
ci: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,11 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   stale:


### PR DESCRIPTION
## Summary
- Add least-privilege `permissions:` blocks to `ci.yml` (`contents: read`) and `stale.yml` (`issues`/`pull-requests: write`) to clear CodeQL `actions/missing-workflow-permissions` alerts.
- Add `workflow_dispatch` to `stale.yml` so the scoped token can be validated without waiting for the daily cron.

Fixes #2479

## Test plan
- [ ] Confirm CI still passes on this PR with `contents: read` only
- [ ] After merge, run **Close stale issues and PRs** via Actions → workflow_dispatch and confirm it can label/comment issues and PRs
- [ ] Re-run code scanning and confirm alerts [#1](https://github.com/clappr/clappr/security/code-scanning/1) and [#2](https://github.com/clappr/clappr/security/code-scanning/2) close