### PR TITLE
Restore ES5 browserslist target and guard dist subclassing contract

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,7 +1,9 @@
-# O piso ES5 e do monorepo inteiro, nao so do pacote de TV: o dist publicado
-# e herdado por plugins de terceiros transpilados para ES5. NAO adicione
-# `not dead` — ela remove bb 7/10 e ie_mob 10/11, os unicos alvos que fazem
-# o preset-env rebaixar `class`, e reintroduz a issue #2540.
+# Monorepo ES5 floor (not just html5-tvs-playback): published dist/ is subclassed by
+# ES5 third-party plugins. Do NOT add `not dead` — it drops bb 7/10 and ie_mob 10/11,
+# the only targets that keep preset-env lowering `class` (see #2540).
+# `not ie <= 11` still leaves ie_mob 10/11 in the set; those (with bb 7/10) are the
+# class-less targets. The floor is implicit on caniuse-lite share data — smoke guards
+# in test/dist-contract.js catch drift after yarn build:dist.
 > 0.5%
 last 2 versions
 not ie <= 11

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,7 @@
+# O piso ES5 e do monorepo inteiro, nao so do pacote de TV: o dist publicado
+# e herdado por plugins de terceiros transpilados para ES5. NAO adicione
+# `not dead` — ela remove bb 7/10 e ie_mob 10/11, os unicos alvos que fazem
+# o preset-env rebaixar `class`, e reintroduz a issue #2540.
 > 0.5%
 last 2 versions
