### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Description
+
+<!-- What does this PR change, and why? Link the related issue. -->
+
+Closes #
+
+## How to test
+
+<!-- Steps for a reviewer to verify this manually: player configuration, source URL,
+     browser/OS, and what to look for. -->
+
+1.
+2.
+
+## Guidelines
+
+- Write the PR title as a short sentence in the present tense describing the outcome (e.g. `Fix mute toggle not restoring volume`) — it feeds the release notes
+- Describe any breaking change in the section above
+- Read the [Contributing Guidelines](https://github.com/clappr/clappr/blob/main/CONTRIBUTING.md) and make sure `yarn test`, `yarn lint` and `yarn format:check` pass


### PR DESCRIPTION
## Description

Adds `.github/pull_request_template.md`, the last open item in the repository's Community Standards checklist now that `CONTRIBUTING.md` and `SECURITY.md` have landed.

Three sections, deliberately short:

- **Description** — motivation and linked issue.
- **How to test** — manual verification steps, mirroring the context `bug_report.yaml` already asks reporters for (player configuration, browser, OS).
- **Guidelines** — plain bullets rather than checkboxes, covering only what is not already documented elsewhere. Anything the CI enforces is left to the CI, and the rest links to `CONTRIBUTING.md` instead of restating it.

The PR title guidance asks for a present-tense sentence describing the outcome, with no conventional-commit prefix. Squash merging is disabled on this repository, so the PR title never becomes a commit subject — commitlint already covers every commit that lands. The title is instead consumed by the `copilot-release-notes` step, whose style guide in `.github/release-notes-instructions.md` explicitly asks for present tense and no `fix:` / `feat(scope):` prefixes.

## How to test

GitHub loads the template from the **base** branch of a new PR, so this PR is not itself prefilled by it. To verify before merging:

1. Open a draft PR with `docs/pull-request-template` as the base branch.
2. Confirm the body is prefilled with the three sections above.
3. Close the draft.

After merging, the template applies to every new PR targeting `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a pull request template with sections for descriptions, testing steps, issue closure, and contributor guidelines.
  * Included reminders for titles, breaking changes, documentation, tests, linting, and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->