### PR TITLE
Set manual release instead of auto

### DIFF
--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -29,13 +29,21 @@ Use Yarn with Lerna.
 - `lerna run <command> --scope=<package-name>` - Run command in specific package
 - `lerna publish` - Publish packages (independent versioning)
 
+# Release
+
+`Release` is **manual only** (Actions → **Release** → Run workflow); merging to main publishes nothing. It refuses to run unless it is on main and CI for that exact commit concluded `success` — a CI run still in progress is refused too. There is no override.
+
+Ritual: merge → wait for CI green → dispatch with `dry_run` to see the computed versions → dispatch again without it. `dry_run` is a pure modifier (nothing is committed, tagged or published) and combines with `publish_only`, the recovery path for versions and tags already on main. Resolving zero publishable packages fails the run, except under `dry_run`.
+
+Failures are not announced anywhere — the red run in Actions is the only signal.
+
 # Release notes
 
 After `Release` successfully publishes `@clappr/player` to npm, it calls **Generate release notes**, which creates a **draft** GitHub Release anchored on `@clappr/player@*`. Manual dispatch (Actions → **Generate release notes**) can regenerate/update a draft.
 
 This is intentional: `@clappr/player` is the public umbrella announcement. Empty Release runs, non-player-only publishes, and runs where the player version was already on npm (nothing new published) do **not** create a GitHub Release — npm + package CHANGELOGs remain the source of truth for those. Manual dispatch is the way to regenerate notes in those cases.
 
-A player version missing from npm is handled differently per path: called by `Release` it **fails** (the publish had already succeeded, so absence is an anomaly worth an issue — a green run would notify nobody); on manual dispatch it skips with a warning, since you aimed at that tag on purpose.
+A player version missing from npm is handled differently per path: called by `Release` it **fails** (the publish had already succeeded, so absence is an anomaly — a green run would notify nobody); on manual dispatch it skips with a warning, since you aimed at that tag on purpose.
 
 If a draft was opened for a player tag that is not on npm: delete the draft, recover with Release `publish_only`, then re-run **Generate release notes** if needed.
 

--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -31,7 +31,7 @@ Use Yarn with Lerna.
 
 # Release
 