-Firefox ESR
-not dead
+not ie <= 11

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Monorepo managed by Lerna with Yarn workspaces. Each package has its own `packag
   - `packages/dash-shaka-playback/` — MPEG-DASH via Shaka Player
   - `packages/html5-tvs-playback/` — HTML5 playback for HbbTV smart TVs (`@clappr/clappr-html5-tvs-playback`)
   - `packages/clappr-telemetry/` — Telemetry helpers
+- `test/` — Shared dist smoke helpers (e.g. ES5 subclassing contract for #2540)
 
 ## Dependencies and shared config
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Shared config locations:
 |--------|------|-------|
 | Babel | `babel.base.json` | Packages extend via `.babelrc` |
 | Jest | `jest.config.base.js` | Packages extend via spread; override `transform` when not resolving sibling ESM source |
-| Browserslist | `.browserslistrc` | Matches autoprefixer `defaults` (`> 0.5%` / `last 2 versions` / `Firefox ESR` / `not dead`); `apps/clappr.io` keeps its own field |
+| Browserslist | `.browserslistrc` | Monorepo ES5 floor (`> 0.5%` / `last 2 versions` / `not ie <= 11`). Must keep at least one target without `class` support (do **not** add `not dead` — see #2540) because published `dist/` is subclassed by ES5 third-party plugins. Same query drives autoprefixer legacy prefixes required by `html5-tvs-playback`. `apps/clappr.io` keeps its own field |
 | ESLint | `eslint.config.js` | Flat config; `eslint` + `@eslint/js` declared at the root. Root `yarn lint` runs `lerna run lint` so package configs (`*.js` at package root) are covered |
 
 Conscious exceptions:
@@ -39,6 +39,7 @@ Conscious exceptions:
 - **`clappr-zepto` `.babelrc`** — stays standalone. Babel merges preset arrays and cannot clear the inherited `modules: false`, which would change zepto's Rollup build.
 - **`jest.config.base.js` sibling-source transform** — default for packages that resolve `@clappr/core` / `@clappr/zepto` to source via `moduleNameMapper`: `babelrc: false` / `configFile: false`, presets from `babel.base.json` `env.test` with `modules: 'commonjs'` forced. **`clappr-zepto` and `clappr-telemetry`** override to plain `babel-jest` (no sibling ESM mapping; zepto's standalone `.babelrc` remains for Rollup).
 - **Deferred to later phases** — `@rollup/plugin-replace`, `rollup-plugin-filesize`, `rollup-plugin-serve` (major divergence).
+- **Browserslist vs Babel targets** — putting the JS floor in `babel.base.json` `targets` and returning `browserslist` only to `html5-tvs-playback` for CSS was evaluated and rejected: clearer separation, but two sources of truth for browser targets.
 
 The Jest family (`jest`, `babel-jest`, `jest-environment-jsdom`, `jest-mock-console`) is fully unified at the root; no package declares a Jest dependency of its own. Test imports use the full path to the module file (`../base/events/events`), matching `src/` — there is no directory-named resolution in the Jest configs.
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.17",
+    "@babel/parser": "^7.22.17",
     "@babel/preset-env": "^7.22.15",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   ],
   "scripts": {
     "dev": "lerna run start --scope=@clappr/player",
-    "lint": "lerna run lint",
-    "lint:fix": "lerna run lint -- --fix",
+    "lint": "lerna run lint && eslint test/",
+    "lint:fix": "lerna run lint -- --fix && eslint test/ --fix",
     "format": "prettier --write \"**/*.{js,ts,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,ts,json,md}\"",
     "release": "lerna version --include-merged-tags --no-push --yes",

--- a/packages/clappr-core/src/dist.smoke.test.js
+++ b/packages/clappr-core/src/dist.smoke.test.js
@@ -108,9 +108,7 @@ describe.each([
   })
 
   test('plugin bases are ES5-subclassable', () => {
-    const dist = loadArtifact(filename)
-    const { BaseObject } = dist.default || dist
-    expectEs5Subclassable(BaseObject)
+    expectEs5Subclassable(loadArtifact(filename).BaseObject)
   })
 })
 

--- a/packages/clappr-core/src/dist.smoke.test.js
+++ b/packages/clappr-core/src/dist.smoke.test.js
@@ -108,7 +108,10 @@ describe.each([
   })
 
   test('plugin bases are ES5-subclassable', () => {
-    expectEs5Subclassable(loadArtifact(filename).BaseObject)
+    const { BaseObject, UIObject, UICorePlugin } = loadArtifact(filename)
+    expectEs5Subclassable(BaseObject)
+    expectEs5Subclassable(UIObject)
+    expectEs5Subclassable(UICorePlugin, { options: {} })
   })
 })
 

--- a/packages/clappr-core/src/dist.smoke.test.js
+++ b/packages/clappr-core/src/dist.smoke.test.js
@@ -12,6 +12,7 @@ const { TextEncoder, TextDecoder } = require('util')
 global.TextEncoder = global.TextEncoder || TextEncoder
 global.TextDecoder = global.TextDecoder || TextDecoder
 const { JSDOM } = require('jsdom')
+const { expectNoNativeClasses, expectEs5Subclassable } = require('../../../test/dist-contract')
 
 const DIST = path.join(__dirname, '..', 'dist')
 
@@ -100,6 +101,16 @@ describe.each([
 
   test('publishes a sourcemap comment', () => {
     assertSourceMappingURL(filename)
+  })
+
+  test('does not emit native class syntax', () => {
+    expectNoNativeClasses(readArtifact(filename))
+  })
+
+  test('plugin bases are ES5-subclassable', () => {
+    const dist = loadArtifact(filename)
+    const { BaseObject } = dist.default || dist
+    expectEs5Subclassable(BaseObject)
   })
 })
 

--- a/packages/clappr-plugins/src/dist.smoke.test.js
+++ b/packages/clappr-plugins/src/dist.smoke.test.js
@@ -4,6 +4,7 @@
  */
 const fs = require('fs')
 const path = require('path')
+const { expectNoNativeClasses } = require('../../../test/dist-contract')
 
 const DIST = path.join(__dirname, '..', 'dist')
 
@@ -89,6 +90,10 @@ describe.each([
 
   test('publishes a sourcemap comment', () => {
     assertSourceMappingURL(filename)
+  })
+
+  test('does not emit native class syntax', () => {
+    expectNoNativeClasses(readArtifact(filename))
   })
 })
 

--- a/packages/dash-shaka-playback/src/dist.smoke.test.js
+++ b/packages/dash-shaka-playback/src/dist.smoke.test.js
@@ -4,6 +4,7 @@
  */
 const fs = require('fs')
 const path = require('path')
+const { expectNoNativeClasses } = require('../../../test/dist-contract')
 
 const DIST = path.join(__dirname, '..', 'dist')
 
@@ -93,6 +94,10 @@ describe.each([
 
   test('publishes a sourcemap comment', () => {
     assertSourceMappingURL(filename)
+  })
+
+  test('does not emit native class syntax', () => {
+    expectNoNativeClasses(readArtifact(filename))
   })
 })
 

--- a/packages/hlsjs-playback/src/dist.smoke.test.js
+++ b/packages/hlsjs-playback/src/dist.smoke.test.js
@@ -12,6 +12,7 @@ const { TextEncoder, TextDecoder } = require('util')
 global.TextEncoder = global.TextEncoder || TextEncoder
 global.TextDecoder = global.TextDecoder || TextDecoder
 const { JSDOM } = require('jsdom')
+const { expectNoNativeClasses } = require('../../../test/dist-contract')
 
 const DIST = path.join(__dirname, '..', 'dist')
 
@@ -101,6 +102,10 @@ describe.each([
 
   test('publishes a sourcemap comment', () => {
     assertSourceMappingURL(filename)
+  })
+
+  test('does not emit native class syntax', () => {
+    expectNoNativeClasses(readArtifact(filename))
   })
 })
 

--- a/packages/html5-tvs-playback/src/dist.smoke.test.js
+++ b/packages/html5-tvs-playback/src/dist.smoke.test.js
@@ -4,6 +4,7 @@
  */
 const fs = require('fs')
 const path = require('path')
+const { expectNoNativeClasses } = require('../../../test/dist-contract')
 
 const DIST = path.join(__dirname, '..', 'dist')
 
@@ -54,6 +55,10 @@ describe.each([
 
   test('publishes a sourcemap comment', () => {
     assertSourceMappingURL(filename)
+  })
+
+  test('does not emit native class syntax', () => {
+    expectNoNativeClasses(readArtifact(filename))
   })
 })
 

--- a/packages/player/src/dist.smoke.test.js
+++ b/packages/player/src/dist.smoke.test.js
@@ -124,17 +124,7 @@ describe.each([
   })
 
   test('plugin bases are ES5-subclassable', () => {
-    const C = resolveClappr(loadArtifact(filename))
-    expectEs5Subclassable(C.BaseObject)
-  })
-})
-
-describe.each([
-  ['plainhtml5 UMD', ARTIFACTS.plainhtml5],
-  ['plainhtml5 UMD minified', ARTIFACTS.plainhtml5Min]
-])('%s (%s)', (_label, filename) => {
-  test('does not emit native class syntax', () => {
-    expectNoNativeClasses(readArtifact(filename))
+    expectEs5Subclassable(resolveClappr(loadArtifact(filename)).BaseObject)
   })
 })
 
@@ -155,6 +145,10 @@ describe('plainhtml5 bundle', () => {
   test.each(PLAINHTML5)('%s has no HLS', filename => {
     const C = resolveClappr(loadArtifact(filename))
     expect(C.HLS).toBeUndefined()
+  })
+
+  test.each(PLAINHTML5)('%s does not emit native class syntax', filename => {
+    expectNoNativeClasses(readArtifact(filename))
   })
 })
 

--- a/packages/player/src/dist.smoke.test.js
+++ b/packages/player/src/dist.smoke.test.js
@@ -124,7 +124,13 @@ describe.each([
   })
 
   test('plugin bases are ES5-subclassable', () => {
-    expectEs5Subclassable(resolveClappr(loadArtifact(filename)).BaseObject)
+    // Behavioral contract for full + plainhtml5: third-party ES5 plugins call
+    // Parent.call(this, ...) on these bases (#2540). Syntax scan below cannot
+    // cover full clappr(.min).js — embedded hls.js ships native classes.
+    const C = resolveClappr(loadArtifact(filename))
+    expectEs5Subclassable(C.BaseObject)
+    expectEs5Subclassable(C.UIObject)
+    expectEs5Subclassable(C.UICorePlugin, { options: {} })
   })
 })
 
@@ -147,6 +153,8 @@ describe('plainhtml5 bundle', () => {
     expect(C.HLS).toBeUndefined()
   })
 
+  // Syntax-only on plainhtml5: full player embeds hls.js (native class). ES5
+  // subclassability of Clappr bases is asserted for all artifacts above.
   test.each(PLAINHTML5)('%s does not emit native class syntax', filename => {
     expectNoNativeClasses(readArtifact(filename))
   })

--- a/packages/player/src/dist.smoke.test.js
+++ b/packages/player/src/dist.smoke.test.js
@@ -12,6 +12,7 @@ const { TextEncoder, TextDecoder } = require('util')
 global.TextEncoder = global.TextEncoder || TextEncoder
 global.TextDecoder = global.TextDecoder || TextDecoder
 const { JSDOM } = require('jsdom')
+const { expectNoNativeClasses, expectEs5Subclassable } = require('../../../test/dist-contract')
 
 const DIST = path.join(__dirname, '..', 'dist')
 const pkg = require('../package.json')
@@ -120,6 +121,20 @@ describe.each([
 ])('%s (%s)', (_label, filename) => {
   test('exports plugins that extend the same-bundle plugin bases', () => {
     assertSharedBundleContract(resolveClappr(loadArtifact(filename)))
+  })
+
+  test('plugin bases are ES5-subclassable', () => {
+    const C = resolveClappr(loadArtifact(filename))
+    expectEs5Subclassable(C.BaseObject)
+  })
+})
+
+describe.each([
+  ['plainhtml5 UMD', ARTIFACTS.plainhtml5],
+  ['plainhtml5 UMD minified', ARTIFACTS.plainhtml5Min]
+])('%s (%s)', (_label, filename) => {
+  test('does not emit native class syntax', () => {
+    expectNoNativeClasses(readArtifact(filename))
   })
 })
 

--- a/test/dist-contract.js
+++ b/test/dist-contract.js
@@ -1,0 +1,21 @@
+const NATIVE_CLASS_PATTERN = /class [A-Za-z_$]+ extends/
+
+function expectNoNativeClasses(code) {
+  expect(code).not.toMatch(NATIVE_CLASS_PATTERN)
+}
+
+function expectEs5Subclassable(Base, options = {}) {
+  function Es5Subclass(opts) {
+    Base.call(this, opts)
+  }
+  Es5Subclass.prototype = Object.create(Base.prototype)
+  Es5Subclass.prototype.constructor = Es5Subclass
+  Object.setPrototypeOf(Es5Subclass, Base)
+
+  expect(() => new Es5Subclass(options)).not.toThrow()
+}
+
+module.exports = {
+  expectNoNativeClasses,
+  expectEs5Subclassable
+}

--- a/test/dist-contract.js
+++ b/test/dist-contract.js
@@ -1,22 +1,47 @@
-const NATIVE_CLASS_PATTERN = /class [A-Za-z_$]+ extends/
+const { parse } = require('@babel/parser')
 
-function stripBlockComments(code) {
-  return code.replace(/\/\*[\s\S]*?\*\//g, '')
+function walk(node, visit) {
+  if (!node || typeof node !== 'object') return
+  visit(node)
+  for (const key of Object.keys(node)) {
+    if (key === 'loc' || key === 'start' || key === 'end' || key === 'range' || key === 'extra') continue
+    const child = node[key]
+    if (Array.isArray(child)) {
+      for (const item of child) walk(item, visit)
+    } else if (child && typeof child.type === 'string') {
+      walk(child, visit)
+    }
+  }
+}
+
+function findNativeClasses(code) {
+  const ast = parse(code, {
+    sourceType: 'unambiguous',
+    errorRecovery: true,
+    allowReturnOutsideFunction: true
+  })
+  const classes = []
+  walk(ast, node => {
+    if (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') {
+      classes.push(node)
+    }
+  })
+  return classes
 }
 
 function expectNoNativeClasses(code) {
-  expect(stripBlockComments(code)).not.toMatch(NATIVE_CLASS_PATTERN)
+  expect(findNativeClasses(code).length).toBe(0)
 }
 
-function expectEs5Subclassable(Base, options = {}) {
-  function Es5Subclass(opts) {
-    Base.call(this, opts)
+function expectEs5Subclassable(Base, ctorArg) {
+  function Es5Subclass(arg) {
+    Base.call(this, arg)
   }
   Es5Subclass.prototype = Object.create(Base.prototype)
   Es5Subclass.prototype.constructor = Es5Subclass
   Object.setPrototypeOf(Es5Subclass, Base)
 
-  expect(() => new Es5Subclass(options)).not.toThrow()
+  expect(() => new Es5Subclass(ctorArg)).not.toThrow()
 }
 
 module.exports = {

--- a/test/dist-contract.js
+++ b/test/dist-contract.js
@@ -1,7 +1,11 @@
 const NATIVE_CLASS_PATTERN = /class [A-Za-z_$]+ extends/
 
+function stripBlockComments(code) {
+  return code.replace(/\/\*[\s\S]*?\*\//g, '')
+}
+
 function expectNoNativeClasses(code) {
-  expect(code).not.toMatch(NATIVE_CLASS_PATTERN)
+  expect(stripBlockComments(code)).not.toMatch(NATIVE_CLASS_PATTERN)
 }
 
 function expectEs5Subclassable(Base, options = {}) {

--- a/test/dist-contract.js
+++ b/test/dist-contract.js
@@ -4,7 +4,9 @@ function walk(node, visit) {
   if (!node || typeof node !== 'object') return
   visit(node)
   for (const key of Object.keys(node)) {
-    if (key === 'loc' || key === 'start' || key === 'end' || key === 'range' || key === 'extra') continue
+    if (key === 'loc' || key === 'start' || key === 'end' || key === 'range' || key === 'extra') {
+      continue
+    }
     const child = node[key]
     if (Array.isArray(child)) {
       for (const item of child) walk(item, visit)
@@ -15,9 +17,9 @@ function walk(node, visit) {
 }
 
 function findNativeClasses(code) {
+  // No errorRecovery: a parse failure must fail the smoke test visibly.
   const ast = parse(code, {
     sourceType: 'unambiguous',
-    errorRecovery: true,
     allowReturnOutsideFunction: true
   })
   const classes = []
@@ -30,7 +32,7 @@ function findNativeClasses(code) {
 }
 
 function expectNoNativeClasses(code) {
-  expect(findNativeClasses(code).length).toBe(0)
+  expect(findNativeClasses(code).map(n => n.id?.name ?? '<anonymous>')).toEqual([])
 }
 
 function expectEs5Subclassable(Base, ctorArg) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,7 +499,7 @@
   dependencies:
     "@babel/types" "^7.29.7"
 
-"@babel/parser@^7.29.8":
+"@babel/parser@^7.22.17", "@babel/parser@^7.29.8":
   version "7.29.8"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.8.tgz#9653716a2f10c677b98fbc63d4bfb000c302cf17"
   integrity sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==
@@ -1853,7 +1853,7 @@
     "@docusaurus/theme-search-algolia" "2.4.3"
     "@docusaurus/types" "2.4.3"
 
-"@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -11975,14 +11975,6 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
-"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
-  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
-  dependencies:
-    "@types/react" "*"
-    prop-types "^15.6.2"
-
 react-router-config@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-router-config/-/react-router-config-5.1.1.tgz#0f4263d1a80c6b2dc7b9c1902c9526478194a988"
@@ -13264,16 +13256,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@4.2.3, "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13323,14 +13306,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14512,16 +14488,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Description

Reverts the `.browserslistrc` regression from `0.12.8` that stopped `@babel/preset-env` from lowering `class`, breaking ES5 third-party plugins that subclass Clappr bases (`UICorePlugin`, `Playback`, etc.) and preventing the media control from rendering.

Also documents the browserslist constraint in `AGENTS.md` and adds shared dist smoke guards so CI fails if native `class` reappears in publishable artifacts.

Closes #2540

## How to test

1. `yarn build:dist && yarn test:smoke` — all publishable-package smoke tests pass, including new ES5 subclassing guards on `@clappr/core` and `@clappr/player`.
2. Confirm the player artifact is ES5-subclassable again:
   ```bash
   node -e 'const s=require("fs").readFileSync("packages/player/dist/clappr.min.js","utf8");console.log("bytes",s.length,"| helper ES5:",s.includes("Cannot call a class as a function"))'
   grep -c -- '-webkit-box' packages/player/dist/clappr.min.js
   ```
3. Embed repro (Firefox or JSDOM): load the rebuilt `@clappr/player` dist with a third-party ES5 plugin such as `level-selector@latest` — expect no `Class constructor … cannot be invoked without 'new'` and the play button renders.
4. Negative guard: temporarily restore `not dead` in `.browserslistrc`, rebuild, and confirm `yarn test:smoke` fails on core/player ES5 guards.

## Guidelines

- Write the PR title as a short sentence in the present tense describing the outcome (e.g. `Fix mute toggle not restoring volume`) — it feeds the release notes
- Describe any breaking change in the section above
- Read the [Contributing Guidelines](https://github.com/clappr/clappr/blob/main/CONTRIBUTING.md) and make sure `yarn test`, `yarn lint` and `yarn format:check` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy ES5 environments by ensuring published bundles avoid native class syntax.
  * Added validation that plugin base classes support ES5-style subclassing across distributed builds.

* **Tests**
  * Expanded distribution smoke tests across playback, player, and plugin packages to verify ES5 compatibility.
  * Added shared checks for transpiled output and subclass behavior.

* **Documentation**
  * Clarified browser-support and ES5 compatibility guidance for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->