### PR TITLE
Split major dependency bumps into their own pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
         patterns: ["*"]
       security:
         applies-to: security-updates
+        update-types: ["minor", "patch"]
         patterns: ["*"]
     commit-message:
       prefix: "chore(deps)"
@@ -32,13 +33,15 @@ updates:
       interval: "cron"
       cronjob: "0 9 1,15 * *"
       timezone: "America/Sao_Paulo"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     groups:
       actions:
         applies-to: version-updates
+        update-types: ["minor", "patch"]
         patterns: ["*"]
       actions-security:
         applies-to: security-updates
+        update-types: ["minor", "patch"]
         patterns: ["*"]
     commit-message:
       prefix: "ci(deps)"


### PR DESCRIPTION
## Description

Stops major bumps from arriving bundled with routine ones.

#2500 grouped 14 security fixes into a single PR, two of which were majors (`webpack-dev-server` 3→5, `http-proxy-middleware` 0.19→2.0). Being all-or-nothing, closing it discarded twelve safe fixes — `@babel/core`, `body-parser`, `joi`, `postcss`, `path-to-regexp` among them — along with the two that needed thought. With 126 open alerts, that pattern would repeat every cycle.

Adding `update-types: ["minor", "patch"]` to a group leaves majors outside every rule, and anything unmatched gets its own PR. So the batch keeps its value and each major becomes independently reviewable.

| | Routine | Security |
|---|---|---|
| **npm** | minor+patch grouped · major blocked by `ignore` | minor+patch grouped · **major one PR each** |
| **actions** | minor+patch grouped · **major one PR each** | minor+patch grouped · **major one PR each** |

Two details behind that asymmetry:

- **The npm version group needs no filter.** `ignore` already holds majors back for routine updates. It does *not* apply to security updates — documented as "`update-types` only affects version updates, not security updates" — which is exactly why the security group needs one.
- **Actions keep receiving majors on purpose.** Staying current there is wanted; the goal is only that seven accumulated majors across five workflows never land as one reviewable unit again, as happened in #2491.

`open-pull-requests-limit` on the actions entry goes from 1 to 5, otherwise the cap would suppress the individual major PRs it now produces. The npm limit stays at 1: its version majors are blocked, and security PRs are not counted against the limit.

Nothing that previously reached the repository is blocked by this change.

No breaking changes.

## How to test

1. **Config parses with the intended shape** — `npx js-yaml .github/dependabot.yml` shows `update-types: ["minor","patch"]` on `security`, `actions` and `actions-security`, and none on `all-updates`.
2. **Batching survives** — press *Check for updates* on the npm entry under `Insights → Dependency graph → Dependabot`. The twelve non-major fixes discarded with #2500 should come back as a single grouped PR.
3. **Majors arrive separately** — `webpack-dev-server` and `http-proxy-middleware` should each open their own PR rather than riding along in the group.
4. **The actions cap is not suppressing anything** — with the limit at 5, a grouped minor/patch PR plus any individual major PRs should all be present.

## Guidelines

- Write the PR title as a short sentence in the present tense describing the outcome (e.g. `Fix mute toggle not restoring volume`) — it feeds the release notes
- Describe any breaking change in the section above
- Read the [Contributing Guidelines](https://github.com/clappr/clappr/blob/main/CONTRIBUTING.md) and make sure `yarn test`, `yarn lint` and `yarn format:check` pass
