### PR TITLE
Drop the directory-named Jest resolver from clappr-core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,9 @@ Conscious exceptions:
 - **`clappr-zepto` `.babelrc`** — stays standalone. Babel merges preset arrays and cannot clear the inherited `modules: false`, which would change zepto's Rollup build.
 - **`dash-shaka-playback` `.babelrc`** — extends the base and overrides `modules: "commonjs"` plus `add-module-exports`.
 - **`clappr-core` Jest transform** — uses `babelrc: false` / `configFile: false`, but reads presets from `babel.base.json` `env.test` (with `modules: 'commonjs'` forced). `env.test` targets `node: current` so the root browserslist does not under-transpile tests.
-- **Deferred to later phases** — Jest family (`jest`, `babel-jest`, `jest-environment-jsdom`, `jest-mock-console`); `@rollup/plugin-replace`, `rollup-plugin-filesize`, `rollup-plugin-serve` (major divergence).
+- **Deferred to later phases** — `@rollup/plugin-replace`, `rollup-plugin-filesize`, `rollup-plugin-serve` (major divergence).
+
+The Jest family (`jest`, `babel-jest`, `jest-environment-jsdom`, `jest-mock-console`) is fully unified at the root; no package declares a Jest dependency of its own. Test imports use the full path to the module file (`../base/events/events`), matching `src/` — there is no directory-named resolution in the Jest configs.
 
 When adding a shared tool, put it at the root and remove per-package copies. Prefer this over Yarn `resolutions` when the packages do not need to install alone.
 

--- a/packages/clappr-core/jest.config.js
+++ b/packages/clappr-core/jest.config.js
@@ -6,7 +6,6 @@ module.exports = {
     'VERSION': pkg.version
   },
   'verbose': true,
