### PR TITLE
Add biweekly Dependabot config and exclude machine accounts from contributors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # Yarn workspaces resolve every manifest into the root lockfile, so a single
+  # entry at "/" covers all packages and apps.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+    groups:
+      all-patches:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+
+  # Actions pinned to a major tag already receive patches silently, so this
+  # entry mostly surfaces major bumps worth reviewing.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 1
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci(deps)"
+    labels:
+      - "dependencies"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to repo
 
 Thanks to all our amazing contributors! 🎉
 
-<!-- readme: contributors -start -->
+<!-- readme: contributors,greenkeeperio-bot/-,cursoragent/- -start -->
 <table>
 	<tbody>
 		<tr>
@@ -864,7 +864,7 @@ Thanks to all our amazing contributors! 🎉
 		</tr>
 	<tbody>
 </table>
-<!-- readme: contributors -end -->
+<!-- readme: contributors,greenkeeperio-bot/-,cursoragent/- -end -->
 
 See the full list on our [contributors page](https://github.com/clappr/clappr/graphs/contributors).
 


### PR DESCRIPTION
## Description

Adds a Dependabot configuration tuned to keep update traffic low, and stops two machine accounts from being listed as human contributors.

No linked issue — this came out of enabling Dependabot on the repository.

**`.github/dependabot.yml`**

| | npm | github-actions |
|---|---|---|
| Directory | `/` | `/` |
| Schedule | 1st and 15th, 09:00 BRT | 1st and 15th, 09:00 BRT |
| Grouping | all matches into one PR | all matches into one PR |
| Filter | patch only | none |
| PR limit | 1 | 1 |
| Commit prefix | `chore(deps)` | `ci(deps)` |

At most **2 PRs per fortnight**, and only when there is something to update. Decisions worth recording:

- **A single `directory: "/"` covers the whole monorepo.** Yarn workspaces resolve all 10 manifests into the root `yarn.lock`, so per-package entries would only fragment the output into one PR each.
- **npm updates are restricted to patch.** The published packages carry virtually no runtime dependencies — only `html5-tvs-playback` declares one (`@babel/runtime`) — so the update surface is build tooling. Trade-off: because `ignore` also applies to security updates, a CVE whose only fix is a major bump raises an alert but does not open a PR automatically.
- **The github-actions entry is not filtered to patch.** Five of the six actions are pinned to a major tag and already receive patches silently, so a patch-only filter would leave that entry permanently mute. It exists to surface major bumps worth reviewing.
- **Commit prefixes follow conventional commits** to stay compatible with `.commitlintrc.js` and `.github/scripts/generate-release-notes.sh`.

**`README.md`**

`greenkeeperio-bot` and `cursoragent` are registered as ordinary `User` accounts rather than GitHub Apps, so `contributors-readme-action`'s type-based bot filter does not catch them and both render in the contributors table. Real app bots (`dependabot[bot]`, `github-actions[bot]`, `clappr-release[bot]`, `copilot-swe-agent[bot]`) are already filtered automatically and need no handling.

The action exposes no input for this — exclusion is only possible through the `/-` operator in the readme markers, applied to both start and end markers, which the action requires to be identical.

No breaking changes.

Note for the reviewer: `yarn format:check` reports 132 unformatted files, but it reports the same 132 on `main` and neither file touched here is among them. That is pre-existing debt, not introduced by this PR.

## How to test

Nothing here affects the player at runtime; verification is on the repository side.

1. **YAML parses as expected** — `npx js-yaml .github/dependabot.yml` lists two `updates` entries, both with `cronjob: "0 9 1,15 * *"`.
2. **Dependabot accepts the config** — after merging, open `Insights → Dependency graph → Dependabot`. Both `npm` and `github-actions` entries should appear with a "Last checked" timestamp and no parse-error banner.
3. **Grouping behaves as intended** — without waiting for the 1st or 15th, press *Check for updates* on the `npm` entry. Any resulting PR should bundle every patch bump together rather than opening one PR per dependency.
4. **Contributors table** — run `gh workflow run contributors.yml --repo clappr/clappr`, then confirm the regenerated table no longer contains `greenkeeperio-bot` or `cursoragent`, dropping from 108 entries to 106.

## Guidelines

- Write the PR title as a short sentence in the present tense describing the outcome (e.g. `Fix mute toggle not restoring volume`) — it feeds the release notes
- Describe any breaking change in the section above
- Read the [Contributing Guidelines](https://github.com/clappr/clappr/blob/main/CONTRIBUTING.md) and make sure `yarn test`, `yarn lint` and `yarn format:check` pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added scheduled automation to help keep project tooling and integrations current.
  * Configured grouped maintenance updates with consistent labeling and commit conventions.

* **Documentation**
  * Updated contributor-list processing guidance to exclude automated accounts, keeping generated contributor information accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->