### PR TITLE
Cover every manifest so the major version block applies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/packages/*"
+      - "/apps/*"
     schedule:
       interval: "cron"
       cronjob: "0 9 1,15 * *"


### PR DESCRIPTION
## Description

Fixes the gap that let #2498 open a major bump of `webpack-dev-server` (3.11.3 → 6.0.0) despite the major block added in #2497.

Ignore rules are scoped to the directories declared in their own `updates` entry, and per the reference, ignore/allow cannot be configured per directory. The npm entry declared only `directory: "/"`, so the nine manifests under `packages/` and `apps/` fell outside any entry and inherited no rules at all. A security update reached `packages/dash-shaka-playback/package.json` and was free to propose a major.

The group name on #2498 confirms the path: `npm_and_yarn` is the built-in group produced by the repository-level grouped security updates setting, which by design covers directories not configured in `dependabot.yml` — not the `security` group defined here.

Switching to the globbing `directories` key brings all ten manifests under the entry that holds the major block.

This does not fragment output into one PR per package. Groups span directories — #2498's own title reads "in the npm_and_yarn group across 1 directory", which is Dependabot's template for multi-directory groups.

Remaining limitation: the major block still governs security updates, since `ignore` has no `applies-to` key. An advisory whose only fix is a major release will stay open as an alert rather than becoming a PR.

No breaking changes.

## How to test

1. **Config parses and covers everything** — `npx js-yaml .github/dependabot.yml` shows the npm entry with `directories: ["/", "/packages/*", "/apps/*"]`. Those globs resolve to all nine workspace manifests plus the root.
2. **The major is now blocked** — close #2498, then press *Check for updates* on the npm entry under `Insights → Dependency graph → Dependabot`. `webpack-dev-server` should not come back with 6.0.0; if a non-major fix exists for the advisory, it should be proposed instead.
3. **Output stays grouped** — the resulting PRs should still bundle updates rather than opening one per package directory.

## Guidelines

- Write the PR title as a short sentence in the present tense describing the outcome (e.g. `Fix mute toggle not restoring volume`) — it feeds the release notes
- Describe any breaking change in the section above
- Read the [Contributing Guidelines](https://github.com/clappr/clappr/blob/main/CONTRIBUTING.md) and make sure `yarn test`, `yarn lint` and `yarn format:check` pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated dependency update monitoring to include the root project and workspace directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->