-  'resolver': 'jest-directory-named-resolver',
   'transform': {
     // babelrc/configFile disabled so the sibling @clappr/zepto source (ESM
     // export default) is compiled to CJS when resolved via moduleNameMapper

--- a/packages/clappr-core/package.json
+++ b/packages/clappr-core/package.json
@@ -43,7 +43,6 @@
     "@rollup/plugin-alias": "^5.0.0",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-replace": "^5.0.2",
-    "jest-directory-named-resolver": "^0.3.0",
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-serve": "^2.0.2",
     "typescript": "^5.5.2"

--- a/packages/clappr-core/src/base/container_plugin/container_plugin.test.js
+++ b/packages/clappr-core/src/base/container_plugin/container_plugin.test.js
@@ -1,5 +1,5 @@
 import ContainerPlugin from './container_plugin'
-import ErrorMixin from '@/base/error_mixin'
+import ErrorMixin from '@/base/error_mixin/error_mixin'
 
 describe('Container Plugin', () => {
   describe('#constructor', () => {

--- a/packages/clappr-core/src/base/core_plugin/core_plugin.test.js
+++ b/packages/clappr-core/src/base/core_plugin/core_plugin.test.js
@@ -1,6 +1,6 @@
 import CorePlugin from './core_plugin'
-import ErrorMixin from '@/base/error_mixin'
-import Player from '@/components/player'
+import ErrorMixin from '@/base/error_mixin/error_mixin'
+import Player from '@/components/player/player'
 
 describe('Core Plugin', () => {
   describe('#constructor', () => {

--- a/packages/clappr-core/src/base/error_mixin/error_mixin.test.js
+++ b/packages/clappr-core/src/base/error_mixin/error_mixin.test.js
@@ -1,12 +1,12 @@
 import ErrorMixin from './error_mixin'
-import PlayerError from '@/components/error'
-import CorePlugin from '@/base/core_plugin'
-import UICorePlugin from '@/base/ui_core_plugin'
-import ContainerPlugin from '@/base/container_plugin'
-import UIContainerPlugin from '@/base/ui_container_plugin'
-import Core from '@/components/core'
-import Playback from '@/base/playback'
-import Events from '@/base/events'
+import PlayerError from '@/components/error/error'
+import CorePlugin from '@/base/core_plugin/core_plugin'
+import UICorePlugin from '@/base/ui_core_plugin/ui_core_plugin'
+import ContainerPlugin from '@/base/container_plugin/container_plugin'
+import UIContainerPlugin from '@/base/ui_container_plugin/ui_container_plugin'
+import Core from '@/components/core/core'
+import Playback from '@/base/playback/playback'
+import Events from '@/base/events/events'
 
 describe('ErrorMixin', function () {
   let errorExample

--- a/packages/clappr-core/src/base/events/events.test.js
+++ b/packages/clappr-core/src/base/events/events.test.js
@@ -1,5 +1,5 @@
 import Events from './events'
-import Log from '@/components/log'
+import Log from '@/components/log/log'
 
 describe('Events', function () {
   let events

--- a/packages/clappr-core/src/base/playback/playback.test.js
+++ b/packages/clappr-core/src/base/playback/playback.test.js
@@ -1,7 +1,7 @@
 import Playback from './playback'
-import Core from '@/components/core'
-import Events from '../../base/events'
-import PlayerError from '@/components/error'
+import Core from '@/components/core/core'
+import Events from '../../base/events/events'
+import PlayerError from '@/components/error/error'
 
 const getProperty = (obj, prop) => {
   return Object.getOwnPropertyDescriptor(Object.getPrototypeOf(obj), prop)

--- a/packages/clappr-core/src/base/ui_container_plugin/ui_container_plugin.test.js
+++ b/packages/clappr-core/src/base/ui_container_plugin/ui_container_plugin.test.js
@@ -1,5 +1,5 @@
 import UIContainerPlugin from './ui_container_plugin'
-import ErrorMixin from '@/base/error_mixin'
+import ErrorMixin from '@/base/error_mixin/error_mixin'
 
 describe('UI Container Plugin', () => {
   describe('constructor', () => {

--- a/packages/clappr-core/src/base/ui_core_plugin/ui_core_plugin.test.js
+++ b/packages/clappr-core/src/base/ui_core_plugin/ui_core_plugin.test.js
@@ -1,5 +1,5 @@
 import UICorePlugin from './ui_core_plugin'
-import ErrorMixin from '@/base/error_mixin'
+import ErrorMixin from '@/base/error_mixin/error_mixin'
 
 describe('UI Core Plugin', () => {
   describe('constructor', () => {

--- a/packages/clappr-core/src/components/container/container.test.js
+++ b/packages/clappr-core/src/components/container/container.test.js
@@ -1,7 +1,7 @@
 import Container from './container'
-import HTML5Playback from '../../playbacks/html5_video'
-import Playback from '../../base/playback'
-import Events from '../../base/events'
+import HTML5Playback from '../../playbacks/html5_video/html5_video'
+import Playback from '../../base/playback/playback'
+import Events from '../../base/events/events'
 
 const FakePlayback = Playback
 

--- a/packages/clappr-core/src/components/container_factory/container_factory.test.js
+++ b/packages/clappr-core/src/components/container_factory/container_factory.test.js
@@ -1,7 +1,7 @@
 import ContainerFactory from './container_factory'
-import Loader from '@/components/loader'
-import ContainerPlugin from '@/base/container_plugin'
-import Playback from '@/base/playback'
+import Loader from '@/components/loader/loader'
+import ContainerPlugin from '@/base/container_plugin/container_plugin'
+import Playback from '@/base/playback/playback'
 
 describe('ContainerFactory', function () {
   let options, playback, loader, container_factory

--- a/packages/clappr-core/src/components/core/core.test.js
+++ b/packages/clappr-core/src/components/core/core.test.js
@@ -1,7 +1,7 @@
 import Core from './core'
-import Browser from '../browser'
-import Events from '../../base/events'
-import { Fullscreen } from '../../utils'
+import Browser from '../browser/browser'
+import Events from '../../base/events/events'
+import { Fullscreen } from '../../utils/utils'
 
 describe('Core', function () {
   describe('When configure', () => {

--- a/packages/clappr-core/src/components/core_factory/core_factory.test.js
+++ b/packages/clappr-core/src/components/core_factory/core_factory.test.js
@@ -1,7 +1,7 @@
 import CoreFactory from './core_factory'
-import Core from '@/components/core'
-import CorePlugin from '@/base/core_plugin'
-import Player from '@/components/player'
+import Core from '@/components/core/core'
+import CorePlugin from '@/base/core_plugin/core_plugin'
+import Player from '@/components/player/player'
 
 describe('CoreFactory', () => {
   const bareOptions = { source: 'http://some.url/for/video.mp4' }

--- a/packages/clappr-core/src/components/error/error.test.js
+++ b/packages/clappr-core/src/components/error/error.test.js
@@ -1,6 +1,6 @@
-import Core from '@/components/core'
+import Core from '@/components/core/core'
 import PlayerError from './error'
-import Events from '@/base/events'
+import Events from '@/base/events/events'
 
 describe('PlayerError', function () {
   let core, playerError, errorData

--- a/packages/clappr-core/src/components/loader/loader.test.js
+++ b/packages/clappr-core/src/components/loader/loader.test.js
@@ -1,9 +1,9 @@
 import Loader from './loader'
 
-import PlaybackPlugin from '@/base/playback'
-import CorePlugin from '@/base/core_plugin'
-import ContainerPlugin from '@/base/container_plugin'
-import UIContainerPlugin from '@/base/ui_container_plugin'
+import PlaybackPlugin from '@/base/playback/playback'
+import CorePlugin from '@/base/core_plugin/core_plugin'
+import ContainerPlugin from '@/base/container_plugin/container_plugin'
+import UIContainerPlugin from '@/base/ui_container_plugin/ui_container_plugin'
 
 describe('Loader', () => {
   test('starts with an empty plugin registry', () => {

--- a/packages/clappr-core/src/components/player/player.test.js
+++ b/packages/clappr-core/src/components/player/player.test.js
@@ -1,5 +1,5 @@
-import Player from '../player'
-import Events from '../../base/events'
+import Player from '../player/player'
+import Events from '../../base/events/events'
 
 describe('Player', function () {
   describe('constructor', () => {

--- a/packages/clappr-core/src/playbacks/html5_video/html5_video.test.js
+++ b/packages/clappr-core/src/playbacks/html5_video/html5_video.test.js
@@ -1,5 +1,5 @@
 import HTML5Video from './html5_video'
-import Events from '../../base/events'
+import Events from '../../base/events/events'
 
 import $ from '@clappr/zepto'
 

--- a/packages/clappr-core/src/plugins/sources/sources.test.js
+++ b/packages/clappr-core/src/plugins/sources/sources.test.js
@@ -1,9 +1,9 @@
 import SourcesPlugin from './sources'
-import Playback from '@/base/playback'
-import NoOp from '@/playbacks/no_op'
-import Container from '@/components/container'
-import Core from '@/components/core'
-import Events from '@/base/events'
+import Playback from '@/base/playback/playback'
+import NoOp from '@/playbacks/no_op/no_op'
+import Container from '@/components/container/container'
+import Core from '@/components/core/core'
+import Events from '@/base/events/events'
 
 const createContainersArray = (options, quantity) => {
   const containers = []

--- a/yarn.lock
+++ b/yarn.lock
@@ -9390,13 +9390,6 @@ jest-diff@30.4.1:
     jest-get-type "^29.6.3"
     pretty-format "^29.7.0"
 
-jest-directory-named-resolver@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/jest-directory-named-resolver/-/jest-directory-named-resolver-0.3.0.tgz#77b7843e25189f2522c3af4bd25eb6323dc12830"
-  integrity sha512-1A/N75O6ly4oedbJvEnWY+Rr9S+9qYX8h6Aql+SCBNu9ViQRKlvmBHOMVzk/jI/8lcqzP0iPo6R1r4ubSP8t1A==
-  dependencies:
-    resolve "^1.9.0"
-
 jest-docblock@30.4.0:
   version "30.4.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-30.4.0.tgz#3ab779a027d1495ae21550accd4266bbe99af7a3"
@@ -13508,7 +13501,7 @@ resolve.exports@2.0.3:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.3.tgz#41955e6f1b4013b7586f873749a635dea07ebe3f"
   integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.22.1, resolve@^1.22.11, resolve@^1.3.2, resolve@^1.9.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.22.1, resolve@^1.22.11, resolve@^1.3.2:
   version "1.22.11"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.11.tgz#aad857ce1ffb8bfa9b0b1ac29f1156383f68c262"
   integrity sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==


### PR DESCRIPTION
## Description

Closes #2527.

`packages/clappr-core/jest.config.js` set `resolver: 'jest-directory-named-resolver'`. After #2528 it was the last package-local Jest dependency in the workspace, and the only custom module resolution left anywhere in it.

Two reasons to move off it:

- **Unmaintained.** It still declares `jest ^19` as its own devDependency.
- **It bypasses the default resolver.** It never calls `options.defaultResolver`; it calls the `resolve` package directly, so it ignores `exports` maps and conditions that Jest 28/29/30 lean on. That was never a blocker — all 28 suites pass on Jest 30 with it in place — but it is where the next dependency shipping an `exports` map without a legacy entry point would surface, and it would surface only under test, with the build unaffected.

**#2527 proposed replacing it with a small local resolver that delegates to `options.defaultResolver`. This removes it instead.** Scoping the replacement turned up the reason: only test files ever used the directory-named shorthand. All 27 modules under `src/` already import the full path to the module file (`../../base/ui_object/ui_object`), and `rollup.config.js` needs no resolution plugin — the convention is only load-bearing in `clappr-plugins`, where `rollup-plugin-named-directory` handles it at build time for `src/main.js`.

So the 43 affected test imports get the same full path `src/` already uses:

```diff
-import Events from '@/base/events'
+import Events from '@/base/events/events'
```

Writing our own resolver would have reproduced the original problem in a smaller form: custom resolution code, outside the Jest team's test matrix, aging against a future major. Removing it leaves nothing to age. `clappr-core` now runs on the stock resolver like every other package, and `exports`/conditions work because nothing intercepts resolution at all.

## How to test

Test infrastructure only — no runtime code changes and `dist/` is untouched, so there is nothing to verify in a player. As in #2528, the meaningful check is that the suite is *identical*, not merely green.

1. `yarn --frozen-lockfile && yarn test` — expect **54 suites / 1101 cases** across the workspace, matching `main`. `clappr-core` alone is **28 suites / 433 cases**.
2. Compare `clappr-core` coverage against `main` — unchanged to the decimal:

   | | statements | branches | functions | lines |
   |---|---:|---:|---:|---:|
   | `main` | 77.93 | 70.35 | 66.43 | 78.69 |
   | this branch | 77.93 | 70.35 | 66.43 | 78.69 |

3. `yarn lint` passes for all 7 projects.
4. Confirm nothing references the resolver any more, `yarn.lock` included:

   ```
   git grep -n jest-directory-named-resolver -- ':!yarn.lock' ; git grep -n jest-directory-named-resolver -- yarn.lock
   ```

   Both should return nothing. No package under `packages/` declares a Jest dependency at this point.

### Notes for the reviewer

- **The import rewrite is one uniform rule** — append `/<basename>` — applied to all 43 occurrences, so the diff should scan quickly. Every affected import is in a `.test.js` file; no production module changed.
- `player.test.js` now reads `import Player from '../player/player'`, which is the mechanical result of that rule. `./player` would match how the other suites import their subject. Left alone so the diff stays uniform — happy to fold it in.
- **The shorthand no longer resolves**, so a new test written as `@/base/events` fails with `Cannot find module`. That is immediate and self-correcting at author time, and it leaves tests consistent with `src/`.
- **The docs commit is separate.** `AGENTS.md` listed the Jest family under "deferred to later phases", which stopped being true when #2528 hoisted it — and this PR removes the last package-local Jest dep, so the line had to go. It also records the full-path import convention that replaced the directory-named lookup.
- `yarn format:check` fails on this branch, but it fails identically on `main` — 130 files either way. The repository has never been Prettier-formatted and CI does not run that step. No file touched here is newly failing.
