### PR TITLE
Raise HlsjsPlayback critical-path unit coverage

### DIFF
--- a/packages/hlsjs-playback/jest.config.js
+++ b/packages/hlsjs-playback/jest.config.js
@@ -24,5 +24,14 @@ module.exports = {
     CLAPPR_CORE_VERSION: ClapprCorePkg.version,
     VERSION: ClapprCorePkg.version
   },
-  coveragePathIgnorePatterns: ['/dist/', '/node_modules/']
+  collectCoverageFrom: ['src/hls.js'],
+  coveragePathIgnorePatterns: ['/dist/', '/node_modules/'],
+  coverageThreshold: {
+    global: {
+      statements: 79,
+      branches: 75,
+      functions: 63,
+      lines: 81
+    }
+  }
 }

--- a/packages/hlsjs-playback/jest.config.js
+++ b/packages/hlsjs-playback/jest.config.js
@@ -29,7 +29,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 79,
-      branches: 75,
+      branches: 74,
       functions: 63,
       lines: 81
     }

--- a/packages/hlsjs-playback/src/hls.js
+++ b/packages/hlsjs-playback/src/hls.js
@@ -372,8 +372,7 @@ export default class HlsjsPlayback extends HTML5Video {
   }
 
   seekPercentage(percentage) {
-    const seekTo = percentage > 0 ? this._duration * (percentage / 100) : this._duration
-    this.seek(seekTo)
+    this.seek(this._duration * (percentage / 100))
   }
 
   seek(time) {

--- a/packages/hlsjs-playback/src/hls.js
+++ b/packages/hlsjs-playback/src/hls.js
@@ -213,7 +213,7 @@ export default class HlsjsPlayback extends HTML5Video {
     this._segmentTargetDuration = null
     // #EXT-X-PLAYLIST-TYPE
     this._playlistType = null
-    this._recoverAttemptsRemaining = this.options.hlsRecoverAttempts || DEFAULT_RECOVER_ATTEMPTS
+    this._recoverAttemptsRemaining = this.options.hlsRecoverAttempts ?? DEFAULT_RECOVER_ATTEMPTS
   }
 
   _setup() {

--- a/packages/hlsjs-playback/src/hls.test.js
+++ b/packages/hlsjs-playback/src/hls.test.js
@@ -540,6 +540,7 @@ describe('HlsjsPlayback', () => {
     test('extrapolated window duration is zero when segment target duration is null', () => {
       const playback = createPlayback()
       playback._playbackType = Playback.LIVE
+      playback._playlistType = null
       playback._playableRegionStartTime = 0
       playback._playableRegionDuration = 100
       playback._segmentTargetDuration = null
@@ -558,7 +559,6 @@ describe('HlsjsPlayback', () => {
       playback._onLevelUpdated('levelUpdated', makeLevelData({ fragments: [] }))
 
       expect(playback._playableRegionStartTime).toBe(15)
-      expect(playback._segmentTargetDuration).toBe(6)
     })
 
     test('first update sets program date time, duration, and correlations', () => {
@@ -816,14 +816,15 @@ describe('HlsjsPlayback', () => {
       expect(playback.el.currentTime).toBe(60)
     })
 
-    test('seekPercentage of zero seeks to full duration', () => {
+    test('seekPercentage of zero seeks to the start', () => {
       const playback = createPlayback()
       playback._playbackType = Playback.VOD
-      playback._playableRegionStartTime = 0
+      playback._playableRegionStartTime = 10
       playback._playableRegionDuration = 90
+      playback.el.currentTime = 50
 
       playback.seekPercentage(0)
-      expect(playback.el.currentTime).toBe(90)
+      expect(playback.el.currentTime).toBe(10)
     })
 
     test('seekToLivePoint seeks to duration', () => {
@@ -923,8 +924,15 @@ describe('HlsjsPlayback', () => {
   })
 
   describe('_onHLSJSError', () => {
+    const cores = []
+
+    afterEach(() => {
+      cores.splice(0).forEach(core => core.destroy())
+    })
+
     const createErrorPlayback = (options = {}) => {
       const core = new Core({})
+      cores.push(core)
       const playback = createPlayback(options, core.playerError)
       stubHls(playback)
       jest.spyOn(playback, 'play').mockImplementation(() => {})

--- a/packages/hlsjs-playback/src/hls.test.js
+++ b/packages/hlsjs-playback/src/hls.test.js
@@ -1,32 +1,80 @@
-import { Core, Events } from '@clappr/core'
+import { Core, Events, Log, Playback } from '@clappr/core'
 import HlsjsPlayback from './hls.js'
 import HLSJS from 'hls.js'
 
-const simplePlaybackMock = new HlsjsPlayback({ src: 'http://clappr.io/video.m3u8' })
+const DEFAULT_SRC = 'http://clappr.io/video.m3u8'
+
+const createPlayback = (options = {}, playerError) =>
+  new HlsjsPlayback({ src: DEFAULT_SRC, mute: true, ...options }, null, playerError)
+
+const makeLevelData = ({
+  targetduration = 6,
+  type = null,
+  totalduration = 120,
+  fragmentStart = 0,
+  rawProgramDateTime = 1556663040000,
+  fragments
+} = {}) => ({
+  details: {
+    targetduration,
+    type,
+    totalduration,
+    fragments: fragments ?? [{ start: fragmentStart, rawProgramDateTime }]
+  }
+})
+
+const stubHls = playback => {
+  playback._hls = {
+    startLoad: jest.fn(),
+    recoverMediaError: jest.fn(),
+    swapAudioCodec: jest.fn(),
+    destroy: jest.fn()
+  }
+  return playback._hls
+}
+
+const freezeNow = (playback, initialMs = 1000000) => {
+  let current = initialMs
+  jest.spyOn(playback, '_now', 'get').mockImplementation(() => current)
+  return {
+    advance(ms) {
+      current += ms
+    }
+  }
+}
 
 describe('HlsjsPlayback', () => {
+  beforeEach(() => {
+    jest.spyOn(window.HTMLMediaElement.prototype, 'play').mockImplementation(() => {})
+    jest.spyOn(window.HTMLMediaElement.prototype, 'load').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   test('have a getter called defaultOptions', () => {
+    const playback = createPlayback()
     expect(
-      Object.getOwnPropertyDescriptor(Object.getPrototypeOf(simplePlaybackMock), 'defaultOptions')
-        .get
+      Object.getOwnPropertyDescriptor(Object.getPrototypeOf(playback), 'defaultOptions').get
     ).toBeTruthy()
   })
 
   test('defaultOptions getter returns all the default options values into one object', () => {
-    expect(simplePlaybackMock.defaultOptions).toEqual({ preload: true })
+    const playback = createPlayback()
+    expect(playback.defaultOptions).toEqual({ preload: true })
   })
 
   test('have a getter called customListeners', () => {
+    const playback = createPlayback()
     expect(
-      Object.getOwnPropertyDescriptor(Object.getPrototypeOf(simplePlaybackMock), 'customListeners')
-        .get
+      Object.getOwnPropertyDescriptor(Object.getPrototypeOf(playback), 'customListeners').get
     ).toBeTruthy()
   })
 
   test('customListeners getter returns all configured custom listeners for each hls.js event', () => {
     const cb = () => {}
-    const playback = new HlsjsPlayback({
-      src: 'http://clappr.io/foo.m3u8',
+    const playback = createPlayback({
       hlsPlayback: {
         customListeners: [{ eventName: 'hlsMediaAttaching', callback: cb }]
       }
@@ -80,7 +128,6 @@ describe('HlsjsPlayback', () => {
   })
 
   test('should trigger a playback error if source load failed', () => {
-    jest.spyOn(window.HTMLMediaElement.prototype, 'play').mockImplementation(() => {})
     let resolveFn
     const promise = new Promise(resolve => {
       resolveFn = resolve
@@ -113,8 +160,7 @@ describe('HlsjsPlayback', () => {
   })
 
   test('levels supports specifying the level', () => {
-    const options = { src: 'http://clappr.io/foo.m3u8' }
-    const playback = new HlsjsPlayback(options)
+    const playback = createPlayback({ src: 'http://clappr.io/foo.m3u8' })
     playback._setup()
     // NOTE: rather than trying to call playback.setupHls, we'll punch a new one in place
     playback._hls = { levels: [] }
@@ -406,6 +452,720 @@ describe('HlsjsPlayback', () => {
       const playback = new HlsjsPlayback({ src: 'http://clappr.io/foo.m3u8' })
       playback._setup()
       expect(playback.currentTimestamp).toBe(null)
+    })
+  })
+
+  describe('DVR time model', () => {
+    test('without correlation duration equals playable region duration', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      playback._playlistType = null
+      playback._playableRegionStartTime = 10
+      playback._playableRegionDuration = 100
+      playback._segmentTargetDuration = 6
+
+      expect(playback.getStartTimeOffset()).toBe(10)
+      expect(playback.getDuration()).toBe(100)
+    })
+
+    test('extrapolated start advances with wall clock and caps at window end', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      playback._playlistType = null
+      playback._playableRegionStartTime = 0
+      playback._playableRegionDuration = 120
+      playback._segmentTargetDuration = 6
+      playback._extrapolatedWindowNumSegments = 2
+      playback._localStartTimeCorrelation = { local: 1000000, remote: 0 }
+      playback._localEndTimeCorrelation = { local: 1000000, remote: 120000 }
+
+      const clock = freezeNow(playback, 1000000)
+      expect(playback.getStartTimeOffset()).toBe(0)
+
+      clock.advance(5000)
+      expect(playback.getStartTimeOffset()).toBe(5)
+
+      clock.advance(20000)
+      expect(playback.getStartTimeOffset()).toBe(12)
+    })
+
+    test('extrapolated end advances and is clamped to actual end', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      playback._playlistType = null
+      playback._playableRegionStartTime = 0
+      playback._playableRegionDuration = 100
+      playback._segmentTargetDuration = 6
+      playback._extrapolatedWindowNumSegments = 2
+      playback._localStartTimeCorrelation = null
+      playback._localEndTimeCorrelation = { local: 1000000, remote: 88000 }
+
+      const clock = freezeNow(playback, 1000000)
+      expect(playback.getDuration()).toBe(88)
+
+      clock.advance(5000)
+      expect(playback.getDuration()).toBe(93)
+
+      clock.advance(20000)
+      expect(playback.getDuration()).toBe(100)
+    })
+
+    test('EVENT playlist uses raw playable start instead of extrapolated start', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      playback._playlistType = 'EVENT'
+      playback._playableRegionStartTime = 40
+      playback._playableRegionDuration = 80
+      playback._segmentTargetDuration = 6
+      playback._localStartTimeCorrelation = { local: 1000000, remote: 0 }
+      freezeNow(playback, 1010000)
+
+      expect(playback.getStartTimeOffset()).toBe(40)
+      expect(playback.getDuration()).toBe(80)
+    })
+
+    test('VOD uses raw playable start instead of extrapolated start', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.VOD
+      playback._playableRegionStartTime = 5
+      playback._playableRegionDuration = 60
+      playback._segmentTargetDuration = 6
+      playback._localStartTimeCorrelation = { local: 1000000, remote: 0 }
+      freezeNow(playback, 1010000)
+
+      expect(playback.getStartTimeOffset()).toBe(5)
+      expect(playback.getDuration()).toBe(60)
+    })
+
+    test('extrapolated window duration is zero when segment target duration is null', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      playback._playableRegionStartTime = 0
+      playback._playableRegionDuration = 100
+      playback._segmentTargetDuration = null
+      playback._localStartTimeCorrelation = { local: 1000000, remote: 0 }
+      const clock = freezeNow(playback, 1000000)
+
+      clock.advance(5000)
+      expect(playback.getStartTimeOffset()).toBe(0)
+    })
+  })
+
+  describe('_onLevelUpdated', () => {
+    test('returns early when fragments are empty without mutating start time', () => {
+      const playback = createPlayback()
+      playback._playableRegionStartTime = 15
+      playback._onLevelUpdated('levelUpdated', makeLevelData({ fragments: [] }))
+
+      expect(playback._playableRegionStartTime).toBe(15)
+      expect(playback._segmentTargetDuration).toBe(6)
+    })
+
+    test('first update sets program date time, duration, and correlations', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      freezeNow(playback, 2000000)
+
+      playback._onLevelUpdated(
+        'levelUpdated',
+        makeLevelData({
+          targetduration: 6,
+          totalduration: 120,
+          fragmentStart: 10,
+          rawProgramDateTime: 1556663040000
+        })
+      )
+
+      expect(playback.getProgramDateTime()).toBe(1556663040000)
+      expect(playback._playableRegionDuration).toBe(102)
+      expect(playback._durationExcludesAfterLiveSyncPoint).toBe(true)
+      expect(playback._playableRegionStartTime).toBe(10)
+      expect(playback._localStartTimeCorrelation).toEqual({
+        local: 2000000,
+        remote: (10 + 6) * 1000
+      })
+      expect(playback._localEndTimeCorrelation).toEqual({
+        local: 2000000,
+        remote: 112000
+      })
+    })
+
+    test('does not trim duration when live sync hidden area exceeds total duration', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      freezeNow(playback)
+
+      playback._onLevelUpdated(
+        'levelUpdated',
+        makeLevelData({ targetduration: 10, totalduration: 20, fragmentStart: 0 })
+      )
+
+      expect(playback._playableRegionDuration).toBe(20)
+      expect(playback._durationExcludesAfterLiveSyncPoint).toBe(false)
+    })
+
+    test('VOD update does not apply live sync trim', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.VOD
+      freezeNow(playback)
+
+      playback._onLevelUpdated(
+        'levelUpdated',
+        makeLevelData({ targetduration: 6, totalduration: 120, fragmentStart: 0 })
+      )
+
+      expect(playback._playableRegionDuration).toBe(120)
+      expect(playback._durationExcludesAfterLiveSyncPoint).toBe(false)
+    })
+
+    test('resets start correlation when extrapolated start falls before first chunk', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      playback._segmentTargetDuration = 6
+      playback._playableRegionStartTime = 0
+      playback._playableRegionDuration = 102
+      playback._localStartTimeCorrelation = { local: 1000000, remote: 0 }
+      playback._localEndTimeCorrelation = { local: 1000000, remote: 102000 }
+      freezeNow(playback, 1000000)
+
+      playback._onLevelUpdated(
+        'levelUpdated',
+        makeLevelData({
+          targetduration: 6,
+          totalduration: 120,
+          fragmentStart: 30,
+          rawProgramDateTime: null
+        })
+      )
+
+      expect(playback._localStartTimeCorrelation.remote).toBe(30000)
+    })
+
+    test('resets start correlation when extrapolated start was past the old window cap', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      playback._segmentTargetDuration = 6
+      playback._extrapolatedWindowNumSegments = 2
+      playback._playableRegionStartTime = 0
+      playback._playableRegionDuration = 102
+      playback._localStartTimeCorrelation = { local: 1000000, remote: 0 }
+      playback._localEndTimeCorrelation = { local: 1000000, remote: 102000 }
+      freezeNow(playback, 1020000)
+
+      playback._onLevelUpdated(
+        'levelUpdated',
+        makeLevelData({
+          targetduration: 6,
+          totalduration: 120,
+          fragmentStart: 5,
+          rawProgramDateTime: null
+        })
+      )
+
+      expect(playback._localStartTimeCorrelation.remote).toBe(12000)
+    })
+
+    test('resets end correlation when extrapolated end exceeds new end time', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      playback._segmentTargetDuration = 6
+      playback._playableRegionStartTime = 0
+      playback._playableRegionDuration = 200
+      playback._localStartTimeCorrelation = { local: 1000000, remote: 0 }
+      playback._localEndTimeCorrelation = { local: 1000000, remote: 200000 }
+      freezeNow(playback, 1000000)
+
+      playback._onLevelUpdated(
+        'levelUpdated',
+        makeLevelData({
+          targetduration: 6,
+          totalduration: 60,
+          fragmentStart: 0,
+          rawProgramDateTime: null
+        })
+      )
+
+      expect(playback._localEndTimeCorrelation.remote).toBe(42000)
+    })
+
+    test('resets end correlation when extrapolated end was capped past the previous end', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      playback._segmentTargetDuration = 6
+      playback._extrapolatedWindowNumSegments = 2
+      playback._playableRegionStartTime = 0
+      playback._playableRegionDuration = 100
+      playback._localStartTimeCorrelation = { local: 1000000, remote: 0 }
+      playback._localEndTimeCorrelation = { local: 1000000, remote: 100000 }
+      freezeNow(playback, 1005000)
+
+      playback._onLevelUpdated(
+        'levelUpdated',
+        makeLevelData({
+          targetduration: 6,
+          totalduration: 128,
+          fragmentStart: 0,
+          rawProgramDateTime: null
+        })
+      )
+
+      expect(playback._localEndTimeCorrelation.remote).toBe(100000)
+    })
+
+    test('resets end correlation when extrapolated end falls behind the window from the end', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      playback._segmentTargetDuration = 6
+      playback._extrapolatedWindowNumSegments = 2
+      playback._playableRegionStartTime = 0
+      playback._playableRegionDuration = 100
+      playback._localStartTimeCorrelation = { local: 1000000, remote: 0 }
+      playback._localEndTimeCorrelation = { local: 1000000, remote: 100000 }
+      freezeNow(playback, 1000000)
+
+      playback._onLevelUpdated(
+        'levelUpdated',
+        makeLevelData({
+          targetduration: 6,
+          totalduration: 200,
+          fragmentStart: 0,
+          rawProgramDateTime: null
+        })
+      )
+
+      expect(playback._localEndTimeCorrelation.remote).toBe((182 - 12) * 1000)
+    })
+
+    test('calls duration and progress handlers when start and duration change', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      freezeNow(playback)
+      jest.spyOn(playback, '_onDurationChange').mockImplementation(() => {})
+      jest.spyOn(playback, '_onProgress').mockImplementation(() => {})
+
+      playback._onLevelUpdated(
+        'levelUpdated',
+        makeLevelData({ targetduration: 6, totalduration: 120, fragmentStart: 10 })
+      )
+
+      expect(playback._onDurationChange).toHaveBeenCalled()
+      expect(playback._onProgress).toHaveBeenCalled()
+    })
+
+    test('respects custom liveSyncDurationCount from hlsjsConfig', () => {
+      const playback = createPlayback({
+        playback: { hlsjsConfig: { liveSyncDurationCount: 2 } }
+      })
+      playback._playbackType = Playback.LIVE
+      freezeNow(playback)
+
+      playback._onLevelUpdated(
+        'levelUpdated',
+        makeLevelData({ targetduration: 10, totalduration: 100, fragmentStart: 0 })
+      )
+
+      expect(playback._playableRegionDuration).toBe(80)
+      expect(playback._durationExcludesAfterLiveSyncPoint).toBe(true)
+    })
+  })
+
+  describe('time API', () => {
+    test('getCurrentTime offsets by start time and never goes below zero', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.VOD
+      playback._playableRegionStartTime = 20
+      playback._playableRegionDuration = 100
+      playback.el.currentTime = 45
+
+      expect(playback.getCurrentTime()).toBe(25)
+
+      playback.el.currentTime = 10
+      expect(playback.getCurrentTime()).toBe(0)
+    })
+
+    test('seek writes element currentTime including start offset', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.VOD
+      playback._playableRegionStartTime = 20
+      playback._playableRegionDuration = 100
+
+      playback.seek(30)
+      expect(playback.el.currentTime).toBe(50)
+    })
+
+    test('seek of negative time warns and seeks to duration', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.VOD
+      playback._playableRegionStartTime = 0
+      playback._playableRegionDuration = 80
+      jest.spyOn(Log, 'warn').mockImplementation(() => {})
+
+      playback.seek(-1)
+
+      expect(Log.warn).toHaveBeenCalled()
+      expect(playback.el.currentTime).toBe(80)
+    })
+
+    test('seekPercentage maps percent of duration then seeks', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.VOD
+      playback._playableRegionStartTime = 10
+      playback._playableRegionDuration = 100
+
+      playback.seekPercentage(50)
+      expect(playback.el.currentTime).toBe(60)
+    })
+
+    test('seekPercentage of zero seeks to full duration', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.VOD
+      playback._playableRegionStartTime = 0
+      playback._playableRegionDuration = 90
+
+      playback.seekPercentage(0)
+      expect(playback.el.currentTime).toBe(90)
+    })
+
+    test('seekToLivePoint seeks to duration', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.LIVE
+      playback._playlistType = 'EVENT'
+      playback._playableRegionStartTime = 5
+      playback._playableRegionDuration = 70
+
+      playback.seekToLivePoint()
+      expect(playback.el.currentTime).toBe(75)
+    })
+  })
+
+  describe('_onTimeUpdate throttling', () => {
+    test('first time update fires PLAYBACK_TIMEUPDATE', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.VOD
+      playback._playableRegionDuration = 100
+      playback.el.currentTime = 1
+      freezeNow(playback, 1000000)
+      const onTimeUpdate = jest.fn()
+      playback.on(Events.PLAYBACK_TIMEUPDATE, onTimeUpdate)
+
+      playback._onTimeUpdate()
+
+      expect(onTimeUpdate).toHaveBeenCalledTimes(1)
+      expect(onTimeUpdate.mock.calls[0][0]).toMatchObject({ current: 1, total: 100 })
+    })
+
+    test('identical payload within throttle delay is suppressed', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.VOD
+      playback._playableRegionDuration = 100
+      playback.el.currentTime = 1
+      const clock = freezeNow(playback, 1000000)
+      const onTimeUpdate = jest.fn()
+      playback.on(Events.PLAYBACK_TIMEUPDATE, onTimeUpdate)
+
+      playback._onTimeUpdate()
+      clock.advance(50)
+      playback._onTimeUpdate()
+
+      expect(onTimeUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    test('fires again after throttle delay even with same payload', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.VOD
+      playback._playableRegionDuration = 100
+      playback.el.currentTime = 1
+      const clock = freezeNow(playback, 1000000)
+      const onTimeUpdate = jest.fn()
+      playback.on(Events.PLAYBACK_TIMEUPDATE, onTimeUpdate)
+
+      playback._onTimeUpdate()
+      clock.advance(250)
+      playback._onTimeUpdate()
+
+      expect(onTimeUpdate).toHaveBeenCalledTimes(2)
+    })
+
+    test('changed current time fires despite throttle window', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.VOD
+      playback._playableRegionDuration = 100
+      playback.el.currentTime = 1
+      const clock = freezeNow(playback, 1000000)
+      const onTimeUpdate = jest.fn()
+      playback.on(Events.PLAYBACK_TIMEUPDATE, onTimeUpdate)
+
+      playback._onTimeUpdate()
+      clock.advance(50)
+      playback.el.currentTime = 2
+      playback._onTimeUpdate()
+
+      expect(onTimeUpdate).toHaveBeenCalledTimes(2)
+    })
+
+    test('changed program date time fires despite throttle window', () => {
+      const playback = createPlayback()
+      playback._playbackType = Playback.VOD
+      playback._playableRegionDuration = 100
+      playback._programDateTime = 1000
+      playback.el.currentTime = 1
+      const clock = freezeNow(playback, 1000000)
+      const onTimeUpdate = jest.fn()
+      playback.on(Events.PLAYBACK_TIMEUPDATE, onTimeUpdate)
+
+      playback._onTimeUpdate()
+      clock.advance(50)
+      playback._programDateTime = 2000
+      playback._onTimeUpdate()
+
+      expect(onTimeUpdate).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('_onHLSJSError', () => {
+    const createErrorPlayback = (options = {}) => {
+      const core = new Core({})
+      const playback = createPlayback(options, core.playerError)
+      stubHls(playback)
+      jest.spyOn(playback, 'play').mockImplementation(() => {})
+      jest.spyOn(playback, 'stop').mockImplementation(() => {})
+      return playback
+    }
+
+    test('recoverable network fatal error calls startLoad', () => {
+      const playback = createErrorPlayback()
+      jest.spyOn(Log, 'warn').mockImplementation(() => {})
+
+      playback._onHLSJSError('hlsError', {
+        fatal: true,
+        type: HLSJS.ErrorTypes.NETWORK_ERROR,
+        details: HLSJS.ErrorDetails.FRAG_LOAD_ERROR
+      })
+
+      expect(playback._hls.startLoad).toHaveBeenCalled()
+      expect(playback.stop).not.toHaveBeenCalled()
+      expect(playback._recoverAttemptsRemaining).toBe(15)
+    })
+
+    test.each([
+      HLSJS.ErrorDetails.MANIFEST_LOAD_ERROR,
+      HLSJS.ErrorDetails.MANIFEST_LOAD_TIMEOUT,
+      HLSJS.ErrorDetails.MANIFEST_PARSING_ERROR,
+      HLSJS.ErrorDetails.LEVEL_LOAD_ERROR,
+      HLSJS.ErrorDetails.LEVEL_LOAD_TIMEOUT
+    ])('unrecoverable network fatal %s triggers error and stop', details => {
+      const playback = createErrorPlayback()
+      jest.spyOn(Log, 'error').mockImplementation(() => {})
+      const onError = jest.fn()
+      playback.on(Events.PLAYBACK_ERROR, onError)
+
+      playback._onHLSJSError('hlsError', {
+        fatal: true,
+        type: HLSJS.ErrorTypes.NETWORK_ERROR,
+        details
+      })
+
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(playback.stop).toHaveBeenCalled()
+      expect(playback._hls.startLoad).not.toHaveBeenCalled()
+    })
+
+    test('media fatal error recovers via recoverMediaError then swapAudioCodec then fails', () => {
+      const playback = createErrorPlayback()
+      jest.spyOn(Log, 'warn').mockImplementation(() => {})
+      jest.spyOn(Log, 'error').mockImplementation(() => {})
+      const onError = jest.fn()
+      playback.on(Events.PLAYBACK_ERROR, onError)
+      const mediaError = {
+        fatal: true,
+        type: HLSJS.ErrorTypes.MEDIA_ERROR,
+        details: HLSJS.ErrorDetails.BUFFER_STALLED_ERROR
+      }
+
+      playback._onHLSJSError('hlsError', mediaError)
+      expect(playback._hls.recoverMediaError).toHaveBeenCalledTimes(1)
+      expect(playback._hls.swapAudioCodec).not.toHaveBeenCalled()
+      expect(playback.play).toHaveBeenCalledTimes(1)
+
+      playback._onHLSJSError('hlsError', mediaError)
+      expect(playback._hls.swapAudioCodec).toHaveBeenCalledTimes(1)
+      expect(playback._hls.recoverMediaError).toHaveBeenCalledTimes(2)
+      expect(playback.play).toHaveBeenCalledTimes(2)
+      expect(onError).not.toHaveBeenCalled()
+
+      playback._onHLSJSError('hlsError', mediaError)
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(playback.stop).toHaveBeenCalled()
+    })
+
+    test('other fatal error types trigger error and stop', () => {
+      const playback = createErrorPlayback()
+      jest.spyOn(Log, 'error').mockImplementation(() => {})
+      const onError = jest.fn()
+      playback.on(Events.PLAYBACK_ERROR, onError)
+
+      playback._onHLSJSError('hlsError', {
+        fatal: true,
+        type: HLSJS.ErrorTypes.OTHER_ERROR,
+        details: 'whatever'
+      })
+
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(playback.stop).toHaveBeenCalled()
+    })
+
+    test('exhausted recover attempts trigger error and stop', () => {
+      const playback = createErrorPlayback({ hlsRecoverAttempts: 0 })
+      jest.spyOn(Log, 'error').mockImplementation(() => {})
+      const onError = jest.fn()
+      playback.on(Events.PLAYBACK_ERROR, onError)
+
+      playback._onHLSJSError('hlsError', {
+        fatal: true,
+        type: HLSJS.ErrorTypes.MEDIA_ERROR,
+        details: HLSJS.ErrorDetails.BUFFER_STALLED_ERROR
+      })
+
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(playback.stop).toHaveBeenCalled()
+      expect(playback._hls.recoverMediaError).not.toHaveBeenCalled()
+    })
+
+    test('non-fatal key denial with option triggers fatal error and stop', () => {
+      const playback = createErrorPlayback({
+        playback: { triggerFatalErrorOnResourceDenied: true }
+      })
+      jest.spyOn(Log, 'error').mockImplementation(() => {})
+      const onError = jest.fn()
+      playback.on(Events.PLAYBACK_ERROR, onError)
+
+      playback._onHLSJSError('hlsError', {
+        fatal: false,
+        type: HLSJS.ErrorTypes.NETWORK_ERROR,
+        details: HLSJS.ErrorDetails.KEY_LOAD_ERROR,
+        response: { code: 403 }
+      })
+
+      expect(onError).toHaveBeenCalledTimes(1)
+      expect(playback.stop).toHaveBeenCalled()
+    })
+
+    test('non-fatal key denial without option only warns', () => {
+      const playback = createErrorPlayback()
+      jest.spyOn(Log, 'warn').mockImplementation(() => {})
+      const onError = jest.fn()
+      playback.on(Events.PLAYBACK_ERROR, onError)
+
+      playback._onHLSJSError('hlsError', {
+        fatal: false,
+        type: HLSJS.ErrorTypes.NETWORK_ERROR,
+        details: HLSJS.ErrorDetails.KEY_LOAD_ERROR,
+        response: { code: 403 }
+      })
+
+      expect(onError).not.toHaveBeenCalled()
+      expect(playback.stop).not.toHaveBeenCalled()
+      expect(Log.warn).toHaveBeenCalled()
+    })
+
+    test('non-fatal key load with response below 400 only warns', () => {
+      const playback = createErrorPlayback({
+        playback: { triggerFatalErrorOnResourceDenied: true }
+      })
+      jest.spyOn(Log, 'warn').mockImplementation(() => {})
+      const onError = jest.fn()
+      playback.on(Events.PLAYBACK_ERROR, onError)
+
+      playback._onHLSJSError('hlsError', {
+        fatal: false,
+        type: HLSJS.ErrorTypes.NETWORK_ERROR,
+        details: HLSJS.ErrorDetails.KEY_LOAD_ERROR,
+        response: { code: 200 }
+      })
+
+      expect(onError).not.toHaveBeenCalled()
+      expect(Log.warn).toHaveBeenCalled()
+    })
+
+    test('includes response in error description when present', () => {
+      const playback = createErrorPlayback()
+      jest.spyOn(Log, 'error').mockImplementation(() => {})
+      const onError = jest.fn()
+      playback.on(Events.PLAYBACK_ERROR, onError)
+
+      playback._onHLSJSError('hlsError', {
+        fatal: true,
+        type: HLSJS.ErrorTypes.NETWORK_ERROR,
+        details: HLSJS.ErrorDetails.MANIFEST_LOAD_ERROR,
+        response: { code: 404, text: 'missing' }
+      })
+
+      expect(onError.mock.calls[0][0].description).toContain('response:')
+    })
+  })
+
+  describe('dvrEnabled and settings', () => {
+    test('dvrEnabled requires live sync trim, min duration, and LIVE type', () => {
+      const playback = createPlayback({ hlsMinimumDvrSize: 60 })
+      playback._playbackType = Playback.LIVE
+      playback._playlistType = 'EVENT'
+      playback._playableRegionStartTime = 0
+      playback._playableRegionDuration = 120
+      playback._durationExcludesAfterLiveSyncPoint = true
+
+      expect(playback.dvrEnabled).toBe(true)
+
+      playback._durationExcludesAfterLiveSyncPoint = false
+      expect(playback.dvrEnabled).toBe(false)
+
+      playback._durationExcludesAfterLiveSyncPoint = true
+      playback._playableRegionDuration = 30
+      expect(playback.dvrEnabled).toBe(false)
+
+      playback._playableRegionDuration = 120
+      playback._playbackType = Playback.VOD
+      expect(playback.dvrEnabled).toBe(false)
+    })
+
+    test('isSeekEnabled is true for VOD or when dvr is enabled', () => {
+      const playback = createPlayback({ hlsMinimumDvrSize: 60 })
+      playback._playbackType = Playback.VOD
+      expect(playback.isSeekEnabled()).toBe(true)
+
+      playback._playbackType = Playback.LIVE
+      playback._playlistType = 'EVENT'
+      playback._playableRegionDuration = 120
+      playback._durationExcludesAfterLiveSyncPoint = false
+      expect(playback.isSeekEnabled()).toBe(false)
+
+      playback._durationExcludesAfterLiveSyncPoint = true
+      expect(playback.isSeekEnabled()).toBe(true)
+    })
+
+    test('_updateSettings chooses left controls from playback type and dvr', () => {
+      const playback = createPlayback({ hlsMinimumDvrSize: 60 })
+      const onSettings = jest.fn()
+      playback.on(Events.PLAYBACK_SETTINGSUPDATE, onSettings)
+
+      playback._playbackType = Playback.VOD
+      playback._updateSettings()
+      expect(playback.settings.left).toEqual(['playpause', 'position', 'duration'])
+      expect(playback.settings.seekEnabled).toBe(true)
+
+      playback._playbackType = Playback.LIVE
+      playback._playlistType = 'EVENT'
+      playback._playableRegionDuration = 120
+      playback._durationExcludesAfterLiveSyncPoint = true
+      playback._updateSettings()
+      expect(playback.settings.left).toEqual(['playpause'])
+      expect(playback.settings.seekEnabled).toBe(true)
+
+      playback._durationExcludesAfterLiveSyncPoint = false
+      playback._updateSettings()
+      expect(playback.settings.left).toEqual(['playstop'])
+      expect(playback.settings.seekEnabled).toBe(false)
+
+      expect(onSettings).toHaveBeenCalledTimes(3)
     })
   })
 })


### PR DESCRIPTION
## Description

Raise unit coverage of `HlsjsPlayback` critical paths (DVR sliding-window math, `_onLevelUpdated`, fatal-error recovery, time API, and time-update throttling) and pin Jest `coverageThreshold` for `src/hls.js`.

Also fix `hlsRecoverAttempts: 0` being ignored via `||` (falsy zero fell back to the default of 16).

Closes #2537

## How to test

1. From the repo root: `lerna run test --scope=@clappr/hlsjs-playback` (or `cd packages/hlsjs-playback && yarn jest ./src --testPathIgnorePatterns=dist.smoke --coverage`)
2. Confirm all unit tests pass and coverage meets the pinned thresholds in `packages/hlsjs-playback/jest.config.js`
3. Optionally set `hlsRecoverAttempts: 0` on a playback that hits a fatal media error and confirm it fails immediately without calling `recoverMediaError`

## Guidelines

- Write the PR title as a short sentence in the present tense describing the outcome (e.g. `Fix mute toggle not restoring volume`) — it feeds the release notes
- Describe any breaking change in the section above
- Read the [Contributing Guidelines](https://github.com/clappr/clappr/blob/main/CONTRIBUTING.md) and make sure `yarn test`, `yarn lint` and `yarn format:check` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved an explicitly configured value of zero for HLS recovery attempts, preventing unintended automatic retries.
  - Improved handling of DVR timing, seeking, playlist updates, and HLS.js error scenarios for more reliable playback behavior.

- **Tests**
  - Expanded automated coverage across playback controls, time updates, DVR settings, playlist changes, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->