### PR TITLE
Accept shaka-player v3 and v4 as peers for dash-shaka-playback

### DIFF
--- a/packages/dash-shaka-playback/README.md
+++ b/packages/dash-shaka-playback/README.md
@@ -22,18 +22,21 @@ A [clappr](https://github.com/clappr/clappr) playback to play dash based on the 
 # Installation
 
 ```bash
-yarn add dash-shaka-playback shaka-player@^3
+yarn add dash-shaka-playback shaka-player@^4
+# or shaka-player@^3 if you need to stay on Shaka 3
 # or
-npm install dash-shaka-playback shaka-player@^3
+npm install dash-shaka-playback shaka-player@^4
 ```
 
-## Breaking change (4.0.0)
+## Peer dependency
 
-`shaka-player` (`^3`) is a **required peer dependency**. npm 7+ / yarn will install it for every consumer of this package — including those who only load the UMD build that already embeds Shaka (`dash-shaka-playback.js` / `.min.js`).
+`shaka-player` (`^3 || ^4`) is a **required peer dependency**. npm 7+ / yarn will install it for every consumer of this package — including those who only load the UMD build that already embeds Shaka (`dash-shaka-playback.js` / `.min.js`).
 
 That is intentional: the package `exports` map routes `import` to the ESM entry (`dash-shaka-playback.esm.mjs`), which keeps `shaka-player` external. A single peer declaration covers bundler and ESM consumers without maintaining a separate optional peer path. CDN / `<script>` users who never install from npm are unaffected.
 
-The `.external` / `.esm` builds expect the peer to be provided by the page or bundler. The default UMD build still embeds Shaka for drop-in script tags.
+The `.external` / `.esm` builds expect the peer (Shaka 3 or 4) to be provided by the page or bundler. The default UMD build still embeds Shaka 3 for drop-in script tags.
+
+Shaka 5+ is not supported yet: APIs this playback still uses (`new shaka.Player(mediaElement)`, `setTextTrackVisibility`) were removed in v5.
 
 ```javascript
 import Clappr from '@clappr/core'

--- a/packages/dash-shaka-playback/README.md
+++ b/packages/dash-shaka-playback/README.md
@@ -23,9 +23,9 @@ A [clappr](https://github.com/clappr/clappr) playback to play dash based on the 
 
 ```bash
 yarn add dash-shaka-playback shaka-player@^4
-# or shaka-player@^3 if you need to stay on Shaka 3
 # or
 npm install dash-shaka-playback shaka-player@^4
+# Shaka 3 also works: shaka-player@^3
 ```
 
 ## Peer dependency
@@ -34,9 +34,7 @@ npm install dash-shaka-playback shaka-player@^4
 
 That is intentional: the package `exports` map routes `import` to the ESM entry (`dash-shaka-playback.esm.mjs`), which keeps `shaka-player` external. A single peer declaration covers bundler and ESM consumers without maintaining a separate optional peer path. CDN / `<script>` users who never install from npm are unaffected.
 
-The `.external` / `.esm` builds expect the peer (Shaka 3 or 4) to be provided by the page or bundler. The default UMD build still embeds Shaka 3 for drop-in script tags.
-
-Shaka 5+ is not supported yet: APIs this playback still uses (`new shaka.Player(mediaElement)`, `setTextTrackVisibility`) were removed in v5.
+The `.external` / `.esm` builds expect the peer (Shaka 3 or 4) to be provided by the page or bundler. The default UMD build still embeds Shaka 3 for drop-in script tags. Shaka 5+ is not supported.
 
 ```javascript
 import Clappr from '@clappr/core'

--- a/packages/dash-shaka-playback/package.json
+++ b/packages/dash-shaka-playback/package.json
@@ -43,7 +43,7 @@
   "license": "BSD-3-Clause",
   "peerDependencies": {
     "@clappr/core": "*",
-    "shaka-player": "^3"
+    "shaka-player": "^3 || ^4"
   },
   "devDependencies": {
     "@clappr/core": "^0.14.8",

--- a/packages/dash-shaka-playback/public/index.external.html
+++ b/packages/dash-shaka-playback/public/index.external.html
@@ -40,7 +40,6 @@
         }
     </script>
     <script src="https://cdn.jsdelivr.net/npm/@clappr/player@latest/dist/clappr.min.js"></script>
-    <!-- Peer accepts shaka-player ^3 || ^4; swap @4 for @3 to exercise Shaka 3 -->
     <script src="https://cdn.jsdelivr.net/npm/shaka-player@4/dist/shaka-player.compiled.js"></script>
     <script type="text/javascript" charset="utf-8" src="dash-shaka-playback.external.js"> </script>
 </body>

--- a/packages/dash-shaka-playback/public/index.external.html
+++ b/packages/dash-shaka-playback/public/index.external.html
@@ -40,7 +40,8 @@
         }
     </script>
     <script src="https://cdn.jsdelivr.net/npm/@clappr/player@latest/dist/clappr.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/shaka-player@3/dist/shaka-player.compiled.js"></script>
+    <!-- Peer accepts shaka-player ^3 || ^4; swap @4 for @3 to exercise Shaka 3 -->
+    <script src="https://cdn.jsdelivr.net/npm/shaka-player@4/dist/shaka-player.compiled.js"></script>
     <script type="text/javascript" charset="utf-8" src="dash-shaka-playback.external.js"> </script>
 </body>
 </html>


### PR DESCRIPTION
## Description

Widens the `dash-shaka-playback` peer dependency on `shaka-player` from `^3` to `^3 || ^4`, so consumers can bring either major for the ESM / `.external` builds.

The default UMD artifacts still embed Shaka 3 (devDependency unchanged). Shaka 5+ stays unsupported for now because this playback still relies on `new shaka.Player(mediaElement)` and `setTextTrackVisibility`, which were removed in v5.

Docs and the external demo page were updated to reflect the dual-major peer.

Closes #

## How to test

1. `cd packages/dash-shaka-playback && yarn test` — unit + release + dist smoke against the repo’s Shaka 3.x
2. Optional peer check: install `shaka-player@4.16.x` in place of the workspace copy and re-run `yarn jest ./src/clappr-dash-shaka-playback.test.js` (already verified green on 4.16.43)
3. Manual: `yarn start` in the package, open `public/index.external.html` (loads Shaka 4 from jsDelivr) and confirm DASH playback / tracks still work; swap the script to `@3` if you want to re-check Shaka 3

## Guidelines

- Write the PR title as a short sentence in the present tense describing the outcome (e.g. `Fix mute toggle not restoring volume`) — it feeds the release notes
- Describe any breaking change in the section above
- Read the [Contributing Guidelines](https://github.com/clappr/clappr/blob/main/CONTRIBUTING.md) and make sure `yarn test`, `yarn lint` and `yarn format:check` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Shaka Player versions 3 and 4.
  - Updated the external playback demo to use Shaka Player 4 by default.

- **Documentation**
  - Clarified installation requirements, including peer dependency setup and external-build guidance.
  - Documented UMD embedding behavior and noted that Shaka Player 5 and later are not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->