### PR TITLE
Allow minor dependency updates and group security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,5 @@
 version: 2
 updates:
-  # Yarn workspaces resolve every manifest into the root lockfile, so a single
-  # entry at "/" covers all packages and apps.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -9,9 +7,6 @@ updates:
       cronjob: "0 9 1,15 * *"
       timezone: "America/Sao_Paulo"
     open-pull-requests-limit: 1
-    # Minor is backwards-compatible by semver contract and carries most upstream
-    # fixes, so only major is held back. "ignore" has no applies-to key, so this
-    # governs security updates as well.
     ignore:
       - dependency-name: "*"
         update-types:
@@ -28,8 +23,6 @@ updates:
     labels:
       - "dependencies"
 
-  # Actions pinned to a major tag already receive patches silently, so this
-  # entry mostly surfaces major bumps worth reviewing.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,19 @@ updates:
       cronjob: "0 9 1,15 * *"
       timezone: "America/Sao_Paulo"
     open-pull-requests-limit: 1
+    # Minor is backwards-compatible by semver contract and carries most upstream
+    # fixes, so only major is held back. "ignore" has no applies-to key, so this
+    # governs security updates as well.
     ignore:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-          - "version-update:semver-minor"
     groups:
-      all-patches:
+      all-updates:
+        applies-to: version-updates
+        patterns: ["*"]
+      security:
+        applies-to: security-updates
         patterns: ["*"]
     commit-message:
       prefix: "chore(deps)"
@@ -33,6 +39,10 @@ updates:
     open-pull-requests-limit: 1
     groups:
       actions:
+        applies-to: version-updates
+        patterns: ["*"]
+      actions-security:
+        applies-to: security-updates
         patterns: ["*"]
     commit-message:
       prefix: "ci(deps)"


### PR DESCRIPTION
## Description

Follow-up to #2489. Two changes, both aimed at the 126 open Dependabot alerts.

**Minor updates are no longer blocked.** The original config held back major *and* minor, which left most alerts without an automatic remediation path — `axios` dominates the open list and its advisories are generally resolved in minor releases. Minor is backwards-compatible by semver contract, so blocking it bought little and cost a lot. Major stays blocked, which is where breaking changes actually live.

Note that `ignore` has no `applies-to` key, so this governs security updates as well as scheduled version updates. A CVE whose only fix is a major release still requires manual action.

**Security updates are now grouped.** Enabling Dependabot security updates produced one PR per advisory (#2493, #2494, #2495, #2496) because the `groups` block only applied to version updates by default. Groups are now scoped explicitly with `applies-to`, so security updates arrive bundled per ecosystem rather than one at a time. This is the same effect as the "Grouped security updates" repository toggle, kept in version control instead.

No breaking changes.

## How to test

1. **YAML parses as expected** — `npx js-yaml .github/dependabot.yml` shows `npm` blocking only `version-update:semver-major`, and four groups total, each with an explicit `applies-to`.
2. **Security updates bundle** — close #2493 through #2496, then press *Check for updates* on the `npm` entry under `Insights → Dependency graph → Dependabot`. The replacements should arrive as a single grouped PR rather than one per package.
3. **Minor bumps are picked up** — the same check should now propose minor versions that were previously skipped; confirm `axios` appears among them.
4. **CI stays green** on the resulting Dependabot PRs, which is what validates the wider update range.

## Guidelines

- Write the PR title as a short sentence in the present tense describing the outcome (e.g. `Fix mute toggle not restoring volume`) — it feeds the release notes
- Describe any breaking change in the section above
- Read the [Contributing Guidelines](https://github.com/clappr/clappr/blob/main/CONTRIBUTING.md) and make sure `yarn test`, `yarn lint` and `yarn format:check` pass
