### PR TITLE
Resolve @clappr/core from source in package Jest configs

### DIFF
--- a/packages/clappr-plugins/jest.config.js
+++ b/packages/clappr-plugins/jest.config.js
@@ -4,14 +4,30 @@ module.exports = {
   testEnvironment: 'jsdom',
   verbose: true,
   transform: {
-    '^.+\\.js$': 'babel-jest',
+    // babelrc/configFile disabled so sibling @clappr/core and @clappr/zepto
+    // source (ESM) is compiled to CJS when resolved via moduleNameMapper outside
+    // rootDir. Presets come from babel.base.json env.test; modules is forced to
+    // commonjs because babel-jest's caller hint is ignored when babelrc/configFile
+    // are both false.
+    '^.+\\.js$': ['babel-jest', {
+      babelrc: false,
+      configFile: false,
+      presets: require('../../babel.base.json').env.test.presets.map(
+        ([name, options = {}]) => [name, { ...options, modules: 'commonjs' }]
+      )
+    }],
     '^.+\\.html$': '<rootDir>/src/__mocks__/htmlMock.js'
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^@clappr/core$': '<rootDir>/../clappr-core/src/main.js',
+    '^@clappr/zepto$': '<rootDir>/../clappr-zepto/src/zepto.js',
     '\\.(scss)$': '<rootDir>/src/__mocks__/styleMock.js',
     '\\.(svg)$': '<rootDir>/src/__mocks__/svgMock.js'
   },
   collectCoverageFrom: ['src/*.js', 'src/**/*.js', 'src/**/**/*.js'],
-  globals: { CLAPPR_CORE_VERSION: ClapprCorePkg.version }
+  globals: {
+    CLAPPR_CORE_VERSION: ClapprCorePkg.version,
+    VERSION: ClapprCorePkg.version
+  }
 }

--- a/packages/clappr-plugins/package.json
+++ b/packages/clappr-plugins/package.json
@@ -52,14 +52,5 @@
       "src/vendor",
       "node_modules"
     ]
-  },
-  "nx": {
-    "targets": {
-      "test": {
-        "dependsOn": [
-          "^release"
-        ]
-      }
-    }
   }
 }

--- a/packages/hlsjs-playback/jest.config.js
+++ b/packages/hlsjs-playback/jest.config.js
@@ -5,10 +5,28 @@ module.exports = {
   testEnvironment: 'jsdom',
   verbose: true,
   transform: {
-    '^.+\\.js$': 'babel-jest'
+    // babelrc/configFile disabled so sibling @clappr/core and @clappr/zepto
+    // source (ESM) is compiled to CJS when resolved via moduleNameMapper outside
+    // rootDir. Presets come from babel.base.json env.test; modules is forced to
+    // commonjs because babel-jest's caller hint is ignored when babelrc/configFile
+    // are both false.
+    '^.+\\.js$': ['babel-jest', {
+      babelrc: false,
+      configFile: false,
+      presets: require('../../babel.base.json').env.test.presets.map(
+        ([name, options = {}]) => [name, { ...options, modules: 'commonjs' }]
+      )
+    }],
+    '^.+\\.html$': '<rootDir>/../clappr-core/src/__mocks__/htmlMock.js'
   },
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1'
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^@clappr/core$': '<rootDir>/../clappr-core/src/main.js',
+    '^@clappr/zepto$': '<rootDir>/../clappr-zepto/src/zepto.js',
+    '\\.(scss)$': '<rootDir>/../clappr-core/src/__mocks__/styleMock.js'
   },
-  globals: { CLAPPR_CORE_VERSION: ClapprCorePkg.version }
+  globals: {
+    CLAPPR_CORE_VERSION: ClapprCorePkg.version,
+    VERSION: ClapprCorePkg.version
+  }
 }

--- a/packages/hlsjs-playback/package.json
+++ b/packages/hlsjs-playback/package.json
@@ -45,14 +45,5 @@
     "hls.js": "1.6.16",
     "rollup-plugin-filesize": "^9.1.1",
     "rollup-plugin-serve": "^1.1.0"