-`Release` is **manual only** (Actions → **Release** → Run workflow); merging to main publishes nothing. It refuses to run unless it is on main and CI for that exact commit concluded `success` — a CI run still in progress is refused too. There is no override.
+`Release` is **manual only** (Actions → **Release** → Run workflow); merging to main publishes nothing. It refuses to run unless it is on main and CI for that exact commit concluded `success` — a CI run still in progress is refused too. There is no override. If Validate finds no CI run (e.g. a past `[skip ci]` tip), Actions → **CI** → Run workflow on `main`, then re-dispatch Release.
 
 Ritual: merge → wait for CI green → dispatch with `dry_run` to see the computed versions → dispatch again without it. `dry_run` is a pure modifier (nothing is committed, tagged or published) and combines with `publish_only`, the recovery path for versions and tags already on main. Resolving zero publishable packages fails the run, except under `dry_run`.
 

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -206,8 +206,8 @@ cmd_resolve() {
 
   # Git tags can land before npm publish succeeds — never draft that case. Retries
   # because Release calls this seconds after publishing. An inconclusive registry is
-  # always a failure, so notify-failure opens an issue instead of leaving a silently
-  # green run. A confirmed absence is a deliberate skip when a human aimed us at the
+  # always a failure, so the run goes red instead of staying silently green.
+  # A confirmed absence is a deliberate skip when a human aimed us at the
   # tag, but a failure under REQUIRE_NPM: there the caller already published the
   # player, so "not on npm" contradicts its own precondition — lag or incident, both
   # need a human, and only a red job notifies anyone.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # Escape hatch when main tip has no CI run (e.g. a past [skip ci] commit).
+  # Manual dispatch still runs the full suite on that SHA; Release then sees success.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -25,4 +25,4 @@ jobs:
           readme_path: 'README.md'
           use_username: true
           committer_username: 'github-actions[bot]'
-          commit_message: 'docs(contributors): update contributors list [skip ci]'
+          commit_message: 'docs(contributors): update contributors list'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,86 @@
+# Hand-triggered only: releasing is a decision, not a consequence of merging.
+#
+# The old `workflow_run: [CI]` trigger gave two guarantees for free — the commit had
+# passed CI, and it came from main. A button gives neither, so both are re-stated as
+# explicit checks in `Validate dispatch`. Removing that step silently re-opens the
+# possibility of publishing a red commit, or pushing a feature branch onto main.
 name: Release
 
 on:
-  workflow_run:
-    workflows: ['CI']
-    branches: [main]
-    types: [completed]
   workflow_dispatch:
     inputs:
+      dry_run:
+        description: 'Preview only: resolve packages and computed versions, then stop (no commit, tag or publish)'
+        type: boolean
+        default: false
       publish_only:
         description: 'Skip versioning; publish current package.json versions (recovery after a failed publish)'
         type: boolean
         default: false
 
+# Double clicks and two people dispatching at once are the realistic race now that a
+# human starts this. Never cancel in progress: a cancel landing inside the publish loop
+# leaves part of the batch on npm with no matching tags.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
       id-token: write
+      # Lets `Validate dispatch` read the CI run for this SHA.
+      actions: read
     outputs:
       player_published: ${{ steps.announce.outputs.player_published || 'false' }}
       player_tag: ${{ steps.announce.outputs.player_tag || '' }}
 
     steps:
+      # First, and before the app token: a rejected dispatch should cost nothing and
+      # mint no credential. `gh` is preinstalled, so this needs no checkout.
+      - name: Validate dispatch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          REF: ${{ github.ref }}
+        run: |
+          # `Push commit, then tags` below does `git push origin HEAD:main`. Dispatched
+          # from a feature branch that would push the branch's content onto main.
+          if [ "$REF" != "refs/heads/main" ]; then
+            echo "::error::Release only runs from main (got $REF). Re-dispatch with main selected in the branch dropdown."
+            exit 1
+          fi
+
+          # github.sha is the head of the dispatched ref, and Checkout below takes no
+          # explicit ref — so the commit gated here is the commit that gets released.
+          RUN=$(gh api "/repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$SHA&per_page=1" \
+            --jq '.workflow_runs[0] | "\(.status) \(.conclusion)"' 2>/dev/null || true)
+
+          if [ -z "$RUN" ] || [ "$RUN" = "null null" ]; then
+            echo "::error::No CI run found for $SHA. CI runs on push to main — wait for it to appear, then dispatch again."
+            exit 1
+          fi
+
+          STATUS=${RUN%% *}
+          CONCLUSION=${RUN##* }
+
+          # The common mistake is merging a PR and clicking Release immediately, while
+          # CI for the new main commit is still running. Pending is not success.
+          if [ "$STATUS" != "completed" ]; then
+            echo "::error::CI for $SHA is still '$STATUS'. Wait for it to finish, then dispatch again."
+            exit 1
+          fi
+
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "::error::CI for $SHA concluded '$CONCLUSION'. Fix main before releasing."
+            exit 1
+          fi
+
+          echo "CI passed for $SHA"
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -66,8 +123,25 @@ jobs:
       - name: Resolve packages to publish
         id: changed
         env:
-          PUBLISH_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_only }}
+          PUBLISH_ONLY: ${{ inputs.publish_only }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
+          # Both ways of resolving nothing end here. A hand-triggered release that
+          # resolves nothing is a mismatch between what you asked for and what the repo
+          # has — usually commits without a conventional prefix, which lerna cannot read
+          # as a change. Only dry_run treats an empty answer as a valid one.
+          nothing_to_release() {
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "## Release preview" >> "$GITHUB_STEP_SUMMARY"
+              echo >> "$GITHUB_STEP_SUMMARY"
+              echo "Nothing to release." >> "$GITHUB_STEP_SUMMARY"
+              echo "No packages to publish"
+              exit 0
+            fi
+            echo "::error::No packages to publish. Check that the commits since the last release use conventional prefixes (feat/fix/...) — lerna reads those to decide what changed."
+            exit 1
+          }
+
           git fetch --tags
           set +e
           ERR_FILE=$(mktemp)
@@ -90,9 +164,7 @@ jobs:
           if [ "$PUBLISH_ONLY" != "true" ] && echo "$ERR$OUTPUT" | grep -q "No changed packages found"; then
             echo "packages=[]" >> "$GITHUB_OUTPUT"
             echo "count=0" >> "$GITHUB_OUTPUT"
-            echo "publish_only=false" >> "$GITHUB_OUTPUT"
-            echo "No packages to publish"
-            exit 0
+            nothing_to_release
           fi
 
           if [ $EXIT_CODE -ne 0 ]; then
@@ -103,17 +175,76 @@ jobs:
           fi
 
           PKGS=$(echo "$OUTPUT" | jq -c '[.[] | select(.private == false) | .name]')
+          COUNT=$(echo "$PKGS" | jq 'length')
           echo "packages=$PKGS" >> "$GITHUB_OUTPUT"
-          echo "count=$(echo "$PKGS" | jq 'length')" >> "$GITHUB_OUTPUT"
-          echo "publish_only=$PUBLISH_ONLY" >> "$GITHUB_OUTPUT"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+          # Second empty path: lerna reported changes, but every changed package is
+          # private (clappr-zepto, clappr-telemetry) so none of them publish.
+          if [ "$COUNT" = "0" ]; then
+            nothing_to_release
+          fi
+
           echo "Packages to publish: $PKGS"
 
+      # Writes package.json versions through lerna but never commits, tags or pushes:
+      # every mutating step below is guarded on dry_run, and the runner is discarded
+      # when the job ends, so the dirty tree cannot leave this machine.
+      - name: Preview release
+        if: ${{ inputs.dry_run && steps.changed.outputs.count != '0' }}
+        env:
+          PUBLISH_ONLY: ${{ inputs.publish_only }}
+          PACKAGES: ${{ steps.changed.outputs.packages }}
+        run: |
+          BEFORE=$(npx lerna list --json)
+          {
+            echo "## Release preview"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$PUBLISH_ONLY" = "true" ]; then
+            {
+              echo "Mode: \`publish_only\` — publishes the versions already in package.json."
+              echo
+              echo "| Package | Version | Already on npm |"
+              echo "|---|---|---|"
+            } >> "$GITHUB_STEP_SUMMARY"
+            for pkg in $(echo "$PACKAGES" | jq -r '.[]'); do
+              ver=$(echo "$BEFORE" | jq -r --arg pkg "$pkg" '.[] | select(.name == $pkg) | .version')
+              if npm view "$pkg@$ver" version >/dev/null 2>&1; then
+                state='yes — would be skipped'
+              else
+                state='no — would publish'
+              fi
+              echo "| \`$pkg\` | $ver | $state |" >> "$GITHUB_STEP_SUMMARY"
+            done
+          else
+            # --no-git-tag-version --no-push: compute and write the bumps without
+            # creating the release commit or any tag.
+            npx lerna version --include-merged-tags --no-git-tag-version --no-push --yes
+            AFTER=$(npx lerna list --json)
+            {
+              echo "| Package | Current | Next |"
+              echo "|---|---|---|"
+            } >> "$GITHUB_STEP_SUMMARY"
+            for pkg in $(echo "$PACKAGES" | jq -r '.[]'); do
+              from=$(echo "$BEFORE" | jq -r --arg pkg "$pkg" '.[] | select(.name == $pkg) | .version')
+              to=$(echo "$AFTER" | jq -r --arg pkg "$pkg" '.[] | select(.name == $pkg) | .version')
+              echo "| \`$pkg\` | $from | $to |" >> "$GITHUB_STEP_SUMMARY"
+            done
+          fi
+
+          {
+            echo
+            echo "Nothing was committed, tagged or published. Re-dispatch with \`dry_run\` unchecked to release."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Version and tag
-        if: steps.changed.outputs.count != '0' && steps.changed.outputs.publish_only != 'true'
+        if: ${{ steps.changed.outputs.count != '0' && !inputs.publish_only && !inputs.dry_run }}
         run: npx lerna version --include-merged-tags --no-push --yes
 
       - name: Push commit, then tags
-        if: steps.changed.outputs.count != '0' && steps.changed.outputs.publish_only != 'true'
+        if: ${{ steps.changed.outputs.count != '0' && !inputs.publish_only && !inputs.dry_run }}
         run: |
           # Fail here if branch protection rejects the bot — before any tags leave the runner
           git push origin HEAD:main
@@ -121,7 +252,7 @@ jobs:
 
       # registry-url only here so Yarn never sees the auth .npmrc during install/cache.
       - name: Configure npm registry
-        if: steps.changed.outputs.count != '0'
+        if: ${{ steps.changed.outputs.count != '0' && !inputs.dry_run }}
         uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
@@ -129,7 +260,7 @@ jobs:
 
       - name: Publish to npm
         id: publish
-        if: steps.changed.outputs.count != '0'
+        if: ${{ steps.changed.outputs.count != '0' && !inputs.dry_run }}
         run: |
           failed=()
           # Records only versions this run actually pushed to npm — the release
@@ -186,7 +317,7 @@ jobs:
       # versions already on npm are skipped — neither is a new release to announce.
       - name: Set release notes outputs
         id: announce
-        if: steps.changed.outputs.count != '0'
+        if: ${{ steps.changed.outputs.count != '0' && !inputs.dry_run }}
         env:
           PUBLISHED_JSON: ${{ steps.publish.outputs.published }}
         run: |
@@ -204,6 +335,7 @@ jobs:
 
   # Draft GitHub Release only when this run pushed a new player version to npm —
   # not on empty Release runs, non-player publishes, or versions already on npm.
+  # dry_run skips this on its own: no publish, so player_published stays false.
   notes:
     needs: release
     if: needs.release.outputs.player_published == 'true'
@@ -219,43 +351,3 @@ jobs:
       # Explicit even though it is the default: this job only exists because the
       # publish succeeded, so a missing npm version here must fail, not skip.
       published_in_run: true
-
-  # `if: failure()` keeps this running when release fails and notes is skipped —
-  # a skipped need does not block a job guarded by a status function.
-  notify-failure:
-    needs: [release, notes]
-    if: failure()
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Open issue for failed release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          REPO: ${{ github.repository }}
-          RELEASE_RESULT: ${{ needs.release.result }}
-        run: |
-          # Publishing and drafting notes fail for different reasons and need
-          # different recovery — do not claim nothing was published when it was.
-          if [ "$RELEASE_RESULT" != "success" ]; then
-            title="Release workflow failed on $(date -u +%Y-%m-%d)"
-            # The publish step publishes package by package, so a failure can leave
-            # part of the batch on npm — check the run rather than assuming either way.
-            body="The Release workflow failed. Some packages may already have been published before the failure — check the \`Publish to npm\` step for what landed.
-
-          Run: $RUN_URL
-
-          Check the failing step before re-running. Recovery is manual via \`workflow_dispatch\` (use publish_only if versions/tags already landed)."
-          else
-            title="Release notes generation failed on $(date -u +%Y-%m-%d)"
-            body="Packages were published to npm successfully, but the **Generate release notes** job failed, so no draft GitHub Release was created.
-
-          Run: $RUN_URL
-
-          Nothing needs to be re-published. Once the failing step is understood, re-run the notes manually via Actions → **Generate release notes**."
-          fi
-          gh issue create --repo "$REPO" \
-            --title "$title" \
-            --label bug \
-            --body "$body"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,12 @@ jobs:
           # event=push restores the old workflow_run:branches:[main] pair; also accept
           # workflow_dispatch so a hand-run CI can unblock a tip that had no push run
           # (e.g. a past [skip ci] commit). pull_request runs are excluded.
+          API_ERR_FILE=$(mktemp)
           RUN=$(gh api "/repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$SHA&per_page=5" \
-            --jq '[.workflow_runs[] | select(.event == "push" or .event == "workflow_dispatch")][0] | "\(.status) \(.conclusion)"' 2>/dev/null || true)
+            --jq '[.workflow_runs[] | select(.event == "push" or .event == "workflow_dispatch")][0] | "\(.status) \(.conclusion)"' 2>"$API_ERR_FILE") || {
+            echo "::warning::gh api call failed: $(cat "$API_ERR_FILE")"
+          }
+          rm -f "$API_ERR_FILE"
 
           if [ -z "$RUN" ] || [ "$RUN" = "null null" ]; then
             echo "::error::No CI run found for $SHA. Wait for push CI, or run CI via workflow_dispatch on this commit, then dispatch again."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,14 @@ jobs:
 
           # github.sha is the head of the dispatched ref, and Checkout below takes no
           # explicit ref — so the commit gated here is the commit that gets released.
-          RUN=$(gh api "/repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$SHA&per_page=1" \
-            --jq '.workflow_runs[0] | "\(.status) \(.conclusion)"' 2>/dev/null || true)
+          # event=push restores the old workflow_run:branches:[main] pair; also accept
+          # workflow_dispatch so a hand-run CI can unblock a tip that had no push run
+          # (e.g. a past [skip ci] commit). pull_request runs are excluded.
+          RUN=$(gh api "/repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$SHA&per_page=5" \
+            --jq '[.workflow_runs[] | select(.event == "push" or .event == "workflow_dispatch")][0] | "\(.status) \(.conclusion)"' 2>/dev/null || true)
 
           if [ -z "$RUN" ] || [ "$RUN" = "null null" ]; then
-            echo "::error::No CI run found for $SHA. CI runs on push to main — wait for it to appear, then dispatch again."
+            echo "::error::No CI run found for $SHA. Wait for push CI, or run CI via workflow_dispatch on this commit, then dispatch again."
             exit 1
           fi
 
@@ -180,7 +183,7 @@ jobs:
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 
           # Second empty path: lerna reported changes, but every changed package is
-          # private (clappr-zepto, clappr-telemetry) so none of them publish.
+          # private (clappr-zepto) so none of them publish.
           if [ "$COUNT" = "0" ]; then
             nothing_to_release
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ Packages that do **not** publish to npm:
 
 The run refuses to start unless it is on main **and** CI for that exact commit concluded `success`. A CI run still in progress is refused too, so a dispatch fired seconds after merging fails on purpose — wait and dispatch again. There is no override input; fix the cause instead.
 
+If Validate says there is **no CI run** for the tip SHA, GitHub never created one — usually a `[skip ci]` commit (or equivalent). `contributors.yml` no longer uses that marker; for any leftover or future case, Actions → **CI** → Run workflow on `main`, wait for green, then dispatch **Release**. That is still a real CI pass on the tip, not a gate bypass.
+
 Resolving zero publishable packages **fails** the run (green only under `dry_run`). You asked for a release, so nothing to release is a mismatch worth surfacing rather than a silent green.
 
 | Input | Use |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ Packages published to npm (via the Release workflow / Trusted Publishers):
 |---------|----------|
 | `packages/clappr-core/` | `@clappr/core` |
 | `packages/clappr-plugins/` | `@clappr/plugins` |
+| `packages/clappr-telemetry/` | `@clappr/telemetry` |
 | `packages/player/` | `@clappr/player` |
 | `packages/hlsjs-playback/` | `@clappr/hlsjs-playback` |
 | `packages/dash-shaka-playback/` | `dash-shaka-playback` |
@@ -60,8 +61,27 @@ Packages that do **not** publish to npm:
 | Package | Reason |
 |---------|--------|
 | `packages/clappr-zepto/` | Internal only (`private: true`); bundled into `@clappr/core` |
-| `packages/clappr-telemetry/` | `private: true` until the first intentional release |
 | `apps/clappr.io/` | Docs site (`clappr-docs`, already `private: true`) |
+
+### Releasing
+
+`Release` runs **only by hand** — Actions → **Release** → Run workflow. Merging to main publishes nothing.
+
+1. Merge to main, wait for **CI** to go green on the resulting commit.
+2. Dispatch **Release** with `dry_run` checked. The job summary lists every package with its current and next version; nothing is committed, tagged or published.
+3. Read the table. Wrong or missing bumps are almost always commits without a conventional prefix.
+4. Dispatch again with `dry_run` unchecked.
+
+The run refuses to start unless it is on main **and** CI for that exact commit concluded `success`. A CI run still in progress is refused too, so a dispatch fired seconds after merging fails on purpose — wait and dispatch again. There is no override input; fix the cause instead.
+
+Resolving zero publishable packages **fails** the run (green only under `dry_run`). You asked for a release, so nothing to release is a mismatch worth surfacing rather than a silent green.
+
+| Input | Use |
+|---|---|
+| `dry_run` | Preview only. A pure modifier — combine with `publish_only` to preview that path too |
+| `publish_only` | Recovery: versions and tags already landed on main, publish `package.json` as-is |
+
+Nothing announces a failed release: the red run in Actions is the only signal.
 
 ### GitHub Release notes
 
@@ -78,14 +98,14 @@ You can also run Actions → **Generate release notes** manually (updates an exi
 
 | Path | Missing on npm | Why |
 |---|---|---|
-| Called by `Release` (`published_in_run: true`) | **Fails** → "Release notes generation failed" issue | The publish already succeeded, so absence contradicts the caller's own precondition. Whether it is registry lag or a real incident, a green run would notify nobody. |
+| Called by `Release` (`published_in_run: true`) | **Fails** → red `notes` job on the Release run | The publish already succeeded, so absence contradicts the caller's own precondition. Whether it is registry lag or a real incident, a green run would notify nobody. |
 | Manual dispatch | Skips with a warning | You aimed at that tag deliberately; failing would be noise. |
 
 The registry gets ~50s (`REGISTRY_ATTEMPTS: 6`) on the Release path before it counts as missing, so the failure means something is wrong rather than npm being slow.
 
-Not finding a version and not being able to ask are also different things: if the npm registry cannot answer at all, the notes job **fails** on both paths instead of quietly skipping the draft (only the Release path opens an issue — `notify-failure` lives in `release.yml`).
+Not finding a version and not being able to ask are also different things: if the npm registry cannot answer at all, the notes job **fails** on both paths instead of quietly skipping the draft.
 
-Nothing needs re-publishing for any notes failure — "Re-run failed jobs" on the Release run re-runs only the notes job, and no duplicate issue is opened.
+Nothing needs re-publishing for any notes failure — "Re-run failed jobs" on the Release run re-runs only the notes job.
 
 Optional repo secret `COPILOT_GITHUB_TOKEN` (fine-grained PAT with Copilot Requests: Read) enables prose Highlights via Copilot; without it the draft uses a mechanical fallback. See `.github/release-notes-instructions.md` and `.github/scripts/generate-release-notes.sh`.
 


### PR DESCRIPTION
## Why

`Release` was triggered by `workflow_run: [CI]` on `main`, so every merge was a potential publish. There was no point at which a person decided "a version goes out now". This makes the button the only way in.

## The part that isn't just deleting a trigger

`workflow_run` carried two guarantees for free — the commit had passed CI, and it came from `main`. A `workflow_dispatch` gives neither, and the branch one matters: `Push commit, then tags` does `git push origin HEAD:main`, so a dispatch from a feature branch would push that branch's content onto main.

Both are now explicit checks in a `Validate dispatch` step that runs **before** the app token is minted, so a rejected dispatch costs nothing and mints no credential. The CI gate separates three cases: no run for the SHA, run still in progress, run concluded non-success. Pending is refused on purpose — the common mistake is merging a PR and clicking Release while CI for the new main commit is still in flight. There is no override input.

## `dry_run`

New input. Resolves packages, computes the bumps with `lerna version --no-git-tag-version --no-push`, prints a current → next table to the job summary, and stops. It is a pure modifier, so it also previews the `publish_only` recovery path, listing which versions are already on npm and would be skipped.

Nothing it writes escapes: every mutating step is guarded on it, and the runner is discarded.

## Zero packages now fails

Silently passing was right when any push could trigger a release — most runs had nothing to do. With a human clicking, "nothing to release" means the request and the repo disagree, usually commits that skipped the conventional prefix. Both empty paths fail now: lerna reporting no changes, and the previously **unhandled** case where lerna reports changes but every changed package is `private` (that one used to go green with all subsequent steps skipped). `dry_run` keeps it green.

## Also

- `concurrency: { group: release, cancel-in-progress: false }` — double clicks are the realistic race now. Never cancel in progress: a cancel inside the publish loop leaves part of the batch on npm with no matching tags.
- `notify-failure` removed. It existed because an automatic release failed with nobody watching. Trade-off accepted: the red run in Actions is now the only signal. Recovery stays documented in `AGENTS.md`.
- Single trigger collapses `github.event_name == 'workflow_dispatch' && inputs.publish_only` to `inputs.publish_only`, which retires the `publish_only` step output.
- `@clappr/telemetry` moved to the published table — it dropped its `private` flag in 0.2.3 (#2470) and has been publishing since; `AGENTS.md` still listed it as withheld.

## Verification done

- CI gate simulated across all seven outcomes (`null null`, empty, `in_progress`, `queued`, `failure`, `cancelled`, `success`) — each lands in the right branch. Confirmed an empty API result yields literally `"null null"`, which the guard tests for.
- `Preview release` executed for real against a throwaway clone. Lerna reported `Skipping git tag/commit` / `Skipping git push`, and the table came out correct (`@clappr/core` 0.14.6 → 0.14.7, `@clappr/player` 0.12.7 → 0.12.8, …).
- `publish_only` preview path executed too: correct table, and **zero** modified files afterwards.
- All `run` blocks pass `bash -n` and `shellcheck -S warning`; all three workflows parse as YAML.
- `actionlint` was not available, so the `${{ }}` expressions in `if:` conditions were reviewed by reading only.

## Suggested review order on the Actions tab

Steps 1–3 are free and reversible; only step 4 touches npm.

1. Dispatch from a non-main branch → fails on the ref check, no app token minted.
2. Dispatch while CI is still running → fails with the pending message.
3. Dispatch on main with `dry_run` → green, summary shows the table, `notes` skipped, `git ls-remote --tags origin | wc -l` unchanged.
4. Real release.

Heads-up for whoever runs step 4: `lerna changed` currently resolves **7** packages, so the first real run publishes all of them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual controls for running CI against a selected commit.
  * Added a manual release workflow with branch and successful-CI validation.
  * Added dry-run support to preview package versions without publishing.
  * Improved handling and reporting when no publishable packages are available.

* **Documentation**
  * Updated release guidance with workflow requirements, recovery steps, dry-run behavior, and failure handling.
  * Clarified release-note generation behavior for missing package versions and registry checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->