### PR TITLE
Extract a shared jest.config.base.js at the workspace root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Shared config locations:
 | Config | Path | Notes |
 |--------|------|-------|
 | Babel | `babel.base.json` | Packages extend via `.babelrc` |
+| Jest | `jest.config.base.js` | Packages extend via spread; override `transform` when not resolving sibling ESM source |
 | Browserslist | `.browserslistrc` | Matches autoprefixer `defaults` (`> 0.5%` / `last 2 versions` / `Firefox ESR` / `not dead`); `apps/clappr.io` keeps its own field |
 | ESLint | `eslint.config.js` | Flat config; `eslint` + `@eslint/js` declared at the root. Root `yarn lint` runs `lerna run lint` so package configs (`*.js` at package root) are covered |
 
@@ -37,7 +38,7 @@ Conscious exceptions:
 
 - **`clappr-zepto` `.babelrc`** — stays standalone. Babel merges preset arrays and cannot clear the inherited `modules: false`, which would change zepto's Rollup build.
 - **`dash-shaka-playback` `.babelrc`** — extends the base and overrides `modules: "commonjs"` plus `add-module-exports`.
-- **`clappr-core` Jest transform** — uses `babelrc: false` / `configFile: false`, but reads presets from `babel.base.json` `env.test` (with `modules: 'commonjs'` forced). `env.test` targets `node: current` so the root browserslist does not under-transpile tests.
+- **`jest.config.base.js` sibling-source transform** — default for packages that resolve `@clappr/core` / `@clappr/zepto` to source via `moduleNameMapper`: `babelrc: false` / `configFile: false`, presets from `babel.base.json` `env.test` with `modules: 'commonjs'` forced. **`clappr-zepto` and `clappr-telemetry`** override to plain `babel-jest` (no sibling ESM mapping; zepto's standalone `.babelrc` remains for Rollup).
 - **Deferred to later phases** — `@rollup/plugin-replace`, `rollup-plugin-filesize`, `rollup-plugin-serve` (major divergence).
 
 The Jest family (`jest`, `babel-jest`, `jest-environment-jsdom`, `jest-mock-console`) is fully unified at the root; no package declares a Jest dependency of its own. Test imports use the full path to the module file (`../base/events/events`), matching `src/` — there is no directory-named resolution in the Jest configs.

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,0 +1,13 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  verbose: true,
+  transform: {
+    '^.+\\.js$': ['babel-jest', {
+      babelrc: false,
+      configFile: false,
+      presets: require('./babel.base.json').env.test.presets.map(
+        ([name, options = {}]) => [name, { ...options, modules: 'commonjs' }]
+      )
+    }]
+  }
+}

--- a/packages/clappr-core/jest.config.js
+++ b/packages/clappr-core/jest.config.js
@@ -1,33 +1,21 @@
+const base = require('../../jest.config.base')
 const pkg = require('./package.json')
 
 module.exports = {
-  'testEnvironment': 'jsdom',
-  'globals': {
-    'VERSION': pkg.version
+  ...base,
+  globals: {
+    VERSION: pkg.version
   },
-  'verbose': true,
-  'transform': {
-    // babelrc/configFile disabled so the sibling @clappr/zepto source (ESM
-    // export default) is compiled to CJS when resolved via moduleNameMapper
-    // outside rootDir. Presets come from babel.base.json env.test; modules
-    // is forced to commonjs because babel-jest's caller hint is ignored when
-    // babelrc/configFile are both false.
-    '^.+\\.js$': ['babel-jest', {
-      babelrc: false,
-      configFile: false,
-      presets: require('../../babel.base.json').env.test.presets.map(
-        ([name, options = {}]) => [name, { ...options, modules: 'commonjs' }]
-      )
-    }],
+  transform: {
+    ...base.transform,
     '^.+\\.html$': '<rootDir>/src/__mocks__/htmlMock.js'
   },
-  'moduleNameMapper': {
+  moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-    // Resolve to source so package tests/IDE runners don't depend on (or stale) dist/
     '^@clappr/zepto$': '<rootDir>/../clappr-zepto/src/zepto.js',
     '\\.(scss)$': '<rootDir>/src/__mocks__/styleMock.js'
   },
-  'collectCoverageFrom': [
+  collectCoverageFrom: [
     'src/*.js',
     'src/**/*.js',
     'src/**/**/*.js'

--- a/packages/clappr-plugins/jest.config.js
+++ b/packages/clappr-plugins/jest.config.js
@@ -1,21 +1,10 @@
+const base = require('../../jest.config.base')
 const ClapprCorePkg = require('@clappr/core/package.json')
 
 module.exports = {
-  testEnvironment: 'jsdom',
-  verbose: true,
+  ...base,
   transform: {
-    // babelrc/configFile disabled so sibling @clappr/core and @clappr/zepto
-    // source (ESM) is compiled to CJS when resolved via moduleNameMapper outside
-    // rootDir. Presets come from babel.base.json env.test; modules is forced to
-    // commonjs because babel-jest's caller hint is ignored when babelrc/configFile
-    // are both false.
-    '^.+\\.js$': ['babel-jest', {
-      babelrc: false,
-      configFile: false,
-      presets: require('../../babel.base.json').env.test.presets.map(
-        ([name, options = {}]) => [name, { ...options, modules: 'commonjs' }]
-      )
-    }],
+    ...base.transform,
     '^.+\\.html$': '<rootDir>/src/__mocks__/htmlMock.js'
   },
   moduleNameMapper: {

--- a/packages/clappr-telemetry/jest.config.js
+++ b/packages/clappr-telemetry/jest.config.js
@@ -1,7 +1,8 @@
+const base = require('../../jest.config.base')
 const path = require('path')
 
 module.exports = {
-  testEnvironment: 'jsdom',
+  ...base,
   testEnvironmentOptions: {},
   transform: {
     '^.+\\.js$': 'babel-jest'

--- a/packages/clappr-zepto/jest.config.js
+++ b/packages/clappr-zepto/jest.config.js
@@ -1,6 +1,7 @@
+const base = require('../../jest.config.base')
+
 module.exports = {
-  testEnvironment: 'jsdom',
-  verbose: true,
+  ...base,
   transform: {
     '^.+\\.js$': 'babel-jest'
   }

--- a/packages/hlsjs-playback/jest.config.js
+++ b/packages/hlsjs-playback/jest.config.js
@@ -1,22 +1,10 @@
+const base = require('../../jest.config.base')
 const ClapprCorePkg = require('@clappr/core/package.json')
 
 module.exports = {
-  // Explicit since jest 27 flipped the default to 'node'; these suites need DOM.
-  testEnvironment: 'jsdom',
-  verbose: true,
+  ...base,
   transform: {
-    // babelrc/configFile disabled so sibling @clappr/core and @clappr/zepto
-    // source (ESM) is compiled to CJS when resolved via moduleNameMapper outside
-    // rootDir. Presets come from babel.base.json env.test; modules is forced to
-    // commonjs because babel-jest's caller hint is ignored when babelrc/configFile
-    // are both false.
-    '^.+\\.js$': ['babel-jest', {
-      babelrc: false,
-      configFile: false,
-      presets: require('../../babel.base.json').env.test.presets.map(
-        ([name, options = {}]) => [name, { ...options, modules: 'commonjs' }]
-      )
-    }],
+    ...base.transform,
     '^.+\\.html$': '<rootDir>/../clappr-core/src/__mocks__/htmlMock.js'
   },
   moduleNameMapper: {

--- a/packages/html5-tvs-playback/jest.config.js
+++ b/packages/html5-tvs-playback/jest.config.js
@@ -1,22 +1,10 @@
+const base = require('../../jest.config.base')
 const ClapprCorePkg = require('@clappr/core/package.json')
 
 module.exports = {
-  // Explicit since jest 27 flipped the default to 'node'; these suites need DOM.
-  testEnvironment: 'jsdom',
-  verbose: true,
+  ...base,
   transform: {
-    // babelrc/configFile disabled so sibling @clappr/core and @clappr/zepto
-    // source (ESM) is compiled to CJS when resolved via moduleNameMapper outside
-    // rootDir. Presets come from babel.base.json env.test; modules is forced to
-    // commonjs because babel-jest's caller hint is ignored when babelrc/configFile
-    // are both false.
-    '^.+\\.js$': ['babel-jest', {
-      babelrc: false,
-      configFile: false,
-      presets: require('../../babel.base.json').env.test.presets.map(
-        ([name, options = {}]) => [name, { ...options, modules: 'commonjs' }]
-      )
-    }],
+    ...base.transform,
     '^.+\\.html$': '<rootDir>/../clappr-core/src/__mocks__/htmlMock.js'
   },
   moduleNameMapper: {


### PR DESCRIPTION
## Description

Extracts the Jest settings repeated across package configs into a root `jest.config.base.js`. Packages that resolve sibling ESM source (`@clappr/core`, `@clappr/zepto`) spread the base and keep only their `moduleNameMapper`, `globals`, HTML mock transform, and coverage keys. `clappr-zepto` and `clappr-telemetry` spread the base but override `transform` to plain `babel-jest`.

Closes #2525

## How to test

1. `yarn test` — all six packages with Jest configs should pass (verified locally).
2. Optionally run a single package, e.g. `lerna run test --scope=@clappr/core`, to confirm the shared Babel transform still compiles sibling source correctly.

## Guidelines

- Write the PR title as a short sentence in the present tense describing the outcome (e.g. `Fix mute toggle not restoring volume`) — it feeds the release notes
- Describe any breaking change in the section above
- Read the [Contributing Guidelines](https://github.com/clappr/clappr/blob/main/CONTRIBUTING.md) and make sure `yarn test`, `yarn lint` and `yarn format:check` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized Jest configuration across packages with a shared base setup.
  * Tests now consistently use a browser-like environment, verbose reporting, and Babel-based JavaScript transformation.
  * Preserved package-specific test settings and mappings where needed.

* **Documentation**
  * Updated contributor guidance for shared testing, browser compatibility, and linting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->