-  },
-  "nx": {
-    "targets": {
-      "test": {
-        "dependsOn": [
-          "^release"
-        ]
-      }
-    }
   }
 }

--- a/packages/html5-tvs-playback/jest.config.js
+++ b/packages/html5-tvs-playback/jest.config.js
@@ -1,8 +1,32 @@
+const ClapprCorePkg = require('@clappr/core/package.json')
+
 module.exports = {
   // Explicit since jest 27 flipped the default to 'node'; these suites need DOM.
   testEnvironment: 'jsdom',
   verbose: true,
-  transform: { '^.+\\.js$': 'babel-jest' },
+  transform: {
+    // babelrc/configFile disabled so sibling @clappr/core and @clappr/zepto
+    // source (ESM) is compiled to CJS when resolved via moduleNameMapper outside
+    // rootDir. Presets come from babel.base.json env.test; modules is forced to
+    // commonjs because babel-jest's caller hint is ignored when babelrc/configFile
+    // are both false.
+    '^.+\\.js$': ['babel-jest', {
+      babelrc: false,
+      configFile: false,
+      presets: require('../../babel.base.json').env.test.presets.map(
+        ([name, options = {}]) => [name, { ...options, modules: 'commonjs' }]
+      )
+    }],
+    '^.+\\.html$': '<rootDir>/../clappr-core/src/__mocks__/htmlMock.js'
+  },
+  moduleNameMapper: {
+    '^@clappr/core$': '<rootDir>/../clappr-core/src/main.js',
+    '^@clappr/zepto$': '<rootDir>/../clappr-zepto/src/zepto.js',
+    '\\.(scss)$': '<rootDir>/../clappr-core/src/__mocks__/styleMock.js'
+  },
+  globals: {
+    VERSION: ClapprCorePkg.version
+  },
   collectCoverageFrom: ['src/*.js', 'src/**/*.js'],
   coverageThreshold: {
     global: {

--- a/packages/html5-tvs-playback/package.json
+++ b/packages/html5-tvs-playback/package.json
@@ -56,14 +56,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "nx": {
-    "targets": {
-      "test": {
-        "dependsOn": [
-          "^release"
-        ]
-      }
-    }
   }
 }


### PR DESCRIPTION
## Description

Package tests in `@clappr/plugins`, `@clappr/hlsjs-playback`, and `@clappr/clappr-html5-tvs-playback` imported `@clappr/core` through its built `dist/`. CI only worked before `yarn build` because Lerna 8 inferred `nx.targets.test.dependsOn: ["^release"]` from each `package.json`, with no `nx.json` declaring that graph.

This PR maps `@clappr/core` and `@clappr/zepto` to source in Jest (same approach `@clappr/core` already uses for zepto), removes those inferred `dependsOn` blocks, and drops the hidden dist-before-test ordering.

Closes #2526

## How to test

1. From a clean checkout, wipe built artifacts for core and the affected packages:

```bash
rm -rf packages/clappr-core/dist packages/clappr-zepto/dist \
  packages/clappr-plugins/dist packages/hlsjs-playback/dist \
  packages/html5-tvs-playback/dist
```

2. Run the three affected test suites (no prior `yarn build` / `release` of core):

```bash
lerna run test --scope=@clappr/plugins --scope=@clappr/hlsjs-playback --scope=@clappr/clappr-html5-tvs-playback
```

3. Run the full monorepo checks:

```bash
yarn test
yarn lint
yarn format:check
```

4. Confirm CI stays green with `test` still running before `build` in `.github/workflows/ci.yml`.

## Guidelines

- Write the PR title as a short sentence in the present tense describing the outcome (e.g. `Fix mute toggle not restoring volume`) — it feeds the release notes
- Describe any breaking change in the section above
- Read the [Contributing Guidelines](https://github.com/clappr/clappr/blob/main/CONTRIBUTING.md) and make sure `yarn test`, `yarn lint` and `yarn format:check` pass