### PR TITLE
docs: add security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,6 +864,10 @@ Thanks to all our amazing contributors! 🎉
 
 See the full list on our [contributors page](https://github.com/clappr/clappr/graphs/contributors).
 
+## Security
+
+Found a vulnerability? Please do not open a public issue — see our [Security Policy](SECURITY.md) for how to report it privately and what falls in scope.
+
 ## License
 
 [BSD-3-Clause](LICENSE) © Globo.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported Versions
+
+Clappr packages are versioned independently. Security fixes ship in the latest
+published minor of each package (`@clappr/player`, `@clappr/core`,
+`@clappr/plugins`, the playback packages, `@clappr/telemetry`, `@clappr/zepto`).
+Older releases are not backported — the recommended remediation is to upgrade.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue, pull request, or discussion for security
+reports. Public reports expose users who have not yet had a chance to upgrade.
+Report privately through GitHub Security Advisories:
+
+**[Report a vulnerability](https://github.com/clappr/clappr/security/advisories/new)**
+
+Include the affected package and version, the impact, and steps to reproduce —
+a minimal HTML page or CodeSandbox is ideal.
+
+Clappr is maintained by volunteers. We aim to acknowledge reports within a week
+and will keep you posted in the advisory thread, including if we conclude the
+report is not a vulnerability. We ask for up to 90 days before public
+disclosure; when a fix ships we publish a GitHub Security Advisory and credit
+you as the reporter unless you prefer otherwise.
+
+## Scope
+
+Clappr is a client-side media player library. It runs in the browser, inside the
+page of whoever embeds it, and has no server component of its own.
+
+**In scope:** XSS or script injection reachable through player options, media
+metadata, or subtitle and caption tracks; prototype pollution in `@clappr/core`
+or `@clappr/zepto`; bypass of same-origin or CORS expectations caused by
+player code.
+
+**Out of scope:**
+
+- **Content protection and DRM.** Clappr is a library, not a content manager. It
+  does not hold keys, issue or validate licenses, or enforce playback rights —
+  those belong to the platform CDM, the device, and the license server operated
+  by whoever embeds the player. Report those to the CDM vendor or to the service
+  distributing the content.
+- **Upstream dependencies.** Report to [hls.js](https://github.com/video-dev/hls.js)
+  or [shaka-player](https://github.com/shaka-project/shaka-player) directly. Tell
+  us anyway if Clappr's usage makes the impact worse.
+- Issues that require the embedder to pass attacker-controlled HTML into a
+  documented HTML-accepting option.
+- Missing security headers, TLS configuration, or other infrastructure findings
+  on clappr.io and the documentation site.
+- Automated scanner output without a demonstrated impact.


### PR DESCRIPTION
## What

Adds `SECURITY.md` and links it from the README.

Until now the repository had no security policy, so the natural path for anyone
finding a vulnerability was to open a public issue — disclosing it before a fix
exists. Private vulnerability reporting is already enabled on the repository;
this gives it a documented front door.

## The policy

Three sections, kept deliberately short:

- **Supported Versions** — fixes ship in the latest published minor of each
  package. No per-package table, since packages are versioned independently and
  a table would go stale with every new one added to the monorepo.
- **Reporting a Vulnerability** — points to GitHub Security Advisories, asks for
  no public issues, states a realistic acknowledgement target for a
  volunteer-maintained project, and sets a 90-day coordinated disclosure window.
- **Scope** — the part that carries the weight for a player library.

## On scope

Two exclusions worth calling out, because they are what keeps triage cost down:

- **Content protection and DRM.** Clappr is a library, not a content manager. It
  does not hold keys, issue or validate licenses, or enforce playback rights —
  those belong to the platform CDM, the device, and the license server operated
  by whoever embeds the player.
- **Upstream dependencies.** Clappr wraps hls.js and shaka-player; without this,
  every CVE in either lands here as an advisory. Reporters are routed upstream,
  while still being asked to tell us when our usage worsens the impact.

In scope is what is genuinely ours: XSS reachable through player options, media
metadata or caption tracks, prototype pollution in `@clappr/core` and
`@clappr/zepto`, and same-origin/CORS bypasses caused by player code.

## Sizing

Of the eight open source players surveyed, six have no security policy at all
(video.js, dash.js, Plyr, vidstack, media-chrome, MediaElement.js). The two that
do are minimal: hls.js ~20 lines, shaka-player ~35. This one is 51 lines — the
extra length is spent almost entirely on scope, which is Clappr-specific and not
something the others solved.

## Still open

Dependabot alerts and secret scanning under Settings → Code security are
unrelated to this file but complete the picture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security guidance and vulnerability reporting instructions.
  * Documented supported versions, report requirements, response timelines, disclosure expectations, and issue scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->