### PR TITLE
Enable ESLint caughtErrors after cleaning unused catch bindings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,7 +80,7 @@ module.exports = [
       // Variables and declarations
       'no-var': 'error',
       'prefer-const': ['error', { destructuring: 'any' }],
-      'no-unused-vars': ['error', { args: 'none', caughtErrors: 'none' }],
+      'no-unused-vars': ['error', { args: 'none' }],
       'no-undef': 'error',
       // Other StandardJS rules
       'accessor-pairs': 'error',

--- a/packages/clappr-core/src/components/browser/browser.js
+++ b/packages/clappr-core/src/components/browser/browser.js
@@ -9,7 +9,7 @@ const hasLocalstorage = function () {
     localStorage.setItem('clappr', 'clappr')
     localStorage.removeItem('clappr')
     return true
-  } catch (e) {
+  } catch {
     return false
   }
 }
@@ -18,7 +18,7 @@ const hasFlash = function () {
   try {
     const fo = new ActiveXObject('ShockwaveFlash.ShockwaveFlash')
     return !!fo
-  } catch (e) {
+  } catch {
     return !!(
       navigator.mimeTypes &&
       navigator.mimeTypes['application/x-shockwave-flash'] !== undefined &&

--- a/packages/clappr-core/src/playbacks/no_op/no_op.js
+++ b/packages/clappr-core/src/playbacks/no_op/no_op.js
@@ -42,7 +42,7 @@ export default class NoOp extends Playback {
     let buffer32
     try {
       buffer32 = new Uint32Array(idata.data.buffer)
-    } catch (err) {
+    } catch {
       buffer32 = new Uint32Array(this.context.canvas.width * this.context.canvas.height * 4)
       const data = idata.data
       for (let i = 0; i < data.length; i++) { buffer32[i] = data[i] }

--- a/packages/clappr-core/src/utils/utils.js
+++ b/packages/clappr-core/src/utils/utils.js
@@ -119,7 +119,7 @@ export class Config {
   static _defaultValueFor(key) {
     try {
       return this._defaultConfig()[key].parse(this._defaultConfig()[key].value)
-    } catch (e) {
+    } catch {
       return undefined
     }
   }
@@ -139,7 +139,7 @@ export class Config {
       try {
         localStorage[this._createKeyspace(key)] = value
         return true
-      } catch (e) {
+      } catch {
         return false
       }
     }


### PR DESCRIPTION
## Description

Follow-up to #2554: remove unused catch bindings and drop `caughtErrors: 'none'` from `no-unused-vars` so ESLint 9+/10’s default (`'all'`) applies.

- Convert five unused `catch (e)` / `catch (err)` to optional catch binding (`catch { ... }`) in `@clappr/core`
- Remove `caughtErrors: 'none'` from root `eslint.config.js`

No runtime behavior change — lint/style only.

Closes #2555

## How to test

1. `yarn lint` — should pass with no unused-catch findings
2. Optional: `yarn build:dist && yarn test:smoke` — optional catch binding is already downleveled by Babel for the ES5 browserslist floor

## Guidelines

- Write the PR title as a short sentence in the present tense describing the outcome (e.g. `Fix mute toggle not restoring volume`) — it feeds the release notes
- Describe any breaking change in the section above
- Read the [Contributing Guidelines](https://github.com/clappr/clappr/blob/main/CONTRIBUTING.md) and make sure `yarn test`, `yarn lint` and `yarn format:check` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up internal error-handling code by removing unused exception variables.
  * Preserved existing fallback behavior for browser storage, Flash detection, configuration, and playback operations.
  * Updated linting rules to enforce the cleanup consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->