### PR TITLE
Stop embedding @clappr/core in hlsjs-playback.min.js

### DIFF
--- a/packages/hlsjs-playback/README.md
+++ b/packages/hlsjs-playback/README.md
@@ -31,7 +31,7 @@ or as an npm package:
 | Bundler / ESM entry (embeds `hls.js`, leaves `@clappr/core` external) | `dist/hlsjs-playback.esm.js` (package `module` field) |
 | Default CommonJS / UMD entry (embeds `hls.js`) | `dist/hlsjs-playback.js` (package `main` field) |
 
-**Migration note (1.10+):** `hlsjs-playback.min.js` no longer embeds `@clappr/core`. Load core (or player) first so a global `Clappr` exists. Use `.external` builds when you supply your own `hls.js`.
+**Migration note (2.0+):** `hlsjs-playback.min.js` no longer embeds `@clappr/core`. Load core (or player) first so a global `Clappr` exists. Use `.external` builds when you supply your own `hls.js`.
 
 Then just add `HlsjsPlayback` into the list of plugins of your player instance:
 

--- a/packages/hlsjs-playback/README.md
+++ b/packages/hlsjs-playback/README.md
@@ -11,7 +11,6 @@ A [Clappr](https://github.com/clappr/clappr) playback to play HTTP Live Streamin
   <a href="https://www.jsdelivr.com/package/npm/@clappr/hlsjs-playback"><img alt="jsDelivr hits (npm)" src="https://img.shields.io/jsdelivr/npm/hm/@clappr/hlsjs-playback?color=orange"></a>
 </p>
 
-
 ## Usage
 
 You can use it from JSDelivr:
@@ -22,14 +21,24 @@ or as an npm package:
 
 `yarn add @clappr/hlsjs-playback`
 
+### Which artifact to load
+
+| Scenario                                                              | Artifact                                                  |
+| --------------------------------------------------------------------- | --------------------------------------------------------- |
+| `<script>` / CDN alongside `@clappr/core` (or `@clappr/player`)       | `dist/hlsjs-playback.min.js`                              |
+| Bundler that should resolve `hls.js` itself                           | `dist/hlsjs-playback.external.js` (or `.external.min.js`) |
+| Bundler / ESM entry (embeds `hls.js`, leaves `@clappr/core` external) | `dist/hlsjs-playback.esm.js` (package `module` field)     |
+| Default CommonJS / UMD entry (embeds `hls.js`)                        | `dist/hlsjs-playback.js` (package `main` field)           |
+
+**Migration note (1.10+):** `hlsjs-playback.min.js` no longer ships a private copy of `@clappr/core`. It is a UMD build that expects a global `Clappr` when loaded via `<script>`, the same contract as the non-minified main artifact. Load `@clappr/core` (or `@clappr/player`) first. `hls.js` remains embedded in the main / min / esm family; use the `.external` builds when you want to supply your own `hls.js`.
+
 Then just add `HlsjsPlayback` into the list of plugins of your player instance:
 
 ```javascript
-var player = new Clappr.Player(
-  {
-    source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
-    plugins: [HlsjsPlayback],
-  });
+var player = new Clappr.Player({
+  source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
+  plugins: [HlsjsPlayback]
+})
 ```
 
 ## Configuration
@@ -37,38 +46,40 @@ var player = new Clappr.Player(
 The options for this playback are shown below:
 
 ```javascript
-var player = new Clappr.Player(
-  {
-    source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
-    plugins: [HlsjsPlayback],
-    hlsUseNextLevel: false,
-    hlsMinimumDvrSize: 60,
-    hlsRecoverAttempts: 16,
-    hlsPlayback: {
-      preload: true,
-      customListeners: [],
-    },
-    playback: {
-      extrapolatedWindowNumSegments: 2,
-      triggerFatalErrorOnResourceDenied: false,
-      hlsjsConfig: {
-        // hls.js specific options
-      },
-    },
-  });
+var player = new Clappr.Player({
+  source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
+  plugins: [HlsjsPlayback],
+  hlsUseNextLevel: false,
+  hlsMinimumDvrSize: 60,
+  hlsRecoverAttempts: 16,
+  hlsPlayback: {
+    preload: true,
+    customListeners: []
+  },
+  playback: {
+    extrapolatedWindowNumSegments: 2,
+    triggerFatalErrorOnResourceDenied: false,
+    hlsjsConfig: {
+      // hls.js specific options
+    }
+  }
+})
 ```
 
 #### hlsUseNextLevel
+
 > Default value: `false`
 
 The default behavior for the HLS playback is to use [hls.currentLevel](https://github.com/video-dev/hls.js/blob/master/docs/API.md#hlscurrentlevel) to switch current level. To change this behaviour and force HLS playback to use [hls.nextLevel](https://github.com/video-dev/hls.js/blob/master/docs/API.md#hlsnextlevel), add `hlsUseNextLevel: true` to embed parameters.
 
 #### hlsMinimumDvrSize
+
 > Default value: `60 (seconds)`
 
 Option to define the minimum DVR size to active seek on Clappr live mode.
 
 #### extrapolatedWindowNumSegments
+
 > Default value: `2`
 
 Configure the size of the start time extrapolation window measured as a multiple of segments.
@@ -78,17 +89,20 @@ Should be 2 or higher, or 0 to disable. It should only need to be increased abov
 E.g.: If the playlist is cached for 10 seconds and new chunks are added/removed every 5.
 
 #### hlsRecoverAttempts
+
 > Default value: `16`
 
 The `hls.js` have recover approaches for some fatal errors. This option sets the max recovery attempts number for those errors.
 
 #### triggerFatalErrorOnResourceDenied
+
 > Default value: `false`
 
 If this option is set to true, the playback will triggers fatal error event if decrypt key http response code is greater than or equal to 400. This option is used to attempt to reproduce iOS devices behaviour which internally use html5 video playback.
 
 #### hlsPlayback
->  Soon (in a new breaking change version), all options related to this playback that are declared in the scope of the `options` object will have to be declared necessarily within this new scope!
+
+> Soon (in a new breaking change version), all options related to this playback that are declared in the scope of the `options` object will have to be declared necessarily within this new scope!
 
 Groups all options related directly to `HlsjsPlayback` configs.
 
@@ -104,6 +118,7 @@ var player = new Clappr.Player(
 ```
 
 #### `hlsPlayback.preload`
+
 > Default value: `true`
 
 Configures whether the source should be loaded as soon as the `HLS.JS` internal reference is setup or only after the first play.
@@ -128,9 +143,9 @@ var player = new Clappr.Player(
 
 The listener object parameters are:
 
-* `eventName`: A valid event name of `hls.js` [events API](https://github.com/video-dev/hls.js/blob/master/docs/API.md#runtime-events);
-* `callback`: The callback that should be called  when the event listened happen.
-* `once`: Flag to configure if the listener needs to be valid just for one time.
+- `eventName`: A valid event name of `hls.js` [events API](https://github.com/video-dev/hls.js/blob/master/docs/API.md#runtime-events);
+- `callback`: The callback that should be called when the event listened happen.
+- `once`: Flag to configure if the listener needs to be valid just for one time.
 
 #### hlsjsConfig
 

--- a/packages/hlsjs-playback/README.md
+++ b/packages/hlsjs-playback/README.md
@@ -11,6 +11,7 @@ A [Clappr](https://github.com/clappr/clappr) playback to play HTTP Live Streamin
   <a href="https://www.jsdelivr.com/package/npm/@clappr/hlsjs-playback"><img alt="jsDelivr hits (npm)" src="https://img.shields.io/jsdelivr/npm/hm/@clappr/hlsjs-playback?color=orange"></a>
 </p>
 
+
 ## Usage
 
 You can use it from JSDelivr:
@@ -23,22 +24,23 @@ or as an npm package:
 
 ### Which artifact to load
 
-| Scenario                                                              | Artifact                                                  |
-| --------------------------------------------------------------------- | --------------------------------------------------------- |
-| `<script>` / CDN alongside `@clappr/core` (or `@clappr/player`)       | `dist/hlsjs-playback.min.js`                              |
-| Bundler that should resolve `hls.js` itself                           | `dist/hlsjs-playback.external.js` (or `.external.min.js`) |
-| Bundler / ESM entry (embeds `hls.js`, leaves `@clappr/core` external) | `dist/hlsjs-playback.esm.js` (package `module` field)     |
-| Default CommonJS / UMD entry (embeds `hls.js`)                        | `dist/hlsjs-playback.js` (package `main` field)           |
+| Scenario | Artifact |
+|---|---|
+| `<script>` / CDN alongside `@clappr/core` (or `@clappr/player`) | `dist/hlsjs-playback.min.js` |
+| Bundler that should resolve `hls.js` itself | `dist/hlsjs-playback.external.js` (or `.external.min.js`) |
+| Bundler / ESM entry (embeds `hls.js`, leaves `@clappr/core` external) | `dist/hlsjs-playback.esm.js` (package `module` field) |
+| Default CommonJS / UMD entry (embeds `hls.js`) | `dist/hlsjs-playback.js` (package `main` field) |
 
-**Migration note (1.10+):** `hlsjs-playback.min.js` no longer ships a private copy of `@clappr/core`. It is a UMD build that expects a global `Clappr` when loaded via `<script>`, the same contract as the non-minified main artifact. Load `@clappr/core` (or `@clappr/player`) first. `hls.js` remains embedded in the main / min / esm family; use the `.external` builds when you want to supply your own `hls.js`.
+**Migration note (1.10+):** `hlsjs-playback.min.js` no longer embeds `@clappr/core`. Load core (or player) first so a global `Clappr` exists. Use `.external` builds when you supply your own `hls.js`.
 
 Then just add `HlsjsPlayback` into the list of plugins of your player instance:
 
 ```javascript
-var player = new Clappr.Player({
-  source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
-  plugins: [HlsjsPlayback]
-})
+var player = new Clappr.Player(
+  {
+    source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
+    plugins: [HlsjsPlayback],
+  });
 ```
 
 ## Configuration
@@ -46,40 +48,38 @@ var player = new Clappr.Player({
 The options for this playback are shown below:
 
 ```javascript
-var player = new Clappr.Player({
-  source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
-  plugins: [HlsjsPlayback],
-  hlsUseNextLevel: false,
-  hlsMinimumDvrSize: 60,
-  hlsRecoverAttempts: 16,
-  hlsPlayback: {
-    preload: true,
-    customListeners: []
-  },
-  playback: {
-    extrapolatedWindowNumSegments: 2,
-    triggerFatalErrorOnResourceDenied: false,
-    hlsjsConfig: {
-      // hls.js specific options
-    }
-  }
-})
+var player = new Clappr.Player(
+  {
+    source: 'https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
+    plugins: [HlsjsPlayback],
+    hlsUseNextLevel: false,
+    hlsMinimumDvrSize: 60,
+    hlsRecoverAttempts: 16,
+    hlsPlayback: {
+      preload: true,
+      customListeners: [],
+    },
+    playback: {
+      extrapolatedWindowNumSegments: 2,
+      triggerFatalErrorOnResourceDenied: false,
+      hlsjsConfig: {
+        // hls.js specific options
+      },
+    },
+  });
 ```
 
 #### hlsUseNextLevel
-
 > Default value: `false`
 
 The default behavior for the HLS playback is to use [hls.currentLevel](https://github.com/video-dev/hls.js/blob/master/docs/API.md#hlscurrentlevel) to switch current level. To change this behaviour and force HLS playback to use [hls.nextLevel](https://github.com/video-dev/hls.js/blob/master/docs/API.md#hlsnextlevel), add `hlsUseNextLevel: true` to embed parameters.
 
 #### hlsMinimumDvrSize
-
 > Default value: `60 (seconds)`
 
 Option to define the minimum DVR size to active seek on Clappr live mode.
 
 #### extrapolatedWindowNumSegments
-
 > Default value: `2`
 
 Configure the size of the start time extrapolation window measured as a multiple of segments.
@@ -89,20 +89,17 @@ Should be 2 or higher, or 0 to disable. It should only need to be increased abov
 E.g.: If the playlist is cached for 10 seconds and new chunks are added/removed every 5.
 
 #### hlsRecoverAttempts
-
 > Default value: `16`
 
 The `hls.js` have recover approaches for some fatal errors. This option sets the max recovery attempts number for those errors.
 
 #### triggerFatalErrorOnResourceDenied
-
 > Default value: `false`
 
 If this option is set to true, the playback will triggers fatal error event if decrypt key http response code is greater than or equal to 400. This option is used to attempt to reproduce iOS devices behaviour which internally use html5 video playback.
 
 #### hlsPlayback
-
-> Soon (in a new breaking change version), all options related to this playback that are declared in the scope of the `options` object will have to be declared necessarily within this new scope!
+>  Soon (in a new breaking change version), all options related to this playback that are declared in the scope of the `options` object will have to be declared necessarily within this new scope!
 
 Groups all options related directly to `HlsjsPlayback` configs.
 
@@ -118,7 +115,6 @@ var player = new Clappr.Player(
 ```
 
 #### `hlsPlayback.preload`
-
 > Default value: `true`
 
 Configures whether the source should be loaded as soon as the `HLS.JS` internal reference is setup or only after the first play.
@@ -143,9 +139,9 @@ var player = new Clappr.Player(
 
 The listener object parameters are:
 
-- `eventName`: A valid event name of `hls.js` [events API](https://github.com/video-dev/hls.js/blob/master/docs/API.md#runtime-events);
-- `callback`: The callback that should be called when the event listened happen.
-- `once`: Flag to configure if the listener needs to be valid just for one time.
+* `eventName`: A valid event name of `hls.js` [events API](https://github.com/video-dev/hls.js/blob/master/docs/API.md#runtime-events);
+* `callback`: The callback that should be called  when the event listened happen.
+* `once`: Flag to configure if the listener needs to be valid just for one time.
 
 #### hlsjsConfig
 

--- a/packages/hlsjs-playback/jest.config.js
+++ b/packages/hlsjs-playback/jest.config.js
@@ -7,6 +7,13 @@ module.exports = {
     ...base.transform,
     '^.+\\.html$': '<rootDir>/../clappr-core/src/__mocks__/htmlMock.js'
   },
+  // The hls.js-embedded UMD builds are too large for babel-jest; they are
+  // already CJS-compatible. ESM stays transformable (.esm.js, not .mjs).
+  transformIgnorePatterns: [
+    '/node_modules/',
+    '<rootDir>/dist/hlsjs-playback\\.js$',
+    '<rootDir>/dist/hlsjs-playback\\.min\\.js$'
+  ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@clappr/core$': '<rootDir>/../clappr-core/src/main.js',
@@ -16,5 +23,6 @@ module.exports = {
   globals: {
     CLAPPR_CORE_VERSION: ClapprCorePkg.version,
     VERSION: ClapprCorePkg.version
-  }
+  },
+  coveragePathIgnorePatterns: ['/dist/', '/node_modules/']
 }

--- a/packages/hlsjs-playback/jest.config.js
+++ b/packages/hlsjs-playback/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     '^.+\\.html$': '<rootDir>/../clappr-core/src/__mocks__/htmlMock.js'
   },
   // The hls.js-embedded UMD builds are too large for babel-jest; they are
-  // already CJS-compatible. ESM stays transformable (.esm.js, not .mjs).
+  // already CJS-compatible.
   transformIgnorePatterns: [
     '/node_modules/',
     '<rootDir>/dist/hlsjs-playback\\.js$',

--- a/packages/hlsjs-playback/package.json
+++ b/packages/hlsjs-playback/package.json
@@ -11,7 +11,7 @@
     "watch": "rollup --config --bundleConfigAsCjs --watch",
     "bundle-check": "ANALYZE_BUNDLE=true rollup --config --bundleConfigAsCjs",
     "release": "MINIMIZE=true rollup --config --bundleConfigAsCjs",
-    "test": "jest ./src --coverage --silent",
+    "test": "jest ./src --testPathIgnorePatterns=dist.smoke --coverage --silent && yarn release && jest ./src/dist.smoke.test.js --silent",
     "test:watch": "jest ./src --watch",
     "lint": "eslint *.js ./src",
     "lint:fix": "yarn lint -- --fix",

--- a/packages/hlsjs-playback/rollup.config.js
+++ b/packages/hlsjs-playback/rollup.config.js
@@ -11,95 +11,87 @@ import visualize from 'rollup-plugin-visualizer'
 import { version as clapprCoreVersion } from '@clappr/core/package.json'
 import pkg from './package.json'
 
-let rollupConfig
-
 const serveLocal = !!process.env.SERVE
 const reloadEnabled = !!process.env.RELOAD
 const analyzeBundle = !!process.env.ANALYZE_BUNDLE
 const minimize = !!process.env.MINIMIZE
 
-const babelOptionsPlugins = { exclude: ['node_modules/**', '../../node_modules/**'], babelHelpers: 'bundled' }
-const servePluginOptions = { contentBase: ['dist', 'public'], host: '0.0.0.0', port: '8080' }
-const livereloadPluginOptions = { watch: ['dist', 'public'] }
-const replacePluginOptions = { CLAPPR_CORE_VERSION: JSON.stringify(clapprCoreVersion), preventAssignment: false }
+const babelOptionsPlugins = {
+  exclude: ['node_modules/**', '../../node_modules/**'],
+  babelHelpers: 'bundled'
+}
+const replacePluginOptions = {
+  CLAPPR_CORE_VERSION: JSON.stringify(clapprCoreVersion),
+  preventAssignment: false
+}
 
-let plugins = [
+const plugins = [
   replace(replacePluginOptions),
   resolve(),
   commonjs(),
   babel(babelOptionsPlugins),
   size(),
-  filesize()
-]
-
-serveLocal && (plugins = [...plugins, replace({ ...replacePluginOptions, 'process.env.NODE_ENV': JSON.stringify('development') }), serve(servePluginOptions)])
-reloadEnabled && (plugins = [...plugins, livereload(livereloadPluginOptions)])
-analyzeBundle && plugins.push(visualize({ open: true }))
+  filesize(),
+  serveLocal &&
+    replace({
+      ...replacePluginOptions,
+      'process.env.NODE_ENV': JSON.stringify('development')
+    }),
+  serveLocal && serve({ contentBase: ['dist', 'public'], host: '0.0.0.0', port: '8080' }),
+  reloadEnabled && livereload({ watch: ['dist', 'public'] }),
+  analyzeBundle && visualize({ open: true })
+].filter(Boolean)
 
 const mainBundle = {
   external: ['@clappr/core'],
   input: 'src/hls.js',
-  output: {
-    name: 'HlsjsPlayback',
-    file: pkg.main,
-    format: 'umd',
-    globals: { '@clappr/core': 'Clappr' }
-  },
+  output: [
+    {
+      name: 'HlsjsPlayback',
+      file: pkg.main,
+      format: 'umd',
+      globals: { '@clappr/core': 'Clappr' },
+      sourcemap: true
+    },
+    minimize && {
+      name: 'HlsjsPlayback',
+      file: 'dist/hlsjs-playback.min.js',
+      format: 'umd',
+      globals: { '@clappr/core': 'Clappr' },
+      sourcemap: true,
+      plugins: [terser()]
+    },
+    {
+      name: 'HlsjsPlayback',
+      file: pkg.module,
+      format: 'esm',
+      sourcemap: true
+    }
+  ].filter(Boolean),
   plugins
 }
 
-const mainBundleWithoutHLS = {
+const externalBundle = {
   external: ['@clappr/core', 'hls.js'],
   input: 'src/hls.js',
-  output: {
-    name: 'HlsjsPlayback',
-    file: 'dist/hlsjs-playback.external.js',
-    format: 'umd',
-    globals: { '@clappr/core': 'Clappr', 'hls.js': 'Hls' }
-  },
+  output: [
+    {
+      name: 'HlsjsPlayback',
+      file: 'dist/hlsjs-playback.external.js',
+      format: 'umd',
+      globals: { '@clappr/core': 'Clappr', 'hls.js': 'Hls' },
+      sourcemap: true
+    },
+    minimize && {
+      name: 'HlsjsPlayback',
+      file: 'dist/hlsjs-playback.external.min.js',
+      format: 'umd',
+      globals: { '@clappr/core': 'Clappr', 'hls.js': 'Hls' },
+      sourcemap: true,
+      plugins: [terser()]
+    }
+  ].filter(Boolean),
   plugins
 }
 
-const mainBundleMinified = {
-  input: 'src/hls.js',
-  output: {
-    name: 'HlsjsPlayback',
-    file: 'dist/hlsjs-playback.min.js',
-    format: 'iife',
-    sourcemap: true,
-    plugins: terser()
-  },
-  plugins
-}
-
-const mainBundleWithoutHLSMinified = {
-  external: ['@clappr/core', 'hls.js'],
-  input: 'src/hls.js',
-  output: {
-    name: 'HlsjsPlayback',
-    file: 'dist/hlsjs-playback.external.min.js',
-    globals: { '@clappr/core': 'Clappr', 'hls.js': 'Hls' },
-    format: 'iife',
-    sourcemap: true,
-    plugins: terser()
-  },
-  plugins
-}
-
-const moduleBundle = {
-  external: ['@clappr/core'],
-  input: 'src/hls.js',
-  output: {
-    name: 'HlsjsPlayback',
-    file: pkg.module,
-    format: 'esm',
-    globals: { '@clappr/core': 'Clappr' }
-  },
-  plugins
-}
-
-rollupConfig = [mainBundle, mainBundleWithoutHLS, moduleBundle]
-serveLocal && (rollupConfig = [mainBundle, mainBundleWithoutHLS])
-minimize && rollupConfig.push(mainBundleMinified, mainBundleWithoutHLSMinified)
-
-export default rollupConfig
+export default [mainBundle, externalBundle]

--- a/packages/hlsjs-playback/rollup.config.js
+++ b/packages/hlsjs-playback/rollup.config.js
@@ -56,8 +56,7 @@ const mainBundle = {
       sourcemap: true,
       plugins: [terser()]
     },
-    // ESM stays on mainBundle (embeds hls.js): player aliases this file via
-    // workspaceDistAlias. dash-shaka puts ESM on externalBundle instead.
+    // ESM embeds hls.js: player aliases dist/hlsjs-playback.esm.js (dash-shaka puts ESM on externalBundle).
     {
       name: 'HlsjsPlayback',
       file: pkg.module,

--- a/packages/hlsjs-playback/rollup.config.js
+++ b/packages/hlsjs-playback/rollup.config.js
@@ -32,11 +32,6 @@ const plugins = [
   babel(babelOptionsPlugins),
   size(),
   filesize(),
-  serveLocal &&
-    replace({
-      ...replacePluginOptions,
-      'process.env.NODE_ENV': JSON.stringify('development')
-    }),
   serveLocal && serve({ contentBase: ['dist', 'public'], host: '0.0.0.0', port: '8080' }),
   reloadEnabled && livereload({ watch: ['dist', 'public'] }),
   analyzeBundle && visualize({ open: true })
@@ -61,6 +56,8 @@ const mainBundle = {
       sourcemap: true,
       plugins: [terser()]
     },
+    // ESM stays on mainBundle (embeds hls.js): player aliases this file via
+    // workspaceDistAlias. dash-shaka puts ESM on externalBundle instead.
     {
       name: 'HlsjsPlayback',
       file: pkg.module,

--- a/packages/hlsjs-playback/src/dist.smoke.test.js
+++ b/packages/hlsjs-playback/src/dist.smoke.test.js
@@ -46,14 +46,12 @@ function assertPlaybackContract(HlsjsPlaybackExport) {
   jest.spyOn(HLSJS, 'isSupported').mockReturnValue(true)
   jest.spyOn(window.HTMLMediaElement.prototype, 'load').mockImplementation(() => {})
 
+  expect(Playback.canPlay('http://example.com/video.m3u8')).toBe(true)
+  expect(Playback.canPlay('http://example.com/video.m3u8?token=1')).toBe(true)
+  expect(Playback.canPlay('http://example.com/video.mpd')).toBe(false)
+
   const playback = new Playback({ src: 'http://example.com/video.m3u8' })
-  try {
-    expect(Playback.canPlay('http://example.com/video.m3u8')).toBe(true)
-    expect(Playback.canPlay('http://example.com/video.m3u8?token=1')).toBe(true)
-    expect(Playback.canPlay('http://example.com/video.mpd')).toBe(false)
-  } finally {
-    playback.destroy()
-  }
+  playback.destroy()
 }
 
 function assertDoesNotEmbedCore(source) {

--- a/packages/hlsjs-playback/src/dist.smoke.test.js
+++ b/packages/hlsjs-playback/src/dist.smoke.test.js
@@ -1,0 +1,122 @@
+/**
+ * Smoke-tests the published dist/ artifacts. Core Jest maps @clappr/core to
+ * source, so without this the Rollup entry points have no CI signal.
+ */
+const fs = require('fs')
+const path = require('path')
+
+const DIST = path.join(__dirname, '..', 'dist')
+
+const ARTIFACTS = {
+  main: 'hlsjs-playback.js',
+  mainMin: 'hlsjs-playback.min.js',
+  external: 'hlsjs-playback.external.js',
+  externalMin: 'hlsjs-playback.external.min.js',
+  esm: 'hlsjs-playback.esm.js'
+}
+
+const EMBEDS_HLS = [ARTIFACTS.main, ARTIFACTS.mainMin, ARTIFACTS.esm]
+const EXTERNAL_HLS = [ARTIFACTS.external, ARTIFACTS.externalMin]
+
+function readArtifact(name) {
+  return fs.readFileSync(path.join(DIST, name), 'utf8')
+}
+
+function loadArtifact(name) {
+  jest.resetModules()
+  return require(path.join(DIST, name))
+}
+
+function assertPlaybackContract(HlsjsPlaybackExport) {
+  // Must re-require after resetModules so the prototype identity matches the
+  // @clappr/core instance the artifact just resolved.
+  const { HTML5Video } = require('@clappr/core')
+  const Playback = HlsjsPlaybackExport.default || HlsjsPlaybackExport
+
+  expect(typeof Playback).toBe('function')
+  expect(Object.getPrototypeOf(Playback.prototype)).toBe(HTML5Video.prototype)
+
+  const HLSJS = Playback.HLSJS
+  expect(HLSJS).toBeTruthy()
+  expect(typeof HLSJS.isSupported).toBe('function')
+  expect(HLSJS.Events).toBeTruthy()
+  expect(typeof HLSJS.version).toBe('string')
+  expect(HLSJS.version.length).toBeGreaterThan(0)
+
+  jest.spyOn(HLSJS, 'isSupported').mockReturnValue(true)
+  jest.spyOn(window.HTMLMediaElement.prototype, 'load').mockImplementation(() => {})
+
+  expect(Playback.canPlay('http://example.com/video.m3u8')).toBe(true)
+  expect(Playback.canPlay('http://example.com/video.m3u8?token=1')).toBe(true)
+  expect(Playback.canPlay('http://example.com/video.mpd')).toBe(false)
+
+  const playback = new Playback({ src: 'http://example.com/video.m3u8' })
+  try {
+    expect(playback).toBeInstanceOf(Playback)
+  } finally {
+    playback.destroy()
+  }
+}
+
+function assertDoesNotEmbedCore(source) {
+  // Same failure mode as the pre-fix hlsjs-playback.min.js shipping a full
+  // Clappr + Zepto copy (#2534).
+  expect(source).not.toMatch(/\bZepto\b/)
+  expect(source).not.toContain('clappr-core')
+  expect(source).not.toContain('@clappr/zepto')
+}
+
+function assertDoesNotEmbedHls(source) {
+  // External UMD builds must keep the hls.js require/AMD dependency.
+  expect(source).toMatch(/['"]hls\.js['"]/)
+  // External builds are ~14–31 KB; 100 KB leaves headroom without matching the
+  // ~500 KB+ hls.js-embedded family.
+  expect(source.length).toBeLessThan(100000)
+}
+
+function assertEmbedsHls(source) {
+  // Positive lock: when the default artifacts stop embedding hls.js (#2538),
+  // this must be updated deliberately — not by a silent layout flip.
+  expect(source).not.toMatch(/require\(['"]hls\.js['"]\)/)
+  expect(source.length).toBeGreaterThan(100000)
+}
+
+function assertSourceMap(filename) {
+  const mapName = `${filename}.map`
+  expect(fs.existsSync(path.join(DIST, mapName))).toBe(true)
+  expect(readArtifact(filename)).toContain(`sourceMappingURL=${mapName}`)
+}
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe.each([
+  ['main UMD', ARTIFACTS.main],
+  ['main UMD minified', ARTIFACTS.mainMin],
+  ['external UMD', ARTIFACTS.external],
+  ['external UMD minified', ARTIFACTS.externalMin],
+  ['ESM', ARTIFACTS.esm]
+])('%s (%s)', (_label, filename) => {
+  test('exports a HlsjsPlayback class that extends HTML5Video and exposes HLSJS', () => {
+    assertPlaybackContract(loadArtifact(filename))
+  })
+
+  test('does not embed @clappr/core or Zepto', () => {
+    assertDoesNotEmbedCore(readArtifact(filename))
+  })
+
+  test('publishes a sourcemap', () => {
+    assertSourceMap(filename)
+  })
+})
+
+describe('hls.js embedding contract', () => {
+  test.each(EXTERNAL_HLS.map(name => [name]))('%s does not embed hls.js', filename => {
+    assertDoesNotEmbedHls(readArtifact(filename))
+  })
+
+  test.each(EMBEDS_HLS.map(name => [name]))('%s embeds hls.js', filename => {
+    assertEmbedsHls(readArtifact(filename))
+  })
+})

--- a/packages/hlsjs-playback/src/dist.smoke.test.js
+++ b/packages/hlsjs-playback/src/dist.smoke.test.js
@@ -46,28 +46,24 @@ function assertPlaybackContract(HlsjsPlaybackExport) {
   jest.spyOn(HLSJS, 'isSupported').mockReturnValue(true)
   jest.spyOn(window.HTMLMediaElement.prototype, 'load').mockImplementation(() => {})
 
-  expect(Playback.canPlay('http://example.com/video.m3u8')).toBe(true)
-  expect(Playback.canPlay('http://example.com/video.m3u8?token=1')).toBe(true)
-  expect(Playback.canPlay('http://example.com/video.mpd')).toBe(false)
-
   const playback = new Playback({ src: 'http://example.com/video.m3u8' })
   try {
-    expect(playback).toBeInstanceOf(Playback)
+    expect(Playback.canPlay('http://example.com/video.m3u8')).toBe(true)
+    expect(Playback.canPlay('http://example.com/video.m3u8?token=1')).toBe(true)
+    expect(Playback.canPlay('http://example.com/video.mpd')).toBe(false)
   } finally {
     playback.destroy()
   }
 }
 
 function assertDoesNotEmbedCore(source) {
-  // Same failure mode as the pre-fix hlsjs-playback.min.js shipping a full
-  // Clappr + Zepto copy (#2534).
+  // Same failure mode as the pre-fix min.js shipping a full Clappr + Zepto copy.
   expect(source).not.toMatch(/\bZepto\b/)
   expect(source).not.toContain('clappr-core')
   expect(source).not.toContain('@clappr/zepto')
 }
 
 function assertDoesNotEmbedHls(source) {
-  // External UMD builds must keep the hls.js require/AMD dependency.
   expect(source).toMatch(/['"]hls\.js['"]/)
   // External builds are ~14–31 KB; 100 KB leaves headroom without matching the
   // ~500 KB+ hls.js-embedded family.
@@ -75,8 +71,7 @@ function assertDoesNotEmbedHls(source) {
 }
 
 function assertEmbedsHls(source) {
-  // Positive lock: when the default artifacts stop embedding hls.js (#2538),
-  // this must be updated deliberately — not by a silent layout flip.
+  // Keep until #2538 inverts the default layout — flip deliberately then.
   expect(source).not.toMatch(/require\(['"]hls\.js['"]\)/)
   expect(source.length).toBeGreaterThan(100000)
 }
@@ -112,11 +107,11 @@ describe.each([
 })
 
 describe('hls.js embedding contract', () => {
-  test.each(EXTERNAL_HLS.map(name => [name]))('%s does not embed hls.js', filename => {
+  test.each(EXTERNAL_HLS)('%s does not embed hls.js', filename => {
     assertDoesNotEmbedHls(readArtifact(filename))
   })
 
-  test.each(EMBEDS_HLS.map(name => [name]))('%s embeds hls.js', filename => {
+  test.each(EMBEDS_HLS)('%s embeds hls.js', filename => {
     assertEmbedsHls(readArtifact(filename))
   })
 })


### PR DESCRIPTION
## Description

Fixes the published `@clappr/hlsjs-playback` minified main artifact embedding a full copy of `@clappr/core` (and Zepto). Root cause: `mainBundleMinified` used `format: 'iife'` with no `external` / `globals`. Both minified outputs are now UMD with matching externals, Rollup configs collapse by externals set (preserving current five-artifact semantics, including ESM still embedding `hls.js` for `@clappr/player`), sourcemaps ship for every output, and a dist smoke test guards the contract going forward.

**Breaking change (2.0.0):** `hlsjs-playback.min.js` is no longer self-contained. Load `@clappr/core` (or `@clappr/player`) first so a global `Clappr` exists. The bundler entries (`main`, `module`) and the `.external` builds are unchanged. `hls.js` remains embedded in the main / min / esm family.

Closes #2534

Follow-ups (not in this PR):
- #2537 — raise unit coverage of `HlsjsPlayback` critical paths
- #2538 — invert the default artifact layout so external becomes the norm (`major`)
- #2541 — adopt a single sourcemap policy across publishable packages
- #2542 — extend published-artifact smoke tests to the remaining packages

## How to test

1. `cd packages/hlsjs-playback && yarn test` — unit tests, then `yarn release`, then dist smoke (20 assertions over the five artifacts)
2. After release: `ls -la dist/` and `grep -c Zepto dist/hlsjs-playback.min.js` → `0`; four UMD files start with the UMD preamble (`typeof exports` / `define.amd`); every artifact has a sibling `.map`
3. Repo-wide: `yarn test && yarn lint && yarn build && yarn build:dist`

## Guidelines

- Write the PR title as a short sentence in the present tense describing the outcome (e.g. `Fix mute toggle not restoring volume`) — it feeds the release notes
- Describe any breaking change in the section above
- Read the [Contributing Guidelines](https://github.com/clappr/clappr/blob/main/CONTRIBUTING.md) and make sure `yarn test`, `yarn lint` and `yarn format:check` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an artifact-selection guide covering CDN, ESM, CommonJS/UMD, and external-bundler builds.
  - Added migration guidance for loading core packages before the non-embedded CDN build.
  - Clarified how to provide `hls.js` through external builds.

- **Bug Fixes**
  - Improved validation of published playback bundles, including dependencies, source maps, and `hls.js` embedding or externalization.
  - Updated release checks across supported distribution formